### PR TITLE
PR-1.3: fix parseProviderID multi-segment and empty-component handling

### DIFF
--- a/.claude/context/PROJECT_CONTEXT.md
+++ b/.claude/context/PROJECT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 > **Read this file before starting any non-trivial change.** Update it whenever you close a tracked item or discover a new one. This is the project's working memory between Claude sessions.
 >
-> **Last meaningful update:** 2026-05-02 — PR-2.1 closed BUG-5 (PhysicalHost patch helper) and removed cross-controller PhysicalHost.Status writes from Beskar7Machine controller (BUG-1 partially closed); `InspectionRequestAnnotation` Pattern A adopted for inter-controller signalling.
+> **Last meaningful update:** 2026-05-02 — PR-1.3 closed BUG-3 (`parseProviderID` rewritten with `strings.CutPrefix`+`strings.SplitN`; multi-segment name now rejected); PR-2.1 closed BUG-5 (PhysicalHost patch helper) and removed cross-controller PhysicalHost.Status writes from Beskar7Machine controller (BUG-1 partially closed); `InspectionRequestAnnotation` Pattern A adopted for inter-controller signalling.
 
 ---
 
@@ -77,7 +77,6 @@ Two unwired internal packages (decision pending, see Decisions log entry D-001):
 |---|---|---|---|
 | BUG-1 | controller | Cross-controller status writes: **partially resolved in PR-2.1** — the three `r.Status().Update(physicalHost)` calls at the original lines 268, 291, 371 are removed. Replaced with annotation signal (`InspectionRequestAnnotation`). Residual risk: annotation processing happens one reconcile cycle after the Beskar7Machine sets it, introducing a brief window where PhysicalHost state lags. A concurrent PhysicalHost reconcile and annotation-clear could drop the signal if the PhysicalHost reconcile races with the annotation patch. Tracked here until a reconcile-triggered-by-annotation watch is wired. | `controllers/beskar7machine_controller.go` (signal path), `controllers/physicalhost_controller.go` (annotation consumer) |
 | BUG-2 | controller | Host claim is list-then-update with no resourceVersion precondition; two Beskar7Machines can claim the same Available host. | `controllers/beskar7machine_controller.go:425-442` |
-| BUG-3 | controller | `parseProviderID` mishandles names containing `/` and silently returns empty namespace on the `idx==0` path. Use `strings.SplitN`. | `controllers/beskar7machine_controller.go:506-522` |
 | BUG-4 | controller | `reconcileDelete` clears `ConsumerRef` but never powers off the host or clears the boot override. Strands hosts in `Once,Pxe,On`. | `controllers/beskar7machine_controller.go:449-476` |
 | BUG-6 | redfish | `SetPowerState(Off)` always uses `ForceOffResetType` — risk of data loss on workload nodes. Default to graceful. | `internal/redfish/gofish_client.go:160-163` |
 | BUG-7 | controller | `Beskar7Machine` doesn't watch `PhysicalHost`; state changes only propagate via 30s requeue. | `controllers/beskar7machine_controller.go:527-531` |
@@ -141,6 +140,7 @@ All of these need a doc rewrite when the v0.4 doc sweep happens. Tracked togethe
 |---|---|---|
 | BLOCK-1 | PR-0.1: defaulted `RedfishClientFactory` to `internalredfish.NewClient` in each reconciler's `SetupWithManager` with a fail-fast non-nil guard; removed misleading `// Use default` from `cmd/manager/main.go`; added unit specs covering nil → default and explicit-factory-preserved for both reconcilers. | 2026-05-01 |
 | kube-rbac-proxy removal (Phase 11, PR-11.1) | Deleted `config/default/manager_auth_proxy_patch.yaml` and the kube-rbac-proxy sidecar from the Helm chart; wired `filters.WithAuthenticationAndAuthorization` via `metricsserver.Options.FilterProvider`; metrics now served directly on `:8443` (HTTPS) with TokenReview/SAR-based auth; added `--secure-metrics` flag (default true) for local dev; added `config/rbac/metrics_auth_role.yaml`, `metrics_auth_role_binding.yaml`, `metrics_reader_role.yaml`; updated all overlay patches and networkpolicies to `:8443`. | 2026-05-01 |
+| BUG-3 | PR-1.3: Replaced hand-rolled loop in `parseProviderID` with `strings.CutPrefix` + `strings.SplitN`. Now rejects missing prefix with informative message, conflates no-slash / empty-namespace / empty-name with a single clear error, and explicitly rejects multi-segment names (BUG-3 root cause: `b7://ns/name/extra` previously returned `("ns", "name/extra", nil)`). Table-driven `TestParseProviderID` added in `controllers/parse_provider_id_test.go` (9 subtests, race-clean). | 2026-05-02 |
 | BUG-5 | PR-2.1: `PhysicalHostReconciler.Reconcile` now uses `patch.NewHelper` deferred at top; `r.Update` (finalizer add/remove) and all `r.Status().Update` calls removed; a single `patchHelper.Patch(ctx, ph, patch.WithStatusObservedGeneration{})` handles both spec and status in one round-trip. `InspectionRequestAnnotation` constant exported for cross-controller use. 2 PIt blocks converted: "Should add finalizer via patch …" and "Should apply inspection-request annotation …". | 2026-05-02 |
 | _initial population_ | review baseline established | 2026-05-01 |
 

--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -530,21 +531,18 @@ func providerID(namespace, name string) string {
 }
 
 func parseProviderID(id string) (string, string, error) {
-	if len(id) <= len(ProviderIDPrefix) {
-		return "", "", fmt.Errorf("invalid provider ID format")
+	rest, ok := strings.CutPrefix(id, ProviderIDPrefix)
+	if !ok {
+		return "", "", fmt.Errorf("invalid provider ID %q: missing %q prefix", id, ProviderIDPrefix)
 	}
-	parts := id[len(ProviderIDPrefix):]
-	idx := 0
-	for i, c := range parts {
-		if c == '/' {
-			idx = i
-			break
-		}
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid provider ID %q: expected %s<namespace>/<name>", id, ProviderIDPrefix)
 	}
-	if idx == 0 {
-		return "", "", fmt.Errorf("invalid provider ID format")
+	if strings.Contains(parts[1], "/") {
+		return "", "", fmt.Errorf("invalid provider ID %q: name segment contains '/'", id)
 	}
-	return parts[:idx], parts[idx+1:], nil
+	return parts[0], parts[1], nil
 }
 
 // isPaused and isClusterPaused functions are in utils.go

--- a/controllers/parse_provider_id_test.go
+++ b/controllers/parse_provider_id_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2024 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseProviderID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		in        string
+		wantNS    string
+		wantName  string
+		wantErr   bool
+		errContains string
+	}{
+		{
+			name:     "happy path",
+			in:       "b7://default/worker-1",
+			wantNS:   "default",
+			wantName: "worker-1",
+		},
+		{
+			name:        "missing prefix",
+			in:          "provider://x/y",
+			wantErr:     true,
+			errContains: "b7://",
+		},
+		{
+			name:        "empty rest after prefix",
+			in:          "b7://",
+			wantErr:     true,
+			errContains: "b7://",
+		},
+		{
+			name:        "no slash after prefix — single segment",
+			in:          "b7://justname",
+			wantErr:     true,
+			errContains: "b7://",
+		},
+		{
+			name:        "empty namespace — leading slash",
+			in:          "b7:///name",
+			wantErr:     true,
+			errContains: "b7://",
+		},
+		{
+			name:        "empty name — trailing slash",
+			in:          "b7://ns/",
+			wantErr:     true,
+			errContains: "b7://",
+		},
+		{
+			// BUG-3: the old hand-rolled loop returned ("ns", "name/extra", nil).
+			name:        "multi-segment name contains slash",
+			in:          "b7://ns/name/extra",
+			wantErr:     true,
+			errContains: "'/'",
+		},
+		{
+			// Trailing whitespace in namespace: passes through as data. Kubernetes
+			// would reject this name at admission, so we don't need a second gate here.
+			name:     "namespace with trailing space — accepted as data",
+			in:       "b7://ns /name",
+			wantNS:   "ns ",
+			wantName: "name",
+		},
+		{
+			// Trailing newline in name: same reasoning — accept as data; the API server
+			// enforces k8s name rules on write.
+			name:     "name with trailing newline — accepted as data",
+			in:       "b7://ns/name\n",
+			wantNS:   "ns",
+			wantName: "name\n",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotNS, gotName, err := parseProviderID(tc.in)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseProviderID(%q) returned nil error; want error containing %q",
+						tc.in, tc.errContains)
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("parseProviderID(%q) error = %q; want it to contain %q",
+						tc.in, err.Error(), tc.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parseProviderID(%q) unexpected error: %v", tc.in, err)
+			}
+			if gotNS != tc.wantNS {
+				t.Errorf("parseProviderID(%q) namespace = %q; want %q", tc.in, gotNS, tc.wantNS)
+			}
+			if gotName != tc.wantName {
+				t.Errorf("parseProviderID(%q) name = %q; want %q", tc.in, gotName, tc.wantName)
+			}
+		})
+	}
+}

--- a/controllers/parse_provider_id_test.go
+++ b/controllers/parse_provider_id_test.go
@@ -25,11 +25,11 @@ func TestParseProviderID(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		in        string
-		wantNS    string
-		wantName  string
-		wantErr   bool
+		name        string
+		in          string
+		wantNS      string
+		wantName    string
+		wantErr     bool
 		errContains string
 	}{
 		{


### PR DESCRIPTION
## Summary

Closes **BUG-3**.

The previous `parseProviderID` rolled its own loop and conflated three distinct malformations (no slash, leading slash, trailing slash) under a single `idx == 0` check. Worse, multi-segment paths like `b7://ns/name/extra` silently returned `("ns", "name/extra", nil)` — which would then attempt a `Get` against a Kubernetes object whose name contained `/`.

Replace with `strings.CutPrefix` + `strings.SplitN(rest, "/", 2)`:

- Missing prefix: clear error citing the expected prefix.
- Single segment, leading slash, or trailing slash: clear error citing `<namespace>/<name>` shape.
- Multi-segment (the BUG-3 case): explicit error mentioning the extra `/`.

## Tests

`controllers/parse_provider_id_test.go` is a new file with 9 table-driven subtests using `t.Parallel`:
- happy path
- missing prefix
- empty rest after prefix
- no slash after prefix (single segment)
- empty namespace (leading slash)
- empty name (trailing slash)
- **BUG-3 regression**: multi-segment name contains slash
- trailing whitespace in namespace — accepted as data (the API server enforces DNS-label rules at admission)
- trailing newline in name — accepted as data (same rationale)

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` passes (full suite + new TestParseProviderID 9/9)
- [x] `go vet ./...` clean
- [x] `make manifests` no-op (no kubebuilder marker changes)
- [ ] CI lint / unit / integration jobs pass
- [ ] CI E2E job passes

## Notes

- Both pass-through cases (whitespace, newline) are deliberately **not** validated here. Adding a DNS-label gate is out of scope for this PR; the API server already enforces those rules at admission. If we want a stricter parser later, that's a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)