### PR TITLE
PR-3.1: graceful power-off default + ctx propagation + per-call HTTP timeout

### DIFF
--- a/.claude/context/PROJECT_CONTEXT.md
+++ b/.claude/context/PROJECT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 > **Read this file before starting any non-trivial change.** Update it whenever you close a tracked item or discover a new one. This is the project's working memory between Claude sessions.
 >
-> **Last meaningful update:** 2026-05-02 — PR-3.3 closed SEC-4 (BMC username removed from INFO logs) and BUG-11 (memory capacity parse rewritten using `resource.ParseQuantity` + allowlist).
+> **Last meaningful update:** 2026-05-02 — PR-3.1 closed BUG-6 (graceful power-off default) and BUG-10 (per-call HTTP timeout + ctx propagation in gofish client).
 
 ---
 
@@ -77,11 +77,9 @@ Two unwired internal packages (decision pending, see Decisions log entry D-001):
 | BUG-1 | controller | Cross-controller status writes: **partially resolved in PR-2.1** — the three `r.Status().Update(physicalHost)` calls at the original lines 268, 291, 371 are removed. Replaced with annotation signal (`InspectionRequestAnnotation`). Residual risk: annotation processing happens one reconcile cycle after the Beskar7Machine sets it, introducing a brief window where PhysicalHost state lags. A concurrent PhysicalHost reconcile and annotation-clear could drop the signal if the PhysicalHost reconcile races with the annotation patch. Tracked here until a reconcile-triggered-by-annotation watch is wired. | `controllers/beskar7machine_controller.go` (signal path), `controllers/physicalhost_controller.go` (annotation consumer) |
 | BUG-2 | controller | Host claim is list-then-update with no resourceVersion precondition; two Beskar7Machines can claim the same Available host. | `controllers/beskar7machine_controller.go:425-442` |
 | BUG-4 | controller | `reconcileDelete` clears `ConsumerRef` but never powers off the host or clears the boot override. Strands hosts in `Once,Pxe,On`. | `controllers/beskar7machine_controller.go:449-476` |
-| BUG-6 | redfish | `SetPowerState(Off)` always uses `ForceOffResetType` — risk of data loss on workload nodes. Default to graceful. | `internal/redfish/gofish_client.go:160-163` |
 | BUG-7 | controller | `Beskar7Machine` doesn't watch `PhysicalHost`; state changes only propagate via 30s requeue. | `controllers/beskar7machine_controller.go:527-531` |
 | BUG-8 | controller | `FailureReason`/`FailureMessage` declared on the API but never set; hardware validation failures requeue forever. | `api/v1beta1/beskar7machine_types.go:96-104`, `controllers/beskar7machine_controller.go:329-363` |
 | BUG-9 | controller | `findControlPlaneEndpoint` ignores user-set `Spec.ControlPlaneEndpoint` and hardcodes port 6443. | `controllers/beskar7cluster_controller.go:278-298, 350-353` |
-| BUG-10 | redfish | gofish calls don't propagate `ctx`; wedged BMC hangs a worker forever. No per-call HTTP timeout in `gofish.ClientConfig`. | `internal/redfish/gofish_client.go:103-220` |
 
 ### Documentation drift (release-relevant)
 
@@ -142,6 +140,8 @@ All of these need a doc rewrite when the v0.4 doc sweep happens. Tracked togethe
 | BUG-5 | PR-2.1: `PhysicalHostReconciler.Reconcile` now uses `patch.NewHelper` deferred at top; `r.Update` (finalizer add/remove) and all `r.Status().Update` calls removed; a single `patchHelper.Patch(ctx, ph, patch.WithStatusObservedGeneration{})` handles both spec and status in one round-trip. `InspectionRequestAnnotation` constant exported for cross-controller use. 2 PIt blocks converted: "Should add finalizer via patch …" and "Should apply inspection-request annotation …". | 2026-05-02 |
 | SEC-4 | PR-3.3: Dropped `"username", username` from both INFO log calls in `NewClient` (`gofish_client.go:25, 57-62`); both calls also moved to `V(1)` debug since they fire on every reconcile. `PasswordProvided` bool retained at V(1) for diagnostics. No username appears in any log path. | 2026-05-02 |
 | BUG-11 | PR-3.3: Replaced `fmt.Sscanf(mem.Capacity, "%d", &memGB)` with `parseMemoryCapacityGB` helper in `controllers/beskar7machine_controller.go`. Helper uses `resource.ParseQuantity` after stripping trailing `B` from BMC unit strings, plus an explicit suffix allowlist (G/Gi/M/Mi/T/Ti) to reject bare integers and exotic SI prefixes. 15-case table test in `controllers/parse_memory_test.go`. | 2026-05-02 |
+| BUG-6 | PR-3.1: `SetPowerState(OffPowerState)` now maps to `GracefulShutdownResetType` instead of `ForceOffResetType`. New `ForcePowerOff` method on the `Client` interface (+ `gofishClient` impl + `MockClient` with `ForcePowerOffCalled` counter and `ShouldFail` support) for callers that need an immediate power-cut. | 2026-05-02 |
+| BUG-10 | PR-3.1: Added `defaultHTTPTimeout = 30s` const and `newHTTPClient(insecure bool)` helper; `NewClient` now passes a custom `*http.Client` with that timeout and TLS config into `gofish.ClientConfig.HTTPClient`. Added `doWithCtx` helper that races a synchronous gofish call against ctx cancellation. Applied to all gofish I/O call sites: `getSystemService`, `SetPowerState`, `SetBootSourcePXE`, `Reset`, `GetNetworkAddresses`, `extractAddressesFromNetworkInterface`. `Close` uses a derived 5-second context. 9 new unit tests in `internal/redfish/gofish_client_test.go`. | 2026-05-02 |
 | _initial population_ | review baseline established | 2026-05-01 |
 
 ---

--- a/internal/redfish/client.go
+++ b/internal/redfish/client.go
@@ -31,6 +31,11 @@ type Client interface {
 
 	// GetNetworkAddresses retrieves network interface addresses
 	GetNetworkAddresses(ctx context.Context) ([]NetworkAddress, error)
+
+	// ForcePowerOff forces an immediate power-off, bypassing OS shutdown.
+	// Use only for unrecoverable error paths; prefer SetPowerState(Off) which
+	// performs a graceful shutdown.
+	ForcePowerOff(ctx context.Context) error
 }
 
 // SystemInfo contains basic system information

--- a/internal/redfish/gofish_client.go
+++ b/internal/redfish/gofish_client.go
@@ -2,14 +2,21 @@ package redfish
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/redfish"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// defaultHTTPTimeout is the per-call HTTP timeout injected into the http.Client
+// passed to gofish. A wedged BMC will be abandoned after this duration; the
+// reconcile loop will requeue and retry.
+const defaultHTTPTimeout = 30 * time.Second
 
 // gofishClient implements the Client interface using the gofish library.
 type gofishClient struct {
@@ -18,6 +25,46 @@ type gofishClient struct {
 }
 
 var log = logf.Log.WithName("redfish-client")
+
+// newHTTPClient builds an *http.Client that mirrors gofish's internal transport
+// defaults while adding a per-call Timeout and honouring the insecure flag.
+// Callers who supply their own HTTPClient (e.g. custom CA) bypass this path.
+func newHTTPClient(insecure bool) *http.Client {
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	transport := &http.Transport{
+		Proxy:                 defaultTransport.Proxy,
+		DialContext:           defaultTransport.DialContext,
+		MaxIdleConns:          defaultTransport.MaxIdleConns,
+		IdleConnTimeout:       defaultTransport.IdleConnTimeout,
+		ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+		TLSHandshakeTimeout:   10 * time.Second,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: insecure, // #nosec G402 — InsecureSkipVerify is operator-opt-in via Spec.RedfishConnection.InsecureSkipVerify
+		},
+	}
+	return &http.Client{
+		Timeout:   defaultHTTPTimeout,
+		Transport: transport,
+	}
+}
+
+// doWithCtx runs op in a goroutine and returns either op's result or ctx.Err()
+// if ctx is cancelled first. The goroutine continues to completion on cancellation
+// (we cannot interrupt a synchronous gofish call mid-flight); its result is
+// discarded. This is the simplest pattern that respects reconcile-context
+// cancellation without requiring upstream gofish ctx support.
+func doWithCtx(ctx context.Context, op func() error) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- op()
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
 
 // NewClient creates a new Redfish client.
 func NewClient(ctx context.Context, address, username, password string, insecure bool) (Client, error) {
@@ -46,11 +93,12 @@ func NewClient(ctx context.Context, address, username, password string, insecure
 	endpointURL := parsedURL.String()
 
 	config := gofish.ClientConfig{
-		Endpoint:  endpointURL, // Use the processed URL
-		Username:  username,
-		Password:  password,
-		Insecure:  insecure,
-		BasicAuth: true,
+		Endpoint:   endpointURL, // Use the processed URL
+		Username:   username,
+		Password:   password,
+		Insecure:   insecure, // retained for documentation intent; HTTPClient below takes precedence
+		BasicAuth:  true,
+		HTTPClient: newHTTPClient(insecure),
 	}
 
 	// Log the final config before connecting. Username is omitted (SEC-4); use
@@ -76,11 +124,10 @@ func NewClient(ctx context.Context, address, username, password string, insecure
 	}, nil
 }
 
-// NewClientWithHTTPClient creates a new Redfish client using a custom HTTP client.
-// Note: The underlying gofish library does not currently accept a custom http.Client.
-// This function preserves API compatibility for tests and callers that wish to provide
-// a client (e.g., to disable TLS verification). The provided httpClient is ignored,
-// and the 'insecure' parameter is used to control TLS verification instead.
+// NewClientWithHTTPClient is a compatibility shim used by integration tests.
+// It forwards to NewClient and ignores the supplied httpClient argument;
+// NewClient now builds its own http.Client from the insecure flag.
+// SEC-5 will rewire this to actually use the supplied client (e.g. for custom CA bundles).
 func NewClientWithHTTPClient(
 	ctx context.Context,
 	address, username, password string,
@@ -90,11 +137,20 @@ func NewClientWithHTTPClient(
 	return NewClient(ctx, address, username, password, insecure)
 }
 
-// Close disconnects the client.
-func (c *gofishClient) Close(ctx context.Context) {
+// Close disconnects the client. It uses a fresh 5-second context so that a
+// partitioned BMC doesn't block a deferred Close indefinitely, even when the
+// caller's ctx is already cancelled.
+func (c *gofishClient) Close(_ context.Context) {
 	if c.gofishClient != nil {
 		log.Info("Disconnecting Redfish client", "address", c.apiEndpoint)
-		c.gofishClient.Logout()
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := doWithCtx(closeCtx, func() error {
+			c.gofishClient.Logout()
+			return nil
+		}); err != nil {
+			log.V(1).Info("Redfish logout did not complete cleanly", "address", c.apiEndpoint, "reason", err)
+		}
 		c.gofishClient = nil
 	}
 }
@@ -106,8 +162,12 @@ func (c *gofishClient) getSystemService(ctx context.Context) (*redfish.ComputerS
 		return nil, fmt.Errorf("redfish client is not connected")
 	}
 	service := c.gofishClient.Service
-	systems, err := service.Systems()
-	if err != nil {
+	var systems []*redfish.ComputerSystem
+	if err := doWithCtx(ctx, func() error {
+		var inner error
+		systems, inner = service.Systems()
+		return inner
+	}); err != nil {
 		log.Error(err, "Failed to retrieve systems from Redfish service root")
 		return nil, fmt.Errorf("failed to retrieve systems: %w", err)
 	}
@@ -149,6 +209,8 @@ func (c *gofishClient) GetPowerState(ctx context.Context) (redfish.PowerState, e
 }
 
 // SetPowerState sets the desired power state of the system.
+// Mapping Off → GracefulShutdown ensures the OS can flush state before power
+// is removed. Callers that need an immediate power-cut must use ForcePowerOff.
 func (c *gofishClient) SetPowerState(ctx context.Context, state redfish.PowerState) error {
 	system, err := c.getSystemService(ctx)
 	if err != nil {
@@ -160,7 +222,7 @@ func (c *gofishClient) SetPowerState(ctx context.Context, state redfish.PowerSta
 	case redfish.OnPowerState:
 		resetType = redfish.OnResetType
 	case redfish.OffPowerState:
-		resetType = redfish.ForceOffResetType
+		resetType = redfish.GracefulShutdownResetType
 	default:
 		// Try direct conversion if it matches a ResetType
 		switch redfish.ResetType(state) {
@@ -172,12 +234,27 @@ func (c *gofishClient) SetPowerState(ctx context.Context, state redfish.PowerSta
 	}
 
 	log.Info("Attempting to set power state", "desiredState", state, "resetType", resetType)
-	err = system.Reset(resetType)
-	if err != nil {
+	if err := doWithCtx(ctx, func() error { return system.Reset(resetType) }); err != nil {
 		log.Error(err, "Failed to set power state", "desiredState", state)
 		return fmt.Errorf("failed to set power state to %s: %w", state, err)
 	}
 	log.Info("Successfully requested power state change", "desiredState", state)
+	return nil
+}
+
+// ForcePowerOff forces an immediate power-off, bypassing OS shutdown.
+// Use only for unrecoverable error paths; prefer SetPowerState(Off) which
+// performs a graceful shutdown.
+func (c *gofishClient) ForcePowerOff(ctx context.Context) error {
+	system, err := c.getSystemService(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get system for force power-off: %w", err)
+	}
+	log.Info("Forcing system power-off (bypassing graceful shutdown)")
+	if err := doWithCtx(ctx, func() error { return system.Reset(redfish.ForceOffResetType) }); err != nil {
+		log.Error(err, "Failed to force power-off")
+		return fmt.Errorf("failed to force power-off: %w", err)
+	}
 	return nil
 }
 
@@ -193,8 +270,7 @@ func (c *gofishClient) SetBootSourcePXE(ctx context.Context) error {
 		BootSourceOverrideEnabled: redfish.OnceBootSourceOverrideEnabled,
 	}
 	log.Info("Attempting to set boot source override to PXE", "target", boot.BootSourceOverrideTarget, "enabled", boot.BootSourceOverrideEnabled)
-	err = system.SetBoot(boot)
-	if err != nil {
+	if err := doWithCtx(ctx, func() error { return system.SetBoot(boot) }); err != nil {
 		log.Error(err, "Failed to set boot source override to PXE")
 		return fmt.Errorf("failed to set boot source override to PXE: %w", err)
 	}
@@ -211,8 +287,7 @@ func (c *gofishClient) Reset(ctx context.Context) error {
 	}
 
 	log.Info("Attempting to reset system")
-	err = system.Reset(redfish.ForceRestartResetType)
-	if err != nil {
+	if err := doWithCtx(ctx, func() error { return system.Reset(redfish.ForceRestartResetType) }); err != nil {
 		log.Error(err, "Failed to reset system")
 		return fmt.Errorf("failed to reset system: %w", err)
 	}
@@ -233,8 +308,12 @@ func (c *gofishClient) GetNetworkAddresses(ctx context.Context) ([]NetworkAddres
 	var addresses []NetworkAddress
 
 	// Try to get EthernetInterfaces first (more common and reliable)
-	ethernetInterfaces, err := system.EthernetInterfaces()
-	if err != nil {
+	var ethernetInterfaces []*redfish.EthernetInterface
+	if err := doWithCtx(ctx, func() error {
+		var inner error
+		ethernetInterfaces, inner = system.EthernetInterfaces()
+		return inner
+	}); err != nil {
 		log.Error(err, "Failed to retrieve ethernet interfaces")
 		// Don't return error yet, try NetworkInterfaces as fallback
 	} else {
@@ -248,8 +327,12 @@ func (c *gofishClient) GetNetworkAddresses(ctx context.Context) ([]NetworkAddres
 	// If we didn't get addresses from EthernetInterfaces, try NetworkInterfaces
 	if len(addresses) == 0 {
 		log.Info("No addresses found via EthernetInterfaces, trying NetworkInterfaces fallback")
-		networkInterfaces, err := system.NetworkInterfaces()
-		if err != nil {
+		var networkInterfaces []*redfish.NetworkInterface
+		if err := doWithCtx(ctx, func() error {
+			var inner error
+			networkInterfaces, inner = system.NetworkInterfaces()
+			return inner
+		}); err != nil {
 			log.Error(err, "Failed to retrieve network interfaces")
 			return nil, fmt.Errorf("failed to retrieve both ethernet and network interfaces: %w", err)
 		}
@@ -312,8 +395,12 @@ func (c *gofishClient) extractAddressesFromNetworkInterface(ctx context.Context,
 	log.V(1).Info("Extracting addresses from NetworkInterface", "interface", netIntf.Name, "id", netIntf.ID)
 
 	// Try to get NetworkPorts from the NetworkInterface
-	networkPorts, err := netIntf.NetworkPorts()
-	if err != nil {
+	var networkPorts []*redfish.NetworkPort
+	if err := doWithCtx(ctx, func() error {
+		var inner error
+		networkPorts, inner = netIntf.NetworkPorts()
+		return inner
+	}); err != nil {
 		log.V(1).Info("Could not retrieve NetworkPorts from NetworkInterface", "interface", netIntf.Name, "error", err)
 	} else if len(networkPorts) > 0 {
 		log.V(1).Info("Found NetworkPorts", "interface", netIntf.Name, "count", len(networkPorts))
@@ -325,8 +412,12 @@ func (c *gofishClient) extractAddressesFromNetworkInterface(ctx context.Context,
 	}
 
 	// Try to get NetworkDeviceFunctions from the NetworkInterface
-	networkDeviceFunctions, err := netIntf.NetworkDeviceFunctions()
-	if err != nil {
+	var networkDeviceFunctions []*redfish.NetworkDeviceFunction
+	if err := doWithCtx(ctx, func() error {
+		var inner error
+		networkDeviceFunctions, inner = netIntf.NetworkDeviceFunctions()
+		return inner
+	}); err != nil {
 		log.V(1).Info("Could not retrieve NetworkDeviceFunctions from NetworkInterface", "interface", netIntf.Name, "error", err)
 	} else if len(networkDeviceFunctions) > 0 {
 		log.V(1).Info("Found NetworkDeviceFunctions", "interface", netIntf.Name, "count", len(networkDeviceFunctions))

--- a/internal/redfish/gofish_client_test.go
+++ b/internal/redfish/gofish_client_test.go
@@ -1,0 +1,132 @@
+package redfish
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// doWithCtx
+// ---------------------------------------------------------------------------
+
+func TestDoWithCtx_Success(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	err := doWithCtx(ctx, func() error { return nil })
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestDoWithCtx_OpError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	want := errors.New("op failed")
+	err := doWithCtx(ctx, func() error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+}
+
+func TestDoWithCtx_CancelledBeforeOp(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// The op blocks for 500 ms; we cancel after 50 ms.
+	err := doWithCtx(ctx, func() error {
+		cancel()
+		// Simulate work that takes longer than the cancellation.
+		time.Sleep(500 * time.Millisecond)
+		return nil
+	})
+	// We cancelled ctx inside the op; doWithCtx should return ctx.Err().
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestDoWithCtx_DeadlineExceeded(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := doWithCtx(ctx, func() error {
+		time.Sleep(500 * time.Millisecond)
+		return nil
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// newHTTPClient
+// ---------------------------------------------------------------------------
+
+func TestNewHTTPClient_Timeout(t *testing.T) {
+	t.Parallel()
+	c := newHTTPClient(false)
+	if c.Timeout != defaultHTTPTimeout {
+		t.Fatalf("expected Timeout=%v, got %v", defaultHTTPTimeout, c.Timeout)
+	}
+}
+
+func TestNewHTTPClient_InsecureFalse(t *testing.T) {
+	t.Parallel()
+	c := newHTTPClient(false)
+	transport, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify=false")
+	}
+}
+
+func TestNewHTTPClient_InsecureTrue(t *testing.T) {
+	t.Parallel()
+	c := newHTTPClient(true)
+	transport, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify=true")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MockClient.ForcePowerOff
+// ---------------------------------------------------------------------------
+
+func TestMockClient_ForcePowerOff_Success(t *testing.T) {
+	t.Parallel()
+	m := NewMockClient()
+	ctx := context.Background()
+
+	if err := m.ForcePowerOff(ctx); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if !m.ForcePowerOffCalled {
+		t.Fatal("expected ForcePowerOffCalled=true")
+	}
+}
+
+func TestMockClient_ForcePowerOff_ShouldFail(t *testing.T) {
+	t.Parallel()
+	m := NewMockClient()
+	want := errors.New("bmc unavailable")
+	m.ShouldFail["ForcePowerOff"] = want
+	ctx := context.Background()
+
+	err := m.ForcePowerOff(ctx)
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+	if !m.ForcePowerOffCalled {
+		t.Fatal("expected ForcePowerOffCalled=true even on failure")
+	}
+}

--- a/internal/redfish/mock_client.go
+++ b/internal/redfish/mock_client.go
@@ -31,6 +31,7 @@ type MockClient struct {
 	SetBootSourcePXECalled    bool
 	ResetCalled               bool
 	GetNetworkAddressesCalled bool
+	ForcePowerOffCalled       bool
 }
 
 // NewMockClient creates a new mock client with default values.
@@ -152,4 +153,18 @@ func (m *MockClient) Close(ctx context.Context) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.CloseCalled = true
+}
+
+// ForcePowerOff mock implementation.
+func (m *MockClient) ForcePowerOff(ctx context.Context) error {
+	m.mu.Lock()
+	m.ForcePowerOffCalled = true
+	m.mu.Unlock()
+	if err := m.failIfNeeded("ForcePowerOff"); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PowerState = redfish.OffPowerState
+	return nil
 }


### PR DESCRIPTION
## Summary

Closes **BUG-6** and **BUG-10**.

### BUG-6 — graceful power-off default

- `SetPowerState(OffPowerState)` now maps to `GracefulShutdownResetType` instead of `ForceOffResetType`. The OS gets a chance to flush state before power is removed — important once we ever issue a power-off against a workload node.
- New `Client.ForcePowerOff(ctx)` method for unrecoverable error paths that need to bypass graceful shutdown. `MockClient` extended with `ForcePowerOffCalled` + standard `failIfNeeded` pattern.
- No force-after-timeout fallback in this PR (architect explicitly deferred — keep it simple).

### BUG-10 — ctx propagation + per-call HTTP timeout

- **HTTP timeout**: `NewClient` now constructs an `*http.Client` via `newHTTPClient(insecure)` with a 30-second `Timeout` (`defaultHTTPTimeout`) and a TLS Transport that mirrors gofish's internal defaults + `TLSClientConfig.InsecureSkipVerify` driven by the caller's flag. Verified that gofish v0.20.0 honors `ClientConfig.HTTPClient` wholesale when provided (`client.go:128-149` in the gofish module).
- **Ctx propagation**: new `doWithCtx` helper races every synchronous gofish I/O call against the caller's ctx. On cancellation the goroutine continues to completion (we can't interrupt mid-flight) and its result is discarded. Simplest pattern that respects reconcile-context cancellation without requiring upstream gofish ctx support.
- Wrapped sites: `getSystemService` (Systems), `SetPowerState` (Reset), `ForcePowerOff` (Reset), `SetBootSourcePXE` (SetBoot), `Reset` (Reset), `GetNetworkAddresses` (EthernetInterfaces, NetworkInterfaces), `extractAddressesFromNetworkInterface` (NetworkPorts, NetworkDeviceFunctions).
- `Close` uses an independent 5-second context (`context.Background` + `WithTimeout`) so a partitioned BMC doesn't block a deferred Close even when the caller's ctx is already cancelled.

### Cleanup

The misleading comment on `NewClientWithHTTPClient` claiming "the underlying gofish library does not currently accept a custom http.Client" was wrong — replaced with an accurate description noting it's a compatibility shim and that **SEC-5** will rewire it to honor custom CA bundles.

## Tests

`internal/redfish/gofish_client_test.go` (new):
- `doWithCtx`: success, op-error, cancelled-before-op, deadline-exceeded.
- `newHTTPClient`: Timeout set; TLS InsecureSkipVerify true/false branches.

## Test plan

- [x] `gofmt -s -d $(git ls-files '*.go' | grep -v '^vendor/')` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes across all packages (envtest with `KUBEBUILDER_ASSETS=$(setup-envtest use 1.31.x -p path)`)
- [ ] CI lint / unit / integration jobs pass
- [ ] CI E2E job passes

## Notes for follow-up

- **BUG-6 integration coverage**: the graceful-shutdown mapping is exercised structurally but `test/emulation/` (`-tags integration`) doesn't have an end-to-end test verifying the actual `ResetType` payload sent over the wire. Worth adding when integration tests are next touched.
- **SEC-5** (`NewClientWithHTTPClient` rewrite to actually use the supplied client for custom CA bundles) is the next-logical PR in `internal/redfish/`. The misleading comment is fixed here; the implementation gap remains for SEC-5.
- Pre-existing `QF1003` staticcheck finding in `client.go:79` (`ConvertToMachineAddresses` should use a tagged switch) is unmodified by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)