### PR TITLE
PR-2.3: clean release on delete + watch PhysicalHost from Beskar7Machine

### DIFF
--- a/.claude/context/PROJECT_CONTEXT.md
+++ b/.claude/context/PROJECT_CONTEXT.md
@@ -2,7 +2,7 @@
 
 > **Read this file before starting any non-trivial change.** Update it whenever you close a tracked item or discover a new one. This is the project's working memory between Claude sessions.
 >
-> **Last meaningful update:** 2026-05-02 — PR-3.1 closed BUG-6 (graceful power-off default) and BUG-10 (per-call HTTP timeout + ctx propagation in gofish client).
+> **Last meaningful update:** 2026-05-02 — PR-2.3 closed BUG-4 (clean release on delete: ClearBootSourceOverride + graceful power-off + ForceReleaseAnnotation escape hatch), BUG-7 (Beskar7Machine now watches PhysicalHost), and the residual BUG-1 risk (latency from annotation-only signal eliminated by the new PhysicalHost watch).
 
 ---
 
@@ -74,10 +74,7 @@ Two unwired internal packages (decision pending, see Decisions log entry D-001):
 
 | ID | Area | Issue | Where |
 |---|---|---|---|
-| BUG-1 | controller | Cross-controller status writes: **partially resolved in PR-2.1** — the three `r.Status().Update(physicalHost)` calls at the original lines 268, 291, 371 are removed. Replaced with annotation signal (`InspectionRequestAnnotation`). Residual risk: annotation processing happens one reconcile cycle after the Beskar7Machine sets it, introducing a brief window where PhysicalHost state lags. A concurrent PhysicalHost reconcile and annotation-clear could drop the signal if the PhysicalHost reconcile races with the annotation patch. Tracked here until a reconcile-triggered-by-annotation watch is wired. | `controllers/beskar7machine_controller.go` (signal path), `controllers/physicalhost_controller.go` (annotation consumer) |
 | BUG-2 | controller | Host claim is list-then-update with no resourceVersion precondition; two Beskar7Machines can claim the same Available host. | `controllers/beskar7machine_controller.go:425-442` |
-| BUG-4 | controller | `reconcileDelete` clears `ConsumerRef` but never powers off the host or clears the boot override. Strands hosts in `Once,Pxe,On`. | `controllers/beskar7machine_controller.go:449-476` |
-| BUG-7 | controller | `Beskar7Machine` doesn't watch `PhysicalHost`; state changes only propagate via 30s requeue. | `controllers/beskar7machine_controller.go:527-531` |
 | BUG-8 | controller | `FailureReason`/`FailureMessage` declared on the API but never set; hardware validation failures requeue forever. | `api/v1beta1/beskar7machine_types.go:96-104`, `controllers/beskar7machine_controller.go:329-363` |
 | BUG-9 | controller | `findControlPlaneEndpoint` ignores user-set `Spec.ControlPlaneEndpoint` and hardcodes port 6443. | `controllers/beskar7cluster_controller.go:278-298, 350-353` |
 
@@ -134,6 +131,9 @@ All of these need a doc rewrite when the v0.4 doc sweep happens. Tracked togethe
 
 | Item | Resolution | Date |
 |---|---|---|
+| BUG-1 | PR-2.1 + PR-2.3: direct `r.Status().Update(physicalHost)` calls removed in PR-2.1; replaced with `InspectionRequestAnnotation` signal. Residual latency concern (one-cycle lag + race on annotation-clear) eliminated in PR-2.3 by adding `Watches(&PhysicalHost{}, ...)` to `Beskar7MachineReconciler.SetupWithManager` — PhysicalHost state changes now trigger an immediate Beskar7Machine reconcile. | 2026-05-02 |
+| BUG-4 | PR-2.3: `reconcileDelete` now issues `ClearBootSourceOverride` then graceful `SetPowerState(Off)` before clearing `ConsumerRef`. Both Redfish calls are best-effort — errors are logged and swallowed so a dead BMC cannot strand the finalizer. `ForceReleaseAnnotation = "infrastructure.cluster.x-k8s.io/force-release"` added as operator escape hatch (skips Redfish ops entirely). Missing-credentials path treated identically. `ClearBootSourceOverride` added to the `Client` interface, `gofishClient`, and `MockClient`. 4 new `It` blocks in `controllers/beskar7machine_controller_test.go`. | 2026-05-02 |
+| BUG-7 | PR-2.3: `Beskar7MachineReconciler.SetupWithManager` now calls `Watches(&PhysicalHost{}, handler.EnqueueRequestsFromMapFunc(r.PhysicalHostToBeskar7Machine))`. The mapping function only enqueues requests where `ConsumerRef.Kind == "Beskar7Machine"` and `ConsumerRef.APIVersion == InfrastructureAPIVersion`, so unrelated consumers produce no spurious reconciles. 4 mapping unit tests added. | 2026-05-02 |
 | BLOCK-1 | PR-0.1: defaulted `RedfishClientFactory` to `internalredfish.NewClient` in each reconciler's `SetupWithManager` with a fail-fast non-nil guard; removed misleading `// Use default` from `cmd/manager/main.go`; added unit specs covering nil → default and explicit-factory-preserved for both reconcilers. | 2026-05-01 |
 | kube-rbac-proxy removal (Phase 11, PR-11.1) | Deleted `config/default/manager_auth_proxy_patch.yaml` and the kube-rbac-proxy sidecar from the Helm chart; wired `filters.WithAuthenticationAndAuthorization` via `metricsserver.Options.FilterProvider`; metrics now served directly on `:8443` (HTTPS) with TokenReview/SAR-based auth; added `--secure-metrics` flag (default true) for local dev; added `config/rbac/metrics_auth_role.yaml`, `metrics_auth_role_binding.yaml`, `metrics_reader_role.yaml`; updated all overlay patches and networkpolicies to `:8443`. | 2026-05-01 |
 | BUG-3 | PR-1.3: Replaced hand-rolled loop in `parseProviderID` with `strings.CutPrefix` + `strings.SplitN`. Now rejects missing prefix with informative message, conflates no-slash / empty-namespace / empty-name with a single clear error, and explicitly rejects multi-segment names (BUG-3 root cause: `b7://ns/name/extra` previously returned `("ns", "name/extra", nil)`). Table-driven `TestParseProviderID` added in `controllers/parse_provider_id_test.go` (9 subtests, race-clean). | 2026-05-02 |

--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -39,6 +39,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -53,6 +55,11 @@ const (
 
 	// Inspection timeout
 	DefaultInspectionTimeout = 10 * time.Minute
+
+	// ForceReleaseAnnotation, when set to "true" on a Beskar7Machine being deleted,
+	// causes the controller to skip the Redfish power-off and boot-override clear
+	// during deletion. Use only when the BMC is permanently unreachable.
+	ForceReleaseAnnotation = "infrastructure.cluster.x-k8s.io/force-release"
 )
 
 // Beskar7MachineReconciler reconciles a Beskar7Machine object.
@@ -454,35 +461,78 @@ func (r *Beskar7MachineReconciler) findAndClaimOrGetAssociatedHost(ctx context.C
 	return nil, ctrl.Result{}, nil
 }
 
-// reconcileDelete handles deletion.
+// reconcileDelete handles deletion. The sequence is:
+//  1. Best-effort Redfish cleanup (ClearBootSourceOverride + graceful power-off).
+//  2. Patch ConsumerRef = nil on the PhysicalHost spec.
+//  3. Remove the Beskar7Machine finalizer.
+//
+// Redfish cleanup is skipped when the ForceReleaseAnnotation is "true" (BMC
+// permanently unreachable) or when the credentials Secret no longer exists.
+// Neither case strands the finalizer: errors from Redfish are logged and
+// swallowed so that a dead BMC cannot block object deletion.
 func (r *Beskar7MachineReconciler) reconcileDelete(ctx context.Context, logger logr.Logger, b7machine *infrastructurev1beta1.Beskar7Machine) (ctrl.Result, error) {
 	logger.Info("Reconciling deletion")
 
-	// Release the host via a spec-only patch (optimistic locking).
 	if b7machine.Spec.ProviderID != nil && *b7machine.Spec.ProviderID != "" {
-		ns, name, err := parseProviderID(*b7machine.Spec.ProviderID)
-		if err == nil {
+		ns, name, parseErr := parseProviderID(*b7machine.Spec.ProviderID)
+		if parseErr != nil {
+			// Malformed providerID — log and proceed; nothing useful we can do.
+			logger.V(1).Info("Cannot parse ProviderID during deletion; proceeding without host release", "err", parseErr)
+		} else {
 			host := &infrastructurev1beta1.PhysicalHost{}
 			if err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, host); err == nil {
 				if host.Spec.ConsumerRef != nil && host.Spec.ConsumerRef.Name == b7machine.Name {
+					forceRelease := b7machine.Annotations[ForceReleaseAnnotation] == "true"
+					if forceRelease {
+						logger.Info("ForceReleaseAnnotation set; skipping Redfish power-off and boot-override clear")
+					} else {
+						// Best-effort Redfish cleanup. Errors are logged but do not block release.
+						r.bestEffortReleaseRedfish(ctx, logger, host)
+					}
+					// Always clear ConsumerRef on the host spec.
 					base := host.DeepCopy()
 					host.Spec.ConsumerRef = nil
 					if err := r.Patch(ctx, host, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+						if apierrors.IsConflict(err) {
+							return ctrl.Result{Requeue: true}, nil
+						}
 						logger.Error(err, "Failed to release host")
 						return ctrl.Result{}, err
 					}
 					logger.Info("Released PhysicalHost", "host", name)
 				}
+			} else if !apierrors.IsNotFound(err) {
+				// Real error fetching host — surface and requeue.
+				return ctrl.Result{}, err
 			}
+			// host NotFound → already gone; nothing to release.
 		}
 	}
 
-	// Remove finalizer
 	if controllerutil.RemoveFinalizer(b7machine, Beskar7MachineFinalizer) {
 		logger.Info("Removing finalizer")
 	}
-
 	return ctrl.Result{}, nil
+}
+
+// bestEffortReleaseRedfish issues ClearBootSourceOverride and a graceful power-off
+// against the host's BMC. All errors are logged at Info and swallowed so a
+// dead BMC cannot strand the Beskar7Machine finalizer.
+// Missing credentials are treated identically — log a warning and return.
+func (r *Beskar7MachineReconciler) bestEffortReleaseRedfish(ctx context.Context, logger logr.Logger, host *infrastructurev1beta1.PhysicalHost) {
+	rfClient, err := r.getRedfishClientForHost(ctx, logger, host)
+	if err != nil {
+		logger.Info("Could not get Redfish client during release; skipping power-off and boot clear", "err", err)
+		return
+	}
+	defer rfClient.Close(ctx)
+
+	if err := rfClient.ClearBootSourceOverride(ctx); err != nil {
+		logger.Info("Failed to clear boot source override during release; continuing", "err", err)
+	}
+	if err := rfClient.SetPowerState(ctx, redfish.OffPowerState); err != nil {
+		logger.Info("Failed to graceful power-off during release; continuing", "err", err)
+	}
 }
 
 // setInspectionRequestAnnotation patches only the annotations of a PhysicalHost to request
@@ -569,7 +619,33 @@ func (r *Beskar7MachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infrastructurev1beta1.Beskar7Machine{}).
+		Watches(
+			&infrastructurev1beta1.PhysicalHost{},
+			handler.EnqueueRequestsFromMapFunc(r.PhysicalHostToBeskar7Machine),
+		).
 		Complete(r)
+}
+
+// PhysicalHostToBeskar7Machine maps a PhysicalHost change to a reconcile
+// request for the Beskar7Machine that currently consumes it. PhysicalHosts
+// without a ConsumerRef, or with a ConsumerRef pointing at a non-Beskar7Machine
+// kind, produce no requests.
+func (r *Beskar7MachineReconciler) PhysicalHostToBeskar7Machine(ctx context.Context, obj client.Object) []reconcile.Request {
+	host, ok := obj.(*infrastructurev1beta1.PhysicalHost)
+	if !ok {
+		r.Log.Error(nil, "Expected a PhysicalHost in PhysicalHostToBeskar7Machine map", "object", obj)
+		return nil
+	}
+	cr := host.Spec.ConsumerRef
+	if cr == nil {
+		return nil
+	}
+	if cr.Kind != "Beskar7Machine" || cr.APIVersion != InfrastructureAPIVersion {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name}},
+	}
 }
 
 // parseMemoryCapacityGB converts a BMC-reported capacity string to whole decimal gigabytes.

--- a/controllers/beskar7machine_controller_test.go
+++ b/controllers/beskar7machine_controller_test.go
@@ -2,10 +2,12 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stmcginnis/gofish/redfish"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -13,6 +15,7 @@ import (
 	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	infrastructurev1beta1 "github.com/projectbeskar/beskar7/api/v1beta1"
 	internalredfish "github.com/projectbeskar/beskar7/internal/redfish"
@@ -314,43 +317,235 @@ var _ = Describe("Beskar7Machine Controller", func() {
 			}, Timeout, Interval).Should(Succeed())
 		})
 
-		PIt("[SKIP - Hardware Testing] Should handle deletion and release host", func() {
-			By("Creating and provisioning machine")
-			Expect(k8sClient.Create(ctx, beskar7Machine)).To(Succeed())
+		// Converted from PIt "[SKIP - Hardware Testing] Should handle deletion and release host":
+		// The deletion path no longer requires a real CAPI Machine owner — reconcileDelete is
+		// called directly. We set up ProviderID + ConsumerRef manually and inject a MockClient.
+		It("Should clear boot source override and power off the host before clearing ConsumerRef", func() {
+			mockRf := internalredfish.NewMockClient()
+			mockRf.PowerState = redfish.OnPowerState
+			mockRf.BootSourceIsPXE = true
 
-			machineLookupKey := types.NamespacedName{Name: beskar7Machine.Name, Namespace: beskar7Machine.Namespace}
+			r := &Beskar7MachineReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Log:    ctrl.Log.WithName("beskar7machine-delete-test"),
+				RedfishClientFactory: func(_ context.Context, _, _, _ string, _ bool) (internalredfish.Client, error) {
+					return mockRf, nil
+				},
+			}
 
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
+			By("Setting ConsumerRef on PhysicalHost")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: testNs.Name}, physicalHost)).To(Succeed())
+			base := physicalHost.DeepCopy()
+			physicalHost.Spec.ConsumerRef = &corev1.ObjectReference{
+				Kind:       "Beskar7Machine",
+				APIVersion: InfrastructureAPIVersion,
+				Name:       "delete-test-machine",
+				Namespace:  testNs.Name,
+			}
+			Expect(k8sClient.Patch(ctx, physicalHost, client.MergeFrom(base))).To(Succeed())
+
+			By("Creating a Beskar7Machine with ProviderID pointing at the host")
+			provID := "b7://" + testNs.Name + "/" + physicalHost.Name
+			b7m := &infrastructurev1beta1.Beskar7Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "delete-test-machine",
+					Namespace:  testNs.Name,
+					Finalizers: []string{Beskar7MachineFinalizer},
+				},
+				Spec: infrastructurev1beta1.Beskar7MachineSpec{
+					InspectionImageURL: "http://boot-server/inspect.ipxe",
+					TargetImageURL:     "http://boot-server/kairos.tar.gz",
+					ProviderID:         &provID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, b7m)).To(Succeed())
+
+			By("Calling reconcileDelete directly")
+			_, err := r.reconcileDelete(ctx, r.Log, b7m)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Verifying host was claimed")
-			claimedHost := &infrastructurev1beta1.PhysicalHost{}
-			hostKey := types.NamespacedName{Name: physicalHost.Name, Namespace: physicalHost.Namespace}
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, hostKey, claimedHost)).To(Succeed())
-				g.Expect(claimedHost.Spec.ConsumerRef).NotTo(BeNil())
-			}, Timeout, Interval).Should(Succeed())
+			By("Verifying ClearBootSourceOverride was called")
+			Expect(mockRf.ClearBootSourceOverrideCalled).To(BeTrue(),
+				"ClearBootSourceOverride must be called on clean release")
 
-			By("Deleting machine")
-			Expect(k8sClient.Delete(ctx, beskar7Machine)).To(Succeed())
+			By("Verifying SetPowerState(Off) was called")
+			Expect(mockRf.SetPowerStateCalled).To(BeTrue(),
+				"SetPowerState must be called on clean release")
+			Expect(mockRf.PowerState).To(Equal(redfish.OffPowerState))
 
-			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
+			By("Verifying ConsumerRef is nil on the host")
+			hostAfter := &infrastructurev1beta1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: testNs.Name}, hostAfter)).To(Succeed())
+			Expect(hostAfter.Spec.ConsumerRef).To(BeNil(), "ConsumerRef must be cleared after deletion")
+
+			By("Cleanup: remove finalizer so the machine can be GC'd")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: b7m.Name, Namespace: testNs.Name}, b7m)).To(Succeed())
+			b7mBase := b7m.DeepCopy()
+			b7m.Finalizers = nil
+			Expect(k8sClient.Patch(ctx, b7m, client.MergeFrom(b7mBase))).To(Succeed())
+		})
+
+		It("Should skip Redfish ops when force-release annotation is set", func() {
+			mockRf := internalredfish.NewMockClient()
+
+			r := &Beskar7MachineReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Log:    ctrl.Log.WithName("beskar7machine-forcerelease-test"),
+				RedfishClientFactory: func(_ context.Context, _, _, _ string, _ bool) (internalredfish.Client, error) {
+					return mockRf, nil
+				},
+			}
+
+			By("Setting ConsumerRef on PhysicalHost")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: testNs.Name}, physicalHost)).To(Succeed())
+			base := physicalHost.DeepCopy()
+			physicalHost.Spec.ConsumerRef = &corev1.ObjectReference{
+				Kind:       "Beskar7Machine",
+				APIVersion: InfrastructureAPIVersion,
+				Name:       "force-release-machine",
+				Namespace:  testNs.Name,
+			}
+			Expect(k8sClient.Patch(ctx, physicalHost, client.MergeFrom(base))).To(Succeed())
+
+			By("Creating a Beskar7Machine with force-release annotation")
+			provID := "b7://" + testNs.Name + "/" + physicalHost.Name
+			b7m := &infrastructurev1beta1.Beskar7Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "force-release-machine",
+					Namespace:  testNs.Name,
+					Finalizers: []string{Beskar7MachineFinalizer},
+					Annotations: map[string]string{
+						ForceReleaseAnnotation: "true",
+					},
+				},
+				Spec: infrastructurev1beta1.Beskar7MachineSpec{
+					InspectionImageURL: "http://boot-server/inspect.ipxe",
+					TargetImageURL:     "http://boot-server/kairos.tar.gz",
+					ProviderID:         &provID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, b7m)).To(Succeed())
+
+			By("Calling reconcileDelete directly")
+			_, err := r.reconcileDelete(ctx, r.Log, b7m)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Verifying host was released")
-			Eventually(func(g Gomega) {
-				releasedHost := &infrastructurev1beta1.PhysicalHost{}
-				g.Expect(k8sClient.Get(ctx, hostKey, releasedHost)).To(Succeed())
-				g.Expect(releasedHost.Spec.ConsumerRef).To(BeNil())
-				g.Expect(releasedHost.Status.State).To(Equal(infrastructurev1beta1.StateAvailable))
-			}, Timeout, Interval).Should(Succeed())
+			By("Verifying ClearBootSourceOverride was NOT called")
+			Expect(mockRf.ClearBootSourceOverrideCalled).To(BeFalse(),
+				"ClearBootSourceOverride must be skipped on force-release")
 
-			By("Verifying machine is eventually deleted")
-			Eventually(func() bool {
-				deletedMachine := &infrastructurev1beta1.Beskar7Machine{}
-				err := k8sClient.Get(ctx, machineLookupKey, deletedMachine)
-				return client.IgnoreNotFound(err) == nil
-			}, Timeout*2, Interval).Should(BeTrue())
+			By("Verifying SetPowerState was NOT called")
+			Expect(mockRf.SetPowerStateCalled).To(BeFalse(),
+				"SetPowerState must be skipped on force-release")
+
+			By("Verifying ConsumerRef is still cleared on the host")
+			hostAfter := &infrastructurev1beta1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: testNs.Name}, hostAfter)).To(Succeed())
+			Expect(hostAfter.Spec.ConsumerRef).To(BeNil(), "ConsumerRef must be cleared even on force-release")
+
+			By("Cleanup: remove finalizer")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: b7m.Name, Namespace: testNs.Name}, b7m)).To(Succeed())
+			b7mBase := b7m.DeepCopy()
+			b7m.Finalizers = nil
+			Expect(k8sClient.Patch(ctx, b7m, client.MergeFrom(b7mBase))).To(Succeed())
+		})
+
+		It("Should remove finalizer cleanly when the host is already gone", func() {
+			r := &Beskar7MachineReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Log:    ctrl.Log.WithName("beskar7machine-hostgone-test"),
+				RedfishClientFactory: func(_ context.Context, _, _, _ string, _ bool) (internalredfish.Client, error) {
+					return internalredfish.NewMockClient(), nil
+				},
+			}
+
+			By("Creating a Beskar7Machine pointing at a non-existent host")
+			provID := "b7://" + testNs.Name + "/does-not-exist"
+			b7m := &infrastructurev1beta1.Beskar7Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "gone-host-machine",
+					Namespace:  testNs.Name,
+					Finalizers: []string{Beskar7MachineFinalizer},
+				},
+				Spec: infrastructurev1beta1.Beskar7MachineSpec{
+					InspectionImageURL: "http://boot-server/inspect.ipxe",
+					TargetImageURL:     "http://boot-server/kairos.tar.gz",
+					ProviderID:         &provID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, b7m)).To(Succeed())
+
+			By("Calling reconcileDelete — should not error even though host is missing")
+			_, err := r.reconcileDelete(ctx, r.Log, b7m)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying finalizer was removed from the in-memory object")
+			Expect(controllerutil.ContainsFinalizer(b7m, Beskar7MachineFinalizer)).To(BeFalse())
+
+			By("Cleanup: patch finalizer list in the API server")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: b7m.Name, Namespace: testNs.Name}, b7m)).To(Succeed())
+			b7mBase := b7m.DeepCopy()
+			b7m.Finalizers = nil
+			Expect(k8sClient.Patch(ctx, b7m, client.MergeFrom(b7mBase))).To(Succeed())
+		})
+
+		It("Should not block deletion when the BMC is unreachable", func() {
+			r := &Beskar7MachineReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Log:    ctrl.Log.WithName("beskar7machine-bmcfail-test"),
+				RedfishClientFactory: func(_ context.Context, _, _, _ string, _ bool) (internalredfish.Client, error) {
+					return nil, fmt.Errorf("BMC unreachable")
+				},
+			}
+
+			By("Setting ConsumerRef on PhysicalHost")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: testNs.Name}, physicalHost)).To(Succeed())
+			base := physicalHost.DeepCopy()
+			physicalHost.Spec.ConsumerRef = &corev1.ObjectReference{
+				Kind:       "Beskar7Machine",
+				APIVersion: InfrastructureAPIVersion,
+				Name:       "bmc-fail-machine",
+				Namespace:  testNs.Name,
+			}
+			Expect(k8sClient.Patch(ctx, physicalHost, client.MergeFrom(base))).To(Succeed())
+
+			By("Creating a Beskar7Machine")
+			provID := "b7://" + testNs.Name + "/" + physicalHost.Name
+			b7m := &infrastructurev1beta1.Beskar7Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "bmc-fail-machine",
+					Namespace:  testNs.Name,
+					Finalizers: []string{Beskar7MachineFinalizer},
+				},
+				Spec: infrastructurev1beta1.Beskar7MachineSpec{
+					InspectionImageURL: "http://boot-server/inspect.ipxe",
+					TargetImageURL:     "http://boot-server/kairos.tar.gz",
+					ProviderID:         &provID,
+				},
+			}
+			Expect(k8sClient.Create(ctx, b7m)).To(Succeed())
+
+			By("Calling reconcileDelete — should succeed despite BMC failure")
+			_, err := r.reconcileDelete(ctx, r.Log, b7m)
+			Expect(err).NotTo(HaveOccurred(), "deletion must not be blocked by an unreachable BMC")
+
+			By("Verifying ConsumerRef was still cleared on the host")
+			hostAfter := &infrastructurev1beta1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: testNs.Name}, hostAfter)).To(Succeed())
+			Expect(hostAfter.Spec.ConsumerRef).To(BeNil())
+
+			By("Verifying finalizer was removed from the in-memory object")
+			Expect(controllerutil.ContainsFinalizer(b7m, Beskar7MachineFinalizer)).To(BeFalse())
+
+			By("Cleanup: remove finalizer in API server")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: b7m.Name, Namespace: testNs.Name}, b7m)).To(Succeed())
+			b7mBase := b7m.DeepCopy()
+			b7m.Finalizers = nil
+			Expect(k8sClient.Patch(ctx, b7m, client.MergeFrom(b7mBase))).To(Succeed())
 		})
 
 		PIt("[SKIP - Hardware Testing] Should handle pause annotation", func() {
@@ -431,5 +626,72 @@ var _ = Describe("Beskar7Machine Controller", func() {
 				g.Expect(cond.Reason).To(ContainSubstring("Validation"))
 			}, Timeout, Interval).Should(Succeed())
 		})
+	})
+})
+
+// PhysicalHostToBeskar7Machine mapping — pure unit tests; no envtest required.
+var _ = Describe("PhysicalHostToBeskar7Machine mapping", func() {
+	var r *Beskar7MachineReconciler
+
+	BeforeEach(func() {
+		r = &Beskar7MachineReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			Log:    ctrl.Log.WithName("mapping-test"),
+		}
+	})
+
+	It("Should enqueue Beskar7Machine when host has matching ConsumerRef", func() {
+		host := &infrastructurev1beta1.PhysicalHost{
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Kind:       "Beskar7Machine",
+					APIVersion: InfrastructureAPIVersion,
+					Name:       "my-machine",
+					Namespace:  "my-ns",
+				},
+			},
+		}
+		reqs := r.PhysicalHostToBeskar7Machine(context.Background(), host)
+		Expect(reqs).To(HaveLen(1))
+		Expect(reqs[0].NamespacedName).To(Equal(types.NamespacedName{Namespace: "my-ns", Name: "my-machine"}))
+	})
+
+	It("Should not enqueue when host has no ConsumerRef", func() {
+		host := &infrastructurev1beta1.PhysicalHost{
+			Spec: infrastructurev1beta1.PhysicalHostSpec{},
+		}
+		reqs := r.PhysicalHostToBeskar7Machine(context.Background(), host)
+		Expect(reqs).To(BeEmpty())
+	})
+
+	It("Should not enqueue when ConsumerRef is a different Kind", func() {
+		host := &infrastructurev1beta1.PhysicalHost{
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Kind:       "SomeOtherKind",
+					APIVersion: InfrastructureAPIVersion,
+					Name:       "some-object",
+					Namespace:  "my-ns",
+				},
+			},
+		}
+		reqs := r.PhysicalHostToBeskar7Machine(context.Background(), host)
+		Expect(reqs).To(BeEmpty())
+	})
+
+	It("Should not enqueue when ConsumerRef APIVersion does not match", func() {
+		host := &infrastructurev1beta1.PhysicalHost{
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Kind:       "Beskar7Machine",
+					APIVersion: "some.other.api/v1",
+					Name:       "my-machine",
+					Namespace:  "my-ns",
+				},
+			},
+		}
+		reqs := r.PhysicalHostToBeskar7Machine(context.Background(), host)
+		Expect(reqs).To(BeEmpty())
 	})
 })

--- a/internal/redfish/client.go
+++ b/internal/redfish/client.go
@@ -36,6 +36,11 @@ type Client interface {
 	// Use only for unrecoverable error paths; prefer SetPowerState(Off) which
 	// performs a graceful shutdown.
 	ForcePowerOff(ctx context.Context) error
+
+	// ClearBootSourceOverride disables any pending one-shot or persistent boot
+	// source override. Used during host release so the next claimant is not
+	// surprised by a stale PXE-once setting.
+	ClearBootSourceOverride(ctx context.Context) error
 }
 
 // SystemInfo contains basic system information

--- a/internal/redfish/gofish_client.go
+++ b/internal/redfish/gofish_client.go
@@ -279,6 +279,27 @@ func (c *gofishClient) SetBootSourcePXE(ctx context.Context) error {
 	return nil
 }
 
+// ClearBootSourceOverride disables any pending one-shot or persistent boot
+// source override so the next claimant is not surprised by a stale PXE-once
+// setting left from the previous provisioning run.
+func (c *gofishClient) ClearBootSourceOverride(ctx context.Context) error {
+	system, err := c.getSystemService(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get system to clear boot source override: %w", err)
+	}
+
+	boot := redfish.Boot{
+		BootSourceOverrideEnabled: redfish.DisabledBootSourceOverrideEnabled,
+	}
+	log.Info("Clearing boot source override")
+	if err := doWithCtx(ctx, func() error { return system.SetBoot(boot) }); err != nil {
+		log.Error(err, "Failed to clear boot source override")
+		return fmt.Errorf("failed to clear boot source override: %w", err)
+	}
+	log.Info("Successfully cleared boot source override")
+	return nil
+}
+
 // Reset performs a system reset.
 func (c *gofishClient) Reset(ctx context.Context) error {
 	system, err := c.getSystemService(ctx)

--- a/internal/redfish/mock_client.go
+++ b/internal/redfish/mock_client.go
@@ -24,14 +24,15 @@ type MockClient struct {
 	GetNetworkAddressesFunc func(ctx context.Context) ([]NetworkAddress, error)
 
 	// Counters (optional, for verification)
-	CloseCalled               bool
-	GetSystemInfoCalled       bool
-	GetPowerStateCalled       bool
-	SetPowerStateCalled       bool
-	SetBootSourcePXECalled    bool
-	ResetCalled               bool
-	GetNetworkAddressesCalled bool
-	ForcePowerOffCalled       bool
+	CloseCalled                   bool
+	GetSystemInfoCalled           bool
+	GetPowerStateCalled           bool
+	SetPowerStateCalled           bool
+	SetBootSourcePXECalled        bool
+	ResetCalled                   bool
+	GetNetworkAddressesCalled     bool
+	ForcePowerOffCalled           bool
+	ClearBootSourceOverrideCalled bool
 }
 
 // NewMockClient creates a new mock client with default values.
@@ -166,5 +167,19 @@ func (m *MockClient) ForcePowerOff(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.PowerState = redfish.OffPowerState
+	return nil
+}
+
+// ClearBootSourceOverride mock implementation.
+func (m *MockClient) ClearBootSourceOverride(ctx context.Context) error {
+	m.mu.Lock()
+	m.ClearBootSourceOverrideCalled = true
+	m.mu.Unlock()
+	if err := m.failIfNeeded("ClearBootSourceOverride"); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.BootSourceIsPXE = false
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes **BUG-4** (strand-on-delete: host left powered-on with PXE-once boot) and **BUG-7** (Beskar7Machine doesn't watch PhysicalHost). Together with PR-2.1, also closes **BUG-1**'s residual latency note (status changes now propagate immediately via the watch instead of waiting up to 30 s for the periodic requeue).

### BUG-4 — clean release on delete

`reconcileDelete` sequence:
1. Best-effort Redfish cleanup: `ClearBootSourceOverride` (new method) → graceful `SetPowerState(Off)`.
2. Patch `ConsumerRef = nil` on the PhysicalHost spec.
3. Remove the `Beskar7MachineFinalizer`.

Redfish errors are logged at Info and swallowed so a dead BMC cannot strand the finalizer. Two escape hatches:
- **`ForceReleaseAnnotation`** (`infrastructure.cluster.x-k8s.io/force-release: "true"`): skip Redfish cleanup entirely. Use when the BMC is permanently unreachable.
- **Missing or unreadable credentials Secret**: treated identically — log, skip Redfish, proceed.

`ConsumerRef`-patch conflict requeues. Host `NotFound` is silently accepted. Other host-fetch errors surface and requeue.

#### New Redfish method

```go
// Client interface
ClearBootSourceOverride(ctx context.Context) error
```

`gofishClient` implementation sets `Boot.BootSourceOverrideEnabled = redfish.DisabledBootSourceOverrideEnabled` and wraps the call in `doWithCtx` (PR-3.1 pattern). `MockClient` extended.

### BUG-7 — watch PhysicalHost from Beskar7Machine

`SetupWithManager` now adds:

```go
.Watches(
    &infrastructurev1beta1.PhysicalHost{},
    handler.EnqueueRequestsFromMapFunc(r.PhysicalHostToBeskar7Machine),
)
```

Mapping function `PhysicalHostToBeskar7Machine`:
- Returns no requests when `ConsumerRef` is nil.
- Filters on `ConsumerRef.Kind == "Beskar7Machine"` AND `ConsumerRef.APIVersion == InfrastructureAPIVersion` to avoid enqueueing for non-Beskar7 consumers (defensive — the PhysicalHost CRD could be shared with other CAPI providers in theory).
- Otherwise enqueues a single reconcile for the consuming `Beskar7Machine`.

## Tests

- **4 envtest specs** covering the deletion matrix: normal release; `force-release` annotation; host already gone; BMC unreachable.
- **4 unit specs** covering the mapping function: matching consumer; no `ConsumerRef`; wrong `Kind`; wrong `APIVersion`.
- **1 `PIt` block converted** (`[SKIP - Hardware Testing] handle deletion and release host`) — replaced by the 4 deletion envtest specs above.

## Test plan

- [x] `gofmt -s -d` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes across all packages with envtest
- [ ] CI lint / unit / integration jobs pass
- [ ] CI E2E job passes

## Notes for follow-up

- `ClearBootSourceOverride` sets only `BootSourceOverrideEnabled = Disabled`. Some BMC firmwares may also expect `BootSourceOverrideTarget = None` to be explicit; worth validating once a hardware test environment is available.
- Local `golangci-lint` is v2.12.1 and can't parse the v1-format `.golangci.yml`. CI uses v1.64.8 so CI is unaffected. A separate small PR to migrate the config to v2 syntax would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)