### PR TITLE
PR-7: tighten Secret/ConfigMap RBAC scope (SEC-2 partial closure, D-007)

### DIFF
--- a/charts/beskar7/templates/rbac.yaml
+++ b/charts/beskar7/templates/rbac.yaml
@@ -6,10 +6,34 @@ metadata:
   labels:
     {{- include "beskar7.labels" . | nindent 4 }}
 rules:
+# ConfigMaps: only fetched by name (inspection-result handoff) and
+# create/update/delete on the same. No informer; list/watch intentionally
+# omitted (SEC-2 / D-007).
 - apiGroups:
   - ""
   resources:
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+# Secrets: get for BMC credentials and bootstrap data (by name);
+# create/update/patch/delete for the per-host bootstrap-token Secret.
+# list/watch are required because PhysicalHostReconciler.SetupWithManager
+# registers a .Watches(&corev1.Secret{}, ...) informer for credential
+# rotation. SEC-2 residual scope after PR-7 (D-007).
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -19,13 +43,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 - apiGroups:
   - cluster.x-k8s.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,22 @@ rules:
   - ""
   resources:
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -17,13 +33,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
 - apiGroups:
   - cluster.x-k8s.io
   resources:

--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -89,7 +89,18 @@ type Beskar7MachineReconciler struct {
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=beskar7machines/finalizers,verbs=update
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=physicalhosts,verbs=get;list;watch;patch
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// Secret access in this controller is by name only:
+//   - getRedfishClientForHost: r.Get on the BMC credentials Secret named
+//     by host.Spec.RedfishConnection.CredentialsSecretRef.
+//   - reconcileBootstrapData: r.Get on the bootstrap-data Secret named by
+//     machine.Spec.Bootstrap.DataSecretName.
+//   - upsertBootstrapTokenSecret: CreateOrUpdate on the per-host bootstrap
+//     token Secret (deterministic name; PhysicalHost-owned).
+// No code path performs List or Watch over Secrets here, so list/watch
+// are intentionally omitted (SEC-2 / D-007). The aggregate ClusterRole
+// will still grant secrets:list,watch because PhysicalHostReconciler's
+// SetupWithManager registers a Secret informer.
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;patch;delete
 
 // Reconcile handles Beskar7Machine reconciliation for iPXE + inspection workflow.
 func (r *Beskar7MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {

--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -81,8 +81,20 @@ func NewPhysicalHostReconciler(
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=physicalhosts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=physicalhosts/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=physicalhosts/finalizers,verbs=update
+// Secret access is read-only and restricted to BMC credential lookup
+// (see getRedfishCredentials). list/watch are required because
+// SetupWithManager registers a .Watches(&corev1.Secret{}, ...) informer
+// to trigger reconciles on credential rotation; controller-runtime's
+// cached client backs that informer with a list+watch on the cluster.
+// SEC-2 (D-007): the cluster-wide list/watch on Secret is the residual
+// scope after PR-7. Eliminating it requires either dropping the watch
+// or replacing it with a label-selected partial cache (v0.5 follow-up).
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// ConfigMaps are only ever fetched by name (the inspection-result
+// ConfigMap referenced from the InspectionResultAnnotation) and
+// upserted/deleted by the inspection handler. There is no informer over
+// ConfigMaps, so list/watch are intentionally omitted (SEC-2 / D-007).
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile handles PhysicalHost reconciliation.


### PR DESCRIPTION
## Summary

Tightens the controller's `Secret` and `ConfigMap` verb set to match what the code actually performs. Closes the verb-overgrant half of **SEC-2**. Records **D-007** (Option A) for the chosen approach.

## D-007 decision

Three options for SEC-2:

- **A** — Tighten verbs only (drop `list`/`watch`); keep cluster-wide ClusterRoleBinding.
- **B** — Per-namespace dynamic `Role`/`RoleBinding` creation. Significant complexity, mismatched with CAPI-provider convention.
- **C** — Hybrid: Option A + Helm opt-in for explicit watched-namespaces.

**Chose A.** CAPI providers (Metal3, CAPV) conventionally use cluster-wide Secret reads because user-supplied Secrets live in arbitrary user namespaces. Option B is meaningful complexity that doesn't match operator expectations. Option C is a v0.5 enhancement with no current user demand.

## Marker changes

| File / Line | Resource | Before | After |
|---|---|---|---|
| `beskar7machine_controller.go:92` | `secrets` | `get;list;watch;create;update;patch;delete` | `get;create;update;patch;delete` |
| `physicalhost_controller.go:85` | `configmaps` | `get;list;watch;create;update;patch;delete` | `get;create;update;patch;delete` |
| `physicalhost_controller.go:84` | `secrets` | `get;list;watch` | **unchanged** |

The PhysicalHost controller's Secret marker is **unchanged** because `SetupWithManager` registers a `.Watches(&corev1.Secret{}, ...)` informer for credential-rotation triggers; controller-runtime's cached client backs that with a cluster-wide `list+watch`. Stripping those verbs would crash the manager at startup. Each marker carries a new inline doc comment explaining the reasoning.

## Threat-model residual after PR-7

- **ConfigMaps**: cannot be enumerated cluster-wide; attacker must know the name (deterministic per host — `<host>-inspection-result` etc.).
- **Secrets**: still enumerable cluster-wide via `list`. Reduced `create`/`delete` attack surface is unchanged from before. Same residual as every CAPI provider.

## Test plan

- [x] `gofmt -s -d` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes (envtest)
- [x] `make manifests` regenerated `config/rbac/role.yaml`; chart RBAC mirrors
- [x] `helm template charts/beskar7` renders cleanly (11 resources)
- [ ] CI lint / unit / integration jobs pass

## Notes for follow-up

- **v0.5 SEC-2 finisher**: drop `secrets:list,watch` by replacing the PhysicalHost Secret informer with a label-selected partial cache (`cache.Options{ByObject: ...}`) so only Beskar7-owned Secrets are watched. Requires every consumed Secret to carry a known label — non-trivial coordination change with users; recommend a staff-architect design pass first.
- Pre-existing chart drift: `charts/beskar7/templates/rbac.yaml` lists `beskar7machinetemplates: get;list;watch` with no matching marker. Worth a follow-up to either add the marker or strip the chart rule.
- Pre-existing `cmd/manager/main.go` marker for `clusterroles`/`clusterrolebindings: get;list;watch` is suspicious for a controller that does not appear to read those resources. Possibly leftover from the deleted `internal/security/rbac_validator.go` consumer (PR-6.1). Worth tracing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)