### PR TITLE
PR-1.2: wire FailureReason on hardware-validation + inspection-timeout terminal failures

### DIFF
--- a/api/v1beta1/beskar7machine_types.go
+++ b/api/v1beta1/beskar7machine_types.go
@@ -44,6 +44,19 @@ const (
 	// BootstrapDataUnavailableReason (Severity=Error, terminal) indicates that the named
 	// bootstrap data Secret was not found in the Beskar7Machine's namespace.
 	BootstrapDataUnavailableReason string = "BootstrapDataUnavailable"
+	// HardwareRequirementsNotMetReason (Severity=Error, terminal) indicates that the
+	// inspection report shows the host does not meet the Beskar7Machine's
+	// HardwareRequirements (CPU/memory/disk). The BMC's hardware cannot change at
+	// runtime, so this is terminal — the operator must lower the requirements,
+	// allocate to a different host, or replace the hardware.
+	HardwareRequirementsNotMetReason string = "HardwareRequirementsNotMet"
+	// InspectionTimedOutReason (Severity=Error, terminal) indicates that the inspection
+	// image did not POST a report within DefaultInspectionTimeout. Likely causes:
+	// misconfigured iPXE, host couldn't reach the manager's callback endpoint, or an
+	// inspection image bug. Terminal because the controller has no way to recover
+	// automatically; the operator must investigate and either delete-and-recreate the
+	// Beskar7Machine or fix the iPXE setup.
+	InspectionTimedOutReason string = "InspectionTimedOut"
 )
 
 // Beskar7MachineSpec defines the desired state of Beskar7Machine.

--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -503,17 +503,23 @@ func (r *Beskar7MachineReconciler) setBootstrapTokenAnnotation(
 func (r *Beskar7MachineReconciler) handleInspectingHost(ctx context.Context, logger logr.Logger, b7machine *infrastructurev1beta1.Beskar7Machine, physicalHost *infrastructurev1beta1.PhysicalHost) (ctrl.Result, error) {
 	logger.Info("Monitoring inspection phase", "inspectionPhase", physicalHost.Status.InspectionPhase)
 
-	// Check for timeout
+	// Check for timeout. Inspection timeout is terminal: we cannot recover
+	// automatically — the operator must investigate (likely an iPXE
+	// misconfiguration or unreachable callback endpoint) and either
+	// delete-and-recreate the Beskar7Machine or fix the iPXE setup.
 	if physicalHost.Status.InspectionTimestamp != nil {
 		elapsed := time.Since(physicalHost.Status.InspectionTimestamp.Time)
 		if elapsed > DefaultInspectionTimeout {
-			logger.Error(nil, "Inspection timeout", "elapsed", elapsed)
-			// Signal the PhysicalHost controller to record the timeout in Status.
-			// We patch only spec/annotations here; the PhysicalHost controller owns status.
+			logger.Info("Inspection timed out (terminal)", "elapsed", elapsed, "timeout", DefaultInspectionTimeout)
+			// Best-effort signal to the PhysicalHost controller. Don't block the
+			// terminal marking on the annotation patch — the PhysicalHost catches
+			// up on its next reconcile regardless.
 			if err := r.setInspectionRequestAnnotation(ctx, logger, physicalHost, "timeout"); err != nil {
 				logger.Error(err, "Failed to set inspection timeout annotation")
 			}
-			return ctrl.Result{}, fmt.Errorf("inspection timeout")
+			msg := fmt.Sprintf("Inspection did not complete within %s", DefaultInspectionTimeout)
+			r.markTerminalFailure(b7machine, infrastructurev1beta1.InspectionTimedOutReason, msg)
+			return ctrl.Result{}, nil
 		}
 	}
 
@@ -548,10 +554,16 @@ func (r *Beskar7MachineReconciler) validateInspectionReport(ctx context.Context,
 			totalCores += cpu.Cores
 		}
 
+		// Hardware-validation failures are terminal. The BMC's hardware does not
+		// change at runtime; requeueing forever would just churn. Operator must
+		// lower the requirements, allocate to a different host, or replace the
+		// hardware. CAPI surfaces FailureReason/FailureMessage in
+		// `kubectl describe machine`.
 		if reqs.MinCPUCores > 0 && totalCores < reqs.MinCPUCores {
-			err := fmt.Errorf("insufficient CPU cores: found %d, required %d", totalCores, reqs.MinCPUCores)
-			logger.Error(err, "Hardware validation failed")
-			return ctrl.Result{}, err
+			msg := fmt.Sprintf("insufficient CPU cores: found %d, required %d", totalCores, reqs.MinCPUCores)
+			logger.Info("Hardware validation failed (terminal)", "check", "MinCPUCores", "found", totalCores, "required", reqs.MinCPUCores)
+			r.markTerminalFailure(b7machine, infrastructurev1beta1.HardwareRequirementsNotMetReason, msg)
+			return ctrl.Result{}, nil
 		}
 
 		// Calculate total memory from all DIMMs
@@ -566,9 +578,10 @@ func (r *Beskar7MachineReconciler) validateInspectionReport(ctx context.Context,
 		}
 
 		if reqs.MinMemoryGB > 0 && totalMemoryGB < reqs.MinMemoryGB {
-			err := fmt.Errorf("insufficient memory: found %d GB, required %d GB", totalMemoryGB, reqs.MinMemoryGB)
-			logger.Error(err, "Hardware validation failed")
-			return ctrl.Result{}, err
+			msg := fmt.Sprintf("insufficient memory: found %d GB, required %d GB", totalMemoryGB, reqs.MinMemoryGB)
+			logger.Info("Hardware validation failed (terminal)", "check", "MinMemoryGB", "found", totalMemoryGB, "required", reqs.MinMemoryGB)
+			r.markTerminalFailure(b7machine, infrastructurev1beta1.HardwareRequirementsNotMetReason, msg)
+			return ctrl.Result{}, nil
 		}
 
 		if reqs.MinDiskGB > 0 {
@@ -577,9 +590,10 @@ func (r *Beskar7MachineReconciler) validateInspectionReport(ctx context.Context,
 				totalDisk += disk.SizeGB
 			}
 			if totalDisk < reqs.MinDiskGB {
-				err := fmt.Errorf("insufficient disk space: found %d GB, required %d GB", totalDisk, reqs.MinDiskGB)
-				logger.Error(err, "Hardware validation failed")
-				return ctrl.Result{}, err
+				msg := fmt.Sprintf("insufficient disk space: found %d GB, required %d GB", totalDisk, reqs.MinDiskGB)
+				logger.Info("Hardware validation failed (terminal)", "check", "MinDiskGB", "found", totalDisk, "required", reqs.MinDiskGB)
+				r.markTerminalFailure(b7machine, infrastructurev1beta1.HardwareRequirementsNotMetReason, msg)
+				return ctrl.Result{}, nil
 			}
 		}
 	}
@@ -758,6 +772,26 @@ func (r *Beskar7MachineReconciler) bestEffortReleaseRedfish(ctx context.Context,
 	if err := rfClient.SetPowerState(ctx, redfish.OffPowerState); err != nil {
 		logger.Info("Failed to graceful power-off during release; continuing", "err", err)
 	}
+}
+
+// markTerminalFailure sets FailureReason/FailureMessage on the Beskar7Machine,
+// flips Status.Ready to false and Phase to "Failed", and marks
+// InfrastructureReadyCondition=False with the same reason at Severity=Error.
+// CAPI surfaces FailureReason/FailureMessage in `kubectl describe machine`.
+//
+// Once set, FailureReason indicates the resource needs operator intervention.
+// Subsequent reconciles must NOT clear it — clearing on success would mask
+// history and the operator wouldn't know the resource ever failed. Callers
+// should return ctrl.Result{}, nil after invoking this helper to stop the
+// requeue cycle (CAPI does not auto-recover from FailureReason).
+func (r *Beskar7MachineReconciler) markTerminalFailure(b7machine *infrastructurev1beta1.Beskar7Machine, reason, message string) {
+	b7machine.Status.FailureReason = &reason
+	b7machine.Status.FailureMessage = &message
+	b7machine.Status.Ready = false
+	phase := "Failed"
+	b7machine.Status.Phase = &phase
+	conditions.MarkFalse(b7machine, infrastructurev1beta1.InfrastructureReadyCondition,
+		reason, clusterv1.ConditionSeverityError, "%s", message)
 }
 
 // setInspectionRequestAnnotation patches only the annotations of a PhysicalHost to request

--- a/controllers/beskar7machine_controller_test.go
+++ b/controllers/beskar7machine_controller_test.go
@@ -572,62 +572,171 @@ var _ = Describe("Beskar7Machine Controller", func() {
 			Expect(unchangedHost.Status.State).To(Equal(infrastructurev1beta1.StateAvailable))
 		})
 
-		PIt("[SKIP - Hardware Testing] Should validate hardware requirements", func() {
-			By("Creating machine with hardware requirements")
-			beskar7Machine.Spec.HardwareRequirements = &infrastructurev1beta1.HardwareRequirements{
-				MinCPUCores: 32,
-				MinMemoryGB: 64,
-				MinDiskGB:   1000,
-			}
-			Expect(k8sClient.Create(ctx, beskar7Machine)).To(Succeed())
-
-			machineLookupKey := types.NamespacedName{Name: beskar7Machine.Name, Namespace: beskar7Machine.Namespace}
-
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Simulating inspection with insufficient hardware")
-			inspectedHost := &infrastructurev1beta1.PhysicalHost{}
-			hostKey := types.NamespacedName{Name: physicalHost.Name, Namespace: physicalHost.Namespace}
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, hostKey, inspectedHost)).To(Succeed())
-				g.Expect(inspectedHost.Spec.ConsumerRef).NotTo(BeNil())
-			}, Timeout, Interval).Should(Succeed())
-
-			inspectedHost.Status.InspectionPhase = infrastructurev1beta1.InspectionComplete
-			inspectedHost.Status.InspectionReport = &infrastructurev1beta1.InspectionReport{
-				Timestamp:    metav1.Now(),
-				Manufacturer: "Dell Inc.",
-				Model:        "PowerEdge R650",
-				SerialNumber: "XYZ789",
-				CPUs: []infrastructurev1beta1.CPUInfo{
-					{
-						ID:    "0",
-						Cores: 16, // Less than required 32
+		// Converted from "[SKIP - Hardware Testing] Should validate hardware requirements".
+		// validateInspectionReport is exercised directly because the full Reconcile path
+		// requires a CAPI Machine owner chain that this test doesn't set up. The helper
+		// is the unit under test for BUG-8 (terminal-failure wiring).
+		Context("hardware-validation terminal failures (BUG-8)", func() {
+			buildMachine := func(reqs *infrastructurev1beta1.HardwareRequirements) *infrastructurev1beta1.Beskar7Machine {
+				return &infrastructurev1beta1.Beskar7Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "validate-target",
+						Namespace: testNs.Name,
 					},
-				},
-				Memory: []infrastructurev1beta1.MemoryInfo{
-					{
-						ID:       "DIMM0",
-						Capacity: "32GB", // Less than required 64GB
+					Spec: infrastructurev1beta1.Beskar7MachineSpec{
+						InspectionImageURL:   "http://boot-server/ipxe/inspect.ipxe",
+						TargetImageURL:       "http://boot-server/images/kairos.tar.gz",
+						HardwareRequirements: reqs,
 					},
-				},
+				}
 			}
-			Expect(k8sClient.Status().Update(ctx, inspectedHost)).To(Succeed())
 
-			By("Reconciling after inspection")
-			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
-			Expect(err).NotTo(HaveOccurred())
+			buildHostWithReport := func(report *infrastructurev1beta1.InspectionReport) *infrastructurev1beta1.PhysicalHost {
+				return &infrastructurev1beta1.PhysicalHost{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "validate-host",
+						Namespace: testNs.Name,
+					},
+					Status: infrastructurev1beta1.PhysicalHostStatus{
+						InspectionReport: report,
+					},
+				}
+			}
 
-			By("Verifying validation failure condition")
-			Eventually(func(g Gomega) {
-				failedMachine := &infrastructurev1beta1.Beskar7Machine{}
-				g.Expect(k8sClient.Get(ctx, machineLookupKey, failedMachine)).To(Succeed())
-				cond := conditions.Get(failedMachine, infrastructurev1beta1.MachineProvisionedCondition)
-				g.Expect(cond).NotTo(BeNil())
-				g.Expect(cond.Status).To(Equal(corev1.ConditionFalse))
-				g.Expect(cond.Reason).To(ContainSubstring("Validation"))
-			}, Timeout, Interval).Should(Succeed())
+			expectTerminalFailure := func(b *infrastructurev1beta1.Beskar7Machine, expectedReason string) {
+				Expect(b.Status.FailureReason).NotTo(BeNil(), "FailureReason must be set on terminal failure")
+				Expect(*b.Status.FailureReason).To(Equal(expectedReason))
+				Expect(b.Status.FailureMessage).NotTo(BeNil(), "FailureMessage must be set")
+				Expect(*b.Status.FailureMessage).NotTo(BeEmpty())
+				Expect(b.Status.Ready).To(BeFalse())
+				Expect(b.Status.Phase).NotTo(BeNil())
+				Expect(*b.Status.Phase).To(Equal("Failed"))
+				cond := conditions.Get(b, infrastructurev1beta1.InfrastructureReadyCondition)
+				Expect(cond).NotTo(BeNil(), "InfrastructureReady condition must be set")
+				Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+				Expect(cond.Reason).To(Equal(expectedReason))
+				Expect(cond.Severity).To(Equal(clusterv1.ConditionSeverityError))
+			}
+
+			It("Should mark Beskar7Machine terminally Failed when CPU cores are insufficient", func() {
+				machine := buildMachine(&infrastructurev1beta1.HardwareRequirements{MinCPUCores: 16})
+				host := buildHostWithReport(&infrastructurev1beta1.InspectionReport{
+					CPUs: []infrastructurev1beta1.CPUInfo{{ID: "0", Cores: 4}},
+				})
+
+				result, err := reconciler.validateInspectionReport(ctx, reconciler.Log, machine, host)
+				Expect(err).NotTo(HaveOccurred(), "terminal failures must NOT return an error (would requeue forever)")
+				Expect(result).To(Equal(ctrl.Result{}), "terminal failures must NOT requeue")
+				expectTerminalFailure(machine, infrastructurev1beta1.HardwareRequirementsNotMetReason)
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("CPU cores"))
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("4"))
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("16"))
+			})
+
+			It("Should mark Beskar7Machine terminally Failed when memory is insufficient", func() {
+				machine := buildMachine(&infrastructurev1beta1.HardwareRequirements{MinMemoryGB: 64})
+				host := buildHostWithReport(&infrastructurev1beta1.InspectionReport{
+					CPUs:   []infrastructurev1beta1.CPUInfo{{ID: "0", Cores: 32}},
+					Memory: []infrastructurev1beta1.MemoryInfo{{ID: "DIMM0", Capacity: "16GB"}},
+				})
+
+				result, err := reconciler.validateInspectionReport(ctx, reconciler.Log, machine, host)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+				expectTerminalFailure(machine, infrastructurev1beta1.HardwareRequirementsNotMetReason)
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("memory"))
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("16"))
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("64"))
+			})
+
+			It("Should mark Beskar7Machine terminally Failed when disk space is insufficient", func() {
+				machine := buildMachine(&infrastructurev1beta1.HardwareRequirements{MinDiskGB: 1000})
+				host := buildHostWithReport(&infrastructurev1beta1.InspectionReport{
+					CPUs:   []infrastructurev1beta1.CPUInfo{{ID: "0", Cores: 32}},
+					Memory: []infrastructurev1beta1.MemoryInfo{{ID: "DIMM0", Capacity: "128GB"}},
+					Disks:  []infrastructurev1beta1.DiskInfo{{Name: "sda", SizeGB: 250}},
+				})
+
+				result, err := reconciler.validateInspectionReport(ctx, reconciler.Log, machine, host)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(ctrl.Result{}))
+				expectTerminalFailure(machine, infrastructurev1beta1.HardwareRequirementsNotMetReason)
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("disk"))
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("250"))
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("1000"))
+			})
+
+			It("Should NOT clear FailureReason on a subsequent reconcile (idempotent terminality)", func() {
+				machine := buildMachine(&infrastructurev1beta1.HardwareRequirements{MinCPUCores: 16})
+				host := buildHostWithReport(&infrastructurev1beta1.InspectionReport{
+					CPUs: []infrastructurev1beta1.CPUInfo{{ID: "0", Cores: 4}},
+				})
+
+				_, err := reconciler.validateInspectionReport(ctx, reconciler.Log, machine, host)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(machine.Status.FailureReason).NotTo(BeNil())
+				originalReason := *machine.Status.FailureReason
+
+				// Re-run validation (simulating a subsequent reconcile). The helper
+				// must overwrite-but-not-clear: same reason, no transition to nil.
+				_, err = reconciler.validateInspectionReport(ctx, reconciler.Log, machine, host)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(machine.Status.FailureReason).NotTo(BeNil(), "FailureReason must persist across reconciles")
+				Expect(*machine.Status.FailureReason).To(Equal(originalReason))
+			})
+		})
+
+		Context("inspection timeout terminal failure (BUG-8)", func() {
+			It("Should mark Beskar7Machine terminally Failed when inspection times out", func() {
+				machine := &infrastructurev1beta1.Beskar7Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "timeout-target",
+						Namespace: testNs.Name,
+					},
+					Spec: infrastructurev1beta1.Beskar7MachineSpec{
+						InspectionImageURL: "http://boot-server/ipxe/inspect.ipxe",
+						TargetImageURL:     "http://boot-server/images/kairos.tar.gz",
+					},
+				}
+				// Build a host with an InspectionTimestamp older than DefaultInspectionTimeout.
+				host := &infrastructurev1beta1.PhysicalHost{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "timeout-host",
+						Namespace: testNs.Name,
+					},
+					Spec: infrastructurev1beta1.PhysicalHostSpec{
+						RedfishConnection: infrastructurev1beta1.RedfishConnection{
+							Address:              "https://192.168.1.100",
+							CredentialsSecretRef: credentialSecret.Name,
+						},
+					},
+				}
+				// Persist the host so setInspectionRequestAnnotation can patch it.
+				// Status is a subresource — set it AFTER Create or it's dropped.
+				Expect(k8sClient.Create(ctx, host)).To(Succeed())
+				old := metav1.NewTime(time.Now().Add(-2 * DefaultInspectionTimeout))
+				host.Status.State = infrastructurev1beta1.StateInspecting
+				host.Status.InspectionTimestamp = &old
+				Expect(k8sClient.Status().Update(ctx, host)).To(Succeed())
+
+				result, err := reconciler.handleInspectingHost(ctx, reconciler.Log, machine, host)
+				Expect(err).NotTo(HaveOccurred(), "terminal failures must NOT return an error")
+				Expect(result).To(Equal(ctrl.Result{}), "terminal failures must NOT requeue")
+
+				// Beskar7Machine in-memory state assertions.
+				Expect(machine.Status.FailureReason).NotTo(BeNil())
+				Expect(*machine.Status.FailureReason).To(Equal(infrastructurev1beta1.InspectionTimedOutReason))
+				Expect(machine.Status.FailureMessage).NotTo(BeNil())
+				Expect(*machine.Status.FailureMessage).To(ContainSubstring("Inspection did not complete"))
+				Expect(machine.Status.Ready).To(BeFalse())
+				Expect(machine.Status.Phase).NotTo(BeNil())
+				Expect(*machine.Status.Phase).To(Equal("Failed"))
+
+				// PhysicalHost should have received the timeout annotation.
+				patchedHost := &infrastructurev1beta1.PhysicalHost{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: host.Namespace}, patchedHost)).To(Succeed())
+				Expect(patchedHost.Annotations[InspectionRequestAnnotation]).To(Equal("timeout"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Closes **BUG-8**. After this lands, the **correctness punch list is empty** and **Phase 1 is fully closed**.

Generalises the `FailureReason`/`FailureMessage` pattern that PR-1.1 introduced for `BootstrapDataUnavailable` to four other terminal paths that previously returned an error and requeued forever:

- `validateInspectionReport` — `MinCPUCores`: insufficient cores
- `validateInspectionReport` — `MinMemoryGB`: insufficient memory
- `validateInspectionReport` — `MinDiskGB`: insufficient disk
- `handleInspectingHost` — inspection timeout

All four are terminal: the BMC's hardware doesn't change at runtime, and an inspection that didn't complete within `DefaultInspectionTimeout` indicates a misconfiguration the controller cannot recover from. Requeueing forever just churned the controller; CAPI expects `FailureReason` / `FailureMessage` so the failure surfaces in `kubectl describe machine` and the operator can intervene.

## Code changes

- **`api/v1beta1/beskar7machine_types.go`**: new `HardwareRequirementsNotMetReason` and `InspectionTimedOutReason` (Severity=Error, terminal).
- **`controllers/beskar7machine_controller.go`**:
  - New `markTerminalFailure(b7machine, reason, message)` helper — single source of truth. Sets `FailureReason` + `FailureMessage`, flips `Status.Ready=false` and `Status.Phase="Failed"`, marks `InfrastructureReadyCondition=False` with the reason at `Severity=Error`.
  - Four call sites converted from `return ctrl.Result{}, err` → `markTerminalFailure(...)` + `return ctrl.Result{}, nil`. Logger downgraded from `Error` to `Info` because terminal-by-design failures are not controller-side errors — they are operator-actionable states.
  - Inspection-timeout signal to the PhysicalHost stays best-effort: the `setInspectionRequestAnnotation` patch may fail transiently, but the Beskar7Machine is still marked terminal regardless. PhysicalHost catches up on its next reconcile.

## Tests

Replaced the long-pending `PIt "[SKIP - Hardware Testing] Should validate hardware requirements"` with two new Contexts containing 5 real `It` specs:

- "hardware-validation terminal failures (BUG-8)" — 4 specs covering CPU, memory, disk, plus an idempotency spec proving subsequent reconciles do NOT clear `FailureReason` (CAPI surfaces it; clearing would mask history).
- "inspection timeout terminal failure (BUG-8)" — 1 envtest-backed spec proving the timeout path marks terminal AND patches the timeout annotation onto the host.

All specs exercise the helpers directly (`validateInspectionReport` and `handleInspectingHost`) since the full `Reconcile` path requires a CAPI Machine owner chain that this test suite doesn't set up — the helpers are the unit under test for BUG-8.

## Test plan

- [x] `gofmt -s -d` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes (84 of 92 specs, 0 failures, 7 pre-existing PIt; the BUG-8 PIt this PR removed was 1 of those)
- [x] **Old pattern grep**: `grep -nE 'ctrl.Result\{\}, fmt.Errorf\("insufficient\|inspection timeout"\)'` returns empty
- [x] `make manifests` no-op (only string constants added)
- [ ] CI lint / unit / integration jobs pass

## Plan progress after this merges

| Phase | Status |
|---|---|
| **0, 1, 2, 3, 4, 5, 6** | **all done** |
| 7 | partial closure (D-007); v0.5 finisher tracked |
| 8 | not started — BUG-9 (`findControlPlaneEndpoint`) |
| 9 | not started — docs sweep |
| 10 | not started — test backfill |
| 11 | partial — kube-rbac-proxy done; digest pin, zap flag, RecordPowerOperation pending |

**No critical-security items remaining. No release-blockers. No correctness BUG- items remaining.** What's left is operator UX (PR-8.1), docs, tests, and Phase 11 housekeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)