### PR TITLE
PR-8.1: honor user-set ControlPlaneEndpoint + readable hostname validator + Beskar7MachineTemplate clusterctl-move markers

### DIFF
--- a/api/v1beta1/beskar7machinetemplate_types.go
+++ b/api/v1beta1/beskar7machinetemplate_types.go
@@ -33,9 +33,16 @@ type Beskar7MachineTemplateResource struct {
 	Spec Beskar7MachineSpec `json:"spec"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=beskar7machinetemplates,scope=Namespaced,categories=cluster-api,shortName=b7mt
+// +kubebuilder:storageversion
 
-// Beskar7MachineTemplate is the Schema for the beskar7machinetemplates API
+// Beskar7MachineTemplate is the Schema for the beskar7machinetemplates API.
+//
+// The `cluster-api` category is required for `clusterctl move`: CAPI walks
+// resources in the `cluster-api` category when migrating a workload cluster
+// between management clusters. Without it, Beskar7MachineTemplate objects
+// would be left behind during a move (BUG-9 / Phase 8).
 type Beskar7MachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/webhooks/beskar7cluster_webhook.go
+++ b/api/v1beta1/webhooks/beskar7cluster_webhook.go
@@ -3,10 +3,10 @@ package webhooks
 import (
 	"context"
 	"net"
-	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -125,19 +125,21 @@ func (webhook *Beskar7ClusterWebhook) validateControlPlaneEndpoint(endpoint clus
 func (webhook *Beskar7ClusterWebhook) validateHost(host string, fieldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	// Check if it's a valid IP address
+	// IPv4 / IPv6 literal — net.ParseIP handles both. Brackets-around-IPv6
+	// (e.g. "[::1]") aren't accepted here because clusterv1.APIEndpoint.Host
+	// is the host portion only; brackets are an authority-component construct.
 	if ip := net.ParseIP(host); ip != nil {
-		// Valid IP address
 		return allErrs
 	}
 
-	// Check if it's a valid hostname/FQDN
-	if !webhook.isValidHostname(host) {
-		allErrs = append(allErrs, field.Invalid(
-			fieldPath,
-			host,
-			"must be a valid IP address or hostname",
-		))
+	// Otherwise it must be a DNS-1123 subdomain (RFC 1123 with the
+	// underscore-rejection clarification). validation.IsDNS1123Subdomain
+	// returns a list of human-readable problems; concatenate them into a
+	// single field.Error detail so the operator sees the actual reason
+	// rather than a generic "must be a valid hostname".
+	if errs := validation.IsDNS1123Subdomain(host); len(errs) > 0 {
+		detail := "must be a valid IP address or DNS subdomain (RFC 1123): " + errs[0]
+		allErrs = append(allErrs, field.Invalid(fieldPath, host, detail))
 	}
 
 	return allErrs
@@ -159,42 +161,6 @@ func (webhook *Beskar7ClusterWebhook) validatePort(port int32, fieldPath *field.
 	// but are not considered validation errors
 
 	return allErrs
-}
-
-func (webhook *Beskar7ClusterWebhook) isValidHostname(hostname string) bool {
-	// Basic hostname validation
-	if hostname == "" || len(hostname) > 253 {
-		return false
-	}
-
-	// Check for invalid characters like consecutive dots
-	if strings.Contains(hostname, "..") {
-		return false
-	}
-
-	// Check each label in the hostname
-	labels := strings.Split(hostname, ".")
-	for _, label := range labels {
-		if !webhook.isValidHostnameLabel(label) {
-			return false
-		}
-	}
-
-	return true
-}
-
-// isValidHostnameLabel validates a single hostname label
-func (webhook *Beskar7ClusterWebhook) isValidHostnameLabel(label string) bool {
-	if label == "" || len(label) > 63 {
-		return false
-	}
-	// Check for valid characters (alphanumeric and hyphens, but not starting/ending with hyphen)
-	for i, r := range label {
-		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && (r != '-' || i == 0 || i == len(label)-1) {
-			return false
-		}
-	}
-	return true
 }
 
 func (webhook *Beskar7ClusterWebhook) defaultBeskar7Cluster(cluster *infrav1beta1.Beskar7Cluster) error {

--- a/api/v1beta1/webhooks/beskar7cluster_webhook_test.go
+++ b/api/v1beta1/webhooks/beskar7cluster_webhook_test.go
@@ -135,7 +135,8 @@ var _ = Describe("Beskar7Cluster Webhook", func() {
 
 			_, err := webhook.ValidateCreate(ctx, cluster)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("must be a valid IP address or hostname"))
+			// PR-8.1 reworded: "must be a valid IP address or DNS subdomain (RFC 1123): <reason>".
+			Expect(err.Error()).To(ContainSubstring("must be a valid IP address or DNS subdomain"))
 		})
 
 		It("should reject invalid port (too low)", func() {

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -8,9 +8,13 @@ metadata:
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
     kind: Beskar7MachineTemplate
     listKind: Beskar7MachineTemplateList
     plural: beskar7machinetemplates
+    shortNames:
+    - b7mt
     singular: beskar7machinetemplate
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -8,9 +8,13 @@ metadata:
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
     kind: Beskar7MachineTemplate
     listKind: Beskar7MachineTemplateList
     plural: beskar7machinetemplates
+    shortNames:
+    - b7mt
     singular: beskar7machinetemplate
   scope: Namespaced
   versions:

--- a/controllers/beskar7cluster_controller.go
+++ b/controllers/beskar7cluster_controller.go
@@ -277,9 +277,37 @@ func failureDomainsEqual(a, b clusterv1.FailureDomains) bool {
 	return reflect.DeepEqual(a, b)
 }
 
+// defaultAPIServerPort is the canonical Kubernetes API server port. Used as
+// the fallback when neither the user nor a discovery path provides one.
+const defaultAPIServerPort = 6443
+
 func (r *Beskar7ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Context, logger logr.Logger, cluster *clusterv1.Cluster, b7cluster *infrastructurev1beta1.Beskar7Cluster) error {
 	logger.Info("Reconciling control plane endpoint")
 
+	// If the operator pre-set a ControlPlaneEndpoint on the Beskar7Cluster spec
+	// (typical for VIP / load-balancer / external-DNS setups), use it
+	// authoritatively. We do not run discovery in this case — the operator
+	// already knows where the API server lives, and discovery would race with
+	// their explicit choice.
+	if specEndpoint := b7cluster.Spec.ControlPlaneEndpoint; specEndpoint.Host != "" {
+		port := specEndpoint.Port
+		if port == 0 {
+			port = defaultAPIServerPort
+		}
+		logger.Info("Using user-supplied control plane endpoint", "host", specEndpoint.Host, "port", port)
+		b7cluster.Status.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+			Host: specEndpoint.Host,
+			Port: port,
+		}
+		conditions.MarkTrue(b7cluster, infrastructurev1beta1.ControlPlaneEndpointReady)
+		b7cluster.Status.Ready = true
+		return nil
+	}
+
+	// No user-supplied endpoint — discover from a ready control-plane Machine.
+	// The discovered host gets paired with Spec.ControlPlaneEndpoint.Port if
+	// set (operator wants a non-default port over the discovered IP), otherwise
+	// the canonical 6443.
 	cpEndpoint, err := r.findControlPlaneEndpoint(ctx, logger, cluster)
 	if err != nil {
 		return errors.Wrapf(err, "failed to find control plane endpoint for cluster %s/%s", cluster.Namespace, cluster.Name)
@@ -291,7 +319,11 @@ func (r *Beskar7ClusterReconciler) reconcileControlPlaneEndpoint(ctx context.Con
 		return nil
 	}
 
-	logger.Info("Control plane endpoint found", "host", cpEndpoint.Host, "port", cpEndpoint.Port)
+	if specPort := b7cluster.Spec.ControlPlaneEndpoint.Port; specPort != 0 {
+		cpEndpoint.Port = specPort
+	}
+
+	logger.Info("Control plane endpoint discovered", "host", cpEndpoint.Host, "port", cpEndpoint.Port)
 	b7cluster.Status.ControlPlaneEndpoint = *cpEndpoint
 	conditions.MarkTrue(b7cluster, infrastructurev1beta1.ControlPlaneEndpointReady)
 	b7cluster.Status.Ready = true
@@ -349,9 +381,12 @@ func (r *Beskar7ClusterReconciler) findControlPlaneEndpoint(ctx context.Context,
 		}
 
 		logger.Info("Found suitable control plane machine endpoint", "machine", machine.Name, "address", selectedAddress)
+		// Port is the canonical 6443 by default; the caller
+		// (reconcileControlPlaneEndpoint) overrides with Spec.ControlPlaneEndpoint.Port
+		// when the operator has set one.
 		return &clusterv1.APIEndpoint{
 			Host: selectedAddress,
-			Port: 6443, // Default Kubernetes API server port
+			Port: defaultAPIServerPort,
 		}, nil
 	}
 

--- a/controllers/beskar7cluster_controller_test.go
+++ b/controllers/beskar7cluster_controller_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -129,6 +130,85 @@ var _ = Describe("Beskar7Cluster Reconciler", func() {
 				g.Expect(b7cluster.Status.Ready).To(BeFalse())
 				g.Expect(b7cluster.Status.ControlPlaneEndpoint.IsZero()).To(BeTrue())
 			}, "5s", "100ms").Should(Succeed(), "ControlPlaneEndpointReady should be False")
+		})
+
+		// BUG-9: when the operator pre-sets Spec.ControlPlaneEndpoint (typical
+		// for VIP / load-balancer / external-DNS setups), the controller must
+		// honor it authoritatively instead of running discovery and overriding.
+		It("should honor user-set Spec.ControlPlaneEndpoint authoritatively (BUG-9)", func() {
+			b7cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+				Host: "api.example.com",
+				Port: 8443,
+			}
+			Expect(k8sClient.Create(ctx, b7cluster)).To(Succeed())
+
+			reconciler := &Beskar7ClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+
+			// First reconcile adds finalizer.
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second reconcile should observe the user-supplied endpoint, mark
+			// Ready=true, and NOT requeue waiting for control-plane machines.
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero(), "user-supplied endpoint must not trigger discovery requeue")
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, key, b7cluster)).To(Succeed())
+				g.Expect(b7cluster.Status.ControlPlaneEndpoint.Host).To(Equal("api.example.com"))
+				g.Expect(b7cluster.Status.ControlPlaneEndpoint.Port).To(Equal(int32(8443)))
+				g.Expect(b7cluster.Status.Ready).To(BeTrue())
+				cond := conditions.Get(b7cluster, infrastructurev1beta1.ControlPlaneEndpointReady)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+			}, "5s", "100ms").Should(Succeed())
+		})
+
+		// BUG-9: when only the port is user-supplied, discovery should still find
+		// the host but the user's port wins.
+		It("should override default port 6443 with Spec.ControlPlaneEndpoint.Port when discovering host (BUG-9)", func() {
+			b7cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+				// Host empty → discovery runs.
+				Port: 7443,
+			}
+			Expect(k8sClient.Create(ctx, b7cluster)).To(Succeed())
+
+			// Stand up a ready control-plane machine with an internal IP.
+			cpMachine := &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cp-bug9",
+					Namespace: testNs.Name,
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel:       capiCluster.Name,
+						"cluster.x-k8s.io/control-plane": "",
+					},
+				},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: capiCluster.Name,
+					Bootstrap:   clusterv1.Bootstrap{DataSecretName: ptr.To("ignored")},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cpMachine)).To(Succeed())
+			cpMachine.Status.Addresses = []clusterv1.MachineAddress{
+				{Type: clusterv1.MachineInternalIP, Address: "10.0.0.42"},
+			}
+			conditions.MarkTrue(cpMachine, clusterv1.InfrastructureReadyCondition)
+			Expect(k8sClient.Status().Update(ctx, cpMachine)).To(Succeed())
+
+			reconciler := &Beskar7ClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, key, b7cluster)).To(Succeed())
+				g.Expect(b7cluster.Status.ControlPlaneEndpoint.Host).To(Equal("10.0.0.42"))
+				g.Expect(b7cluster.Status.ControlPlaneEndpoint.Port).To(Equal(int32(7443)),
+					"user-supplied Spec.ControlPlaneEndpoint.Port must override default 6443")
+			}, "5s", "100ms").Should(Succeed())
 		})
 
 		It("should derive endpoint when a ready control plane machine has an IP", func() {

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979 // indirect
+	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect


### PR DESCRIPTION
## Summary

Closes **BUG-9** and the matching medium hardening items. Closes **Phase 8**. After this lands, the only remaining v0.4 work is **Phase 9 (docs sweep)** and **Phase 10 (test backfill)** — all code is done.

## What changed

### 1. BUG-9 — `reconcileControlPlaneEndpoint` honors `Spec.ControlPlaneEndpoint` authoritatively

When the operator pre-sets `Beskar7Cluster.Spec.ControlPlaneEndpoint` (typical for VIP / load-balancer / external-DNS setups), the controller now uses it directly and **skips discovery entirely** — the operator already knows where the API server lives, and discovery would race with their explicit choice.

- Port defaults to `6443` only when neither the user nor discovery provides one. New `defaultAPIServerPort` constant centralises the magic number.
- If the user sets `Spec.ControlPlaneEndpoint.Port` without `Host`, discovery still finds the host but the user's port wins.

### 2. Webhook hostname validator → `validation.IsDNS1123Subdomain`

The previous hand-rolled rune-by-rune validator worked but was hard to read and was a home-grown approximation of the DNS subdomain rules. Replaced with `k8s.io/apimachinery/pkg/util/validation.IsDNS1123Subdomain` — canonical, descriptive errors, one line. Removed `isValidHostname` and `isValidHostnameLabel` helpers. Error message reworded from `"must be a valid IP address or hostname"` to `"must be a valid IP address or DNS subdomain (RFC 1123): <specific reason>"`.

### 3. `Beskar7MachineTemplate` `clusterctl move` markers

Added `+kubebuilder:resource:path=beskar7machinetemplates,scope=Namespaced,categories=cluster-api,shortName=b7mt` and `+kubebuilder:storageversion`. The `cluster-api` category is the discriminator `clusterctl move` uses to know which resources to migrate during a workload-cluster move. Without it, `Beskar7MachineTemplate` objects would be left behind. The other three CRDs already had it; this was the outlier. `make manifests` + `make sync-chart-crds` regenerated and synced.

## Tests

- **`controllers/beskar7cluster_controller_test.go`**: 2 new envtest specs for BUG-9 — "should honor user-set `Spec.ControlPlaneEndpoint` authoritatively" (also proves discovery is short-circuited via `RequeueAfter == 0`) and "should override default port 6443 with `Spec.ControlPlaneEndpoint.Port` when discovering host".
- **`api/v1beta1/webhooks/beskar7cluster_webhook_test.go`**: existing "should reject invalid hostname" assertion updated to match the new wording.

## Test plan

- [x] `gofmt -s -d` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes (envtest)
- [x] `make manifests` + `make sync-chart-crds` regenerated; chart CRD byte-identical to `config/crd/bases/`
- [ ] CI lint / unit / integration jobs pass

## Plan progress after this merges

| Phase | Status |
|---|---|
| 0, 1, 2, 3, 4, 5, 6, **8**, 11 | **all done** |
| 7 | partial (D-007 closed; v0.5 finisher tracked) |
| 9 | open — **docs sweep (large, tech-writer)** |
| 10 | open — **test backfill (M–L, qa-engineer)** |

**No code BUG- items remain.** No critical-security items. No release-blockers. The v0.4 controller is functionally and structurally complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)