### PR TITLE
PR-9: docs sweep — bring docs/ + examples/ + README/CHANGELOG in line with v0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
-- Future enhancements and planned features
+
+Work landed since the v0.4.0-alpha entry below. See `.claude/context/PROJECT_CONTEXT.md` for the full punch-list and PR history.
+
+### Added
+- TLS CA bundle support on `RedfishConnection` via `caBundleSecretRef` (PR-3.2 / SEC-5). Mutually exclusive with `insecureSkipVerify=true`; conflict reported as `RedfishConnectionReady=False (InsecureCABundleConflict)`.
+- Per-host bearer-token authentication on the host callback endpoint `:8082` (PR-5.1, PR-5.2 / D-004). 32-byte random token, SHA-256 hash on `PhysicalHost.Status.Bootstrap.TokenHash`, plaintext in a per-host Secret named `<host>-bootstrap-token` (PR-5.2 / D-006).
+- Bootstrap GET endpoint `GET /api/v1/bootstrap/{ns}/{name}` on `:8082`, gated by the same bearer-token middleware as the inspection POST (PR-5.3 / D-003). The reconciler reads `Machine.Spec.Bootstrap.DataSecretName` and signals the per-host URL to the host via the `infrastructure.cluster.x-k8s.io/bootstrap-url` annotation (PR-1.1).
+- `BootstrapStatus` sub-object on `PhysicalHostStatus` with `URL`, `TokenHash`, `IssuedAt`, `ExpiresAt` (PR-5.1).
+- `--bootstrap-url-base`, `--inspection-port`, `--inspection-cert-dir`, `--secure-metrics` manager flags (PR-5.x, PR-11.1).
+- `ForceReleaseAnnotation` (`infrastructure.cluster.x-k8s.io/force-release=true`) on Beskar7Machine to skip Redfish power-off / boot-clear during deletion (PR-2.3 / BUG-4).
+- Watch on `PhysicalHost` from the `Beskar7Machine` reconciler so host state changes trigger immediate machine reconciles (PR-2.3 / BUG-7).
+- Cache field index on `PhysicalHost.Status.State` so the `Beskar7Machine` reconciler filters `Available` hosts server-side (PR-2.2 / BUG-2).
+- Helm chart parity: `--enable-webhook` wired in Deployment args; webhook configuration template ships MWC + VWC for Beskar7Cluster only; always-on `<release>-controller-manager` Service on port 8082; NetworkPolicy ingress for 8082; CRDs synced from `config/crd/bases/`; `sync-chart-crds` and `manifests-and-sync` Makefile targets (PR-4 / BLOCK-3,4,5).
+
+### Changed
+- Metrics now served directly on `:8443` (HTTPS) with TokenReview/SubjectAccessReview authentication via controller-runtime's `WithAuthenticationAndAuthorization` (PR-11.1). The `kube-rbac-proxy` sidecar has been removed; metrics auth runs in-process. Scrapers need the `metrics-reader` ClusterRole.
+- `PhysicalHost` state machine simplified to `Available` / `InUse` / `Inspecting` / `Ready` / `Error` (the v0.3 `Claimed`/`Provisioning`/`Provisioned`/`Deprovisioning` strings are gone; deprecated Go aliases map them all to the new strings).
+- `PhysicalHost.Status.InspectionReport` is now an array-of-structs shape: `cpus []CPUInfo`, `memory []MemoryInfo`, `disks []DiskInfo`, `nics []NICInfo`. The flat-object shape from earlier drafts is gone.
+- `Beskar7MachineSpec` simplified to `inspectionImageURL`, `targetImageURL`, `configurationURL`, `hardwareRequirements`. The v0.3 fields (`imageURL`, `osFamily`, `provisioningMode`, `bootMode`, `configURL`) are removed.
+- Controllers use `patch.NewHelper` deferred at the top of `Reconcile`; no `r.Update`/`r.Status().Update` in the same reconcile cycle (PR-2.1 / BUG-5).
+- The inspection HTTP handler no longer writes to `PhysicalHost.Status` directly. It writes the validated `InspectionReport` to a ConfigMap and patches an annotation; the `PhysicalHost` reconciler is the sole writer of `Status.InspectionReport`/`Status.InspectionPhase` (PR-5.2 / D-005).
+- `SetPowerState(OffPowerState)` issues `GracefulShutdown` (was `ForceOff`); a separate `ForcePowerOff` method is available for callers that need an immediate cut (PR-3.1 / BUG-6).
+- All gofish I/O calls now race against `ctx` cancellation with a 30-second per-call HTTP timeout (PR-3.1 / BUG-10).
+- Memory-capacity parser accepts `GB`/`GiB`/`MB`/`MiB`/`TB`/`TiB` and rejects bare integers and exotic SI prefixes (PR-3.3 / BUG-11).
+- BMC username and password no longer logged at any verbosity (PR-3.3 / SEC-4). At V(1), the structured logger emits `passwordProvided` (boolean) only.
+- RBAC: cluster-wide ClusterRole, but Secret reads in the controllers are by name only. Cluster-wide `secrets: list,watch` retained for the credentials-rotation informer (residual scope tracked as SEC-2 / D-007).
+
+### Removed
+- Dead-code packages `internal/coordination/` and `internal/security/{monitor,rbac_validator,tls_validator}.go` (PR-6.1 / D-001). Companion cleanup removed unused metric definitions, the `config/security/security-policy.yaml` ConfigMap, and references in `config/security/kustomization.yaml`.
+- `kube-rbac-proxy` sidecar (PR-11.1). Metrics auth is now in-process.
+- Documentation overclaims: the `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, and CIS/NIST/SOC2/ISO27001 compliance claims have been removed from the security docs (none of these were ever shipped).
+
+### Fixed
+- `parseProviderID` rejects malformed and multi-segment provider IDs (PR-1.3 / BUG-3).
+- Atomic host claim — concurrent claims are resolved server-side via `MergeFromWithOptimisticLock`; exactly one Beskar7Machine wins (PR-2.2 / BUG-2).
+- Clean release on Beskar7Machine deletion: `ClearBootSourceOverride` + graceful power-off before clearing `ConsumerRef`; errors are logged and swallowed so a dead BMC cannot strand the finalizer (PR-2.3 / BUG-4).
+
+### Security
+- Inspection POST endpoint now requires TLS and `Authorization: Bearer <token>`. Body capped at 1 MiB; over-limit returns 413; auth failures return opaque 401 (PR-5.2 / SEC-1).
+- Bootstrap GET endpoint requires the same per-host bearer token; chain-walk failures collapse to opaque 404 to avoid leaking host topology (PR-5.3).
 
 ## [v0.4.0-alpha] - 2025-11-27
 
@@ -71,12 +110,12 @@ This release represents a complete architectural redesign of Beskar7, moving fro
 #### API Enhancements
 
 ##### PhysicalHost API
-- **InspectionReport Type**: New structured hardware information
-  - CPU details (count, cores, threads, model, architecture, MHz)
-  - Memory details (total, available, in bytes and GB)
-  - Disk information (device, size, type: SSD/HDD/NVMe, model, serial)
-  - Network interfaces (interface name, MAC, link status, speed, driver)
-  - System information (manufacturer, model, serial, BIOS version, BMC address)
+- **InspectionReport Type**: New structured hardware information (array of structs per category)
+  - `cpus []CPUInfo`: per-CPU `id`, `vendor`, `model`, `cores`, `threads`, `frequency`
+  - `memory []MemoryInfo`: per-DIMM `id`, `type`, `capacity` (string with `GB`/`GiB`/`MB`/`MiB`/`TB`/`TiB`), `speed`
+  - `disks []DiskInfo`: per-disk `name`, `model`, `sizeGB`, `type` (SSD/HDD/NVMe), `serialNumber`
+  - `nics []NICInfo`: per-NIC `name`, `macAddress`, `driver`, `speed`, `ipAddresses []string`
+  - System metadata: `manufacturer`, `model`, `serialNumber`, `bootModeDetected`, `firmwareVersion`
 - **InspectionPhase Enum**: New phase tracking
   - `Pending`: Inspection not yet started
   - `Booting`: iPXE boot in progress
@@ -94,12 +133,11 @@ This release represents a complete architectural redesign of Beskar7, moving fro
   - `InspectionImage`: URL for iPXE boot to inspection environment
   - `TargetOSImage`: URL for final OS image (kexec target)
   - `BootMode`: Removed (UEFI only)
-- **Condition Constants**: Added missing condition types
+- **Condition Constants**: Added condition types
   - `MachineProvisionedCondition`
   - `WaitingForHostReason`
-  - `InspectionInProgressReason`
-  - `InspectionCompleteReason`
   - `InspectionFailedReason`
+  - `InspectionTimedOutReason`
 
 ### Enhancements
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,6 @@ Contributions are welcome! Please:
 
 Apache License 2.0 - See [LICENSE](LICENSE) file for details.
 
-## Migration
-
-Migrating from wrkode/beskar7? See [docs/migration-to-projectbeskar.md](docs/migration-to-projectbeskar.md).
-
 ## Support
 
 - **Issues:** https://github.com/projectbeskar/beskar7/issues

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,115 +1,84 @@
 # Beskar7 Documentation
 
-Welcome to the Beskar7 documentation! This directory contains comprehensive documentation for the Beskar7 Cluster API infrastructure provider.
+This directory contains the user-facing documentation for the Beskar7 Cluster API infrastructure provider. The source of truth for everything described here is the code in `api/v1beta1/`, `controllers/`, `cmd/manager/`, and `internal/`. If a doc and the code disagree, the code wins.
 
-## Getting Started
+## Getting started
 
-- [**Introduction**](introduction.md) - Overview of Beskar7 and its purpose
-- [**Quick Start Guide**](quick-start.md) - Get Beskar7 up and running quickly
-- [**🚀 NEW: Quick Start - Vendor Support**](quick-start-vendor-support.md) - Get started with automatic vendor detection
-- [**Architecture**](architecture.md) - Understand how Beskar7 components work together
+- [Introduction](introduction.md) — what Beskar7 does and where it fits.
+- [Quick Start Guide](quick-start.md) — install + first PhysicalHost.
+- [Architecture](architecture.md) — controllers, callback endpoint, inspection workflow.
 
-## API Documentation
+## API reference
 
-- [**API Reference**](api-reference.md) - Complete reference for all Beskar7 CRDs
-- [**PhysicalHost**](physicalhost.md) - Detailed documentation for PhysicalHost resources
-- [**Beskar7Machine**](beskar7machine.md) - Detailed documentation for Beskar7Machine resources
-- [**Beskar7Cluster**](beskar7cluster.md) - Detailed documentation for Beskar7Cluster resources
-- [**Beskar7MachineTemplate**](beskar7machinetemplate.md) - Detailed documentation for template resources
+- [API Reference](api-reference.md) — every CRD field in `v1beta1`.
+- [PhysicalHost](physicalhost.md) — operational notes for the host CRD.
+- [Beskar7Machine](beskar7machine.md) — operational notes for the machine CRD.
+- [Beskar7Cluster](beskar7cluster.md) — operational notes for the cluster CRD.
+- [Beskar7MachineTemplate](beskar7machinetemplate.md) — template schema; consumed by KubeadmControlPlane / MachineDeployment.
 
-## Deployment and Operations
+## Operations
 
-- [**Deployment Best Practices**](deployment-best-practices.md) - Production deployment guidelines
-- [**Advanced Usage**](advanced-usage.md) - Advanced configuration and usage scenarios
-- [**🚀 NEW: State Management**](state-management.md) - State machine operations and recovery
-- [**Troubleshooting**](troubleshooting.md) - Common issues and solutions
+- [State Management](state-management.md) — PhysicalHost lifecycle, transition rules, recovery.
+- [Deployment Best Practices](deployment-best-practices.md) — production deployment guidance.
+- [iPXE Setup](ipxe-setup.md) — DHCP, HTTP boot server, kernel cmdline variables consumed by inspection and bootstrap.
+- [Advanced Usage](advanced-usage.md) — bootstrap-data flow, hardware requirements.
+- [Troubleshooting](troubleshooting.md) — diagnostic procedures for common failures.
+- [Resource Planning](resource-planning.md) — sizing the controller and the inspection footprint.
 
-## Hardware and Compatibility
+## Hardware and compatibility
 
-- [**Hardware Compatibility Matrix**](hardware-compatibility.md) - Vendor support and compatibility information
-- [**🚀 NEW: Vendor-Specific Support**](vendor-specific-support.md) - Automatic vendor detection and configuration
+- [Hardware Compatibility Matrix](hardware-compatibility.md) — Redfish-compliant BMCs that have been exercised.
 
-## Monitoring and Observability
+## Observability
 
-- [**Metrics**](metrics.md) - Available metrics and monitoring setup
+- [Metrics](metrics.md) — Prometheus surface and how to scrape it.
 
-## Documentation Organization
+## Security
 
-### For New Users
-1. Start with [Introduction](introduction.md) to understand Beskar7's purpose
-2. **NEW:** Check out [Quick Start - Vendor Support](quick-start-vendor-support.md) for automatic hardware support
-3. Follow the [Quick Start Guide](quick-start.md) to deploy your first setup
-4. Review [Hardware Compatibility](hardware-compatibility.md) for your specific hardware
+- [Security overview](security/README.md) — what the operator actually enforces.
+- [Security configuration](security/configuration.md) — TLS, credentials, manager flags.
+- [RBAC hardening](security/rbac-hardening.md) — the deployed ClusterRole and rationale.
+- [Security troubleshooting](security/troubleshooting.md) — diagnosing security-control failures.
 
-### For Operators
-1. Review [Deployment Best Practices](deployment-best-practices.md) for production deployments
-2. **NEW:** Understand [State Management](state-management.md) for operational procedures
-3. Set up monitoring using [Metrics](metrics.md) documentation
-4. Familiarize yourself with [Troubleshooting](troubleshooting.md) procedures
+## Development
 
-### For Developers
-1. Understand the [Architecture](architecture.md) and component interactions
-2. Use the [API Reference](api-reference.md) for comprehensive field documentation
-3. Explore [Advanced Usage](advanced-usage.md) for complex scenarios
+- [CI/CD and Testing](ci-cd-and-testing.md) — build, test, lint expectations.
 
-## Key Concepts
+## Examples
 
-### Resources
-- **PhysicalHost**: Represents a physical server manageable via Redfish
-- **Beskar7Machine**: Infrastructure provider for CAPI Machine resources
-- **Beskar7Cluster**: Infrastructure provider for CAPI Cluster resources
-- **Beskar7MachineTemplate**: Template for creating machine configurations
+- [`examples/`](../examples/) — working YAML for a minimal test, a single-host smoke test, and a complete cluster.
 
-### Provisioning Modes
-- **RemoteConfig**: Boot generic ISO with remote configuration URL (requires configURL)
-- **PreBakedISO**: Boot pre-configured ISO with embedded settings
-- **PXE**: Network boot using PXE (requires external PXE infrastructure)
-- **iPXE**: Network boot using iPXE (requires external iPXE infrastructure)
+## Reading order
 
-### Supported Operating Systems
-The following immutable OS families are currently supported with full RemoteConfig capabilities:
-- **Kairos** (recommended) - Cloud-native, immutable OS with built-in cluster provisioning
-- **Flatcar Container Linux** - Minimal, secure container-optimized OS
-- **openSUSE Leap Micro** - Lightweight immutable OS for containers and edge computing
+If you are new to Beskar7:
 
-## Hardware Support
+1. [Introduction](introduction.md)
+2. [Quick Start Guide](quick-start.md)
+3. [Hardware Compatibility](hardware-compatibility.md)
+4. [iPXE Setup](ipxe-setup.md)
+5. The CRD docs you'll be editing: [PhysicalHost](physicalhost.md), [Beskar7Machine](beskar7machine.md), [Beskar7Cluster](beskar7cluster.md).
 
-Beskar7 works with any Redfish-compliant BMC. See the [Hardware Compatibility Matrix](hardware-compatibility.md) for vendor-specific information and known limitations.
+If you are operating an existing install:
 
-**Tested Vendors:**
-- Dell Technologies (iDRAC)
-- HPE (iLO)
-- Lenovo (XCC)
-- Supermicro (BMC)
+1. [Deployment Best Practices](deployment-best-practices.md)
+2. [State Management](state-management.md)
+3. [Metrics](metrics.md)
+4. [Troubleshooting](troubleshooting.md)
+
+## Vendor notes
+
+Beskar7 uses only the universally-supported portions of Redfish (power state, one-time PXE boot source, system info, network interface enumeration). It does not require vendor-specific extensions and does not ship vendor-specific code paths.
+
+| Vendor | BMC product | Tested | Notes |
+|---|---|---|---|
+| Dell EMC | iDRAC 8/9 | Yes | Redfish must be enabled in iDRAC settings. |
+| HPE | iLO 5 | Yes | Requires an iLO Advanced license for some power operations. |
+| Lenovo | XCC | Yes | – |
+| Supermicro | BMC | Yes | Redfish API enable in Configuration → Redfish API. |
+| Other Redfish-compliant BMCs | – | – | Should work; please report results. |
+
+For BMC-specific configuration tips, see [Hardware Compatibility](hardware-compatibility.md).
 
 ## Contributing
 
-For information about contributing to Beskar7, see the main repository documentation.
-
-## Support
-
-- **GitHub Issues**: https://github.com/projectbeskar/beskar7/issues
-- **Documentation Issues**: Report problems with this documentation as GitHub issues
-
-## Document Status
-
-| Document | Status | Last Updated |
-|----------|--------|--------------|
-| Introduction | Yes Complete | Current |
-| Quick Start Guide | Yes Complete | Current |
-| **🚀 Quick Start - Vendor Support** | **Yes NEW** | **Current** |
-| **🚀 Vendor-Specific Support** | **Yes NEW** | **Current** |
-| Architecture | Yes Complete | Current |
-| API Reference | Yes Complete | Current |
-| PhysicalHost | Yes Complete | Current |
-| Beskar7Machine | Yes Complete | Current |
-| Beskar7Cluster | Yes Complete | Current |
-| Beskar7MachineTemplate | Yes Complete | Current |
-| Deployment Best Practices | Yes Complete | Current |
-| Advanced Usage | Yes Complete | Current |
-| Hardware Compatibility | Yes Complete | Current |
-| Troubleshooting | Yes Complete | Current |
-| **🚀 State Management** | **Yes NEW** | **Current** |
-| Metrics | Yes Complete | Current |
-
-All documentation is current and comprehensive as of the latest release. 
+For information about contributing, see the main repository documentation.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,78 +1,113 @@
 # Advanced Usage
 
-This document covers more advanced configuration options and usage scenarios for Beskar7.
+This page covers Beskar7 features beyond the basic "register a host, claim a host" flow. The v0.3 `RemoteConfig`/`PreBakedISO`/`UefiTargetBootSourceOverride` approaches were removed in v0.4 — the only provisioning path now is iPXE network boot to an inspection image, followed by kexec into the target OS.
 
-## Provisioning Modes
+## Bootstrap data flow
 
-Beskar7 supports two primary provisioning modes controlled by the `spec.provisioningMode` field on the `Beskar7Machine` resource:
+Beskar7 honours the CAPI bootstrap-provider contract: every `Beskar7Machine` requires its owning `Machine` to expose a `Spec.Bootstrap.DataSecretName`. The Secret's `value` key holds the user-data the target OS consumes (cloud-init, ignition, or whatever your bootstrap provider produces).
 
-*   **`RemoteConfig` (Default if `spec.configURL` is set):**
-    *   Requires `spec.osFamily`, `spec.imageURL` (pointing to a generic OS installer ISO), and `spec.configURL` (pointing to an OS configuration file like Kairos YAML, Flatcar Ignition JSON, or openSUSE Combustion script).
-    *   Beskar7 attempts to configure the BMC to boot the generic ISO and inject kernel parameters (`config_url=...` for Kairos, `flatcar.ignition.config.url=...` for Flatcar, `combustion.path=...` for LeapMicro) so the booting OS can fetch its configuration from the specified `configURL`.
-    *   **Reliability:** This mode depends heavily on the target BMC's Redfish implementation supporting the `UefiTargetBootSourceOverride` method for setting boot parameters. Success may vary across hardware vendors.
-    *   **Supported OS Families:** Currently only `kairos`, `flatcar`, and `LeapMicro` are supported with RemoteConfig mode.
-*   **`PreBakedISO` (Default if `spec.configURL` is *not* set):**
-    *   Requires `spec.osFamily` and `spec.imageURL`.
-    *   The `spec.imageURL` must point to an ISO image that has *already* been customized (using the target OS's native tooling, e.g., `kairos-agent build iso ...`) to include all necessary configuration for an unattended installation.
-    *   Beskar7 simply instructs the BMC to boot from this provided ISO without injecting any extra parameters.
-    *   The user is responsible for ensuring the pre-baked ISO is bootable (BIOS/UEFI) and self-sufficient.
+End-to-end:
 
-## Vendor-Specific Boot Configuration
+1. The bootstrap provider (e.g. `kubeadm` via `KubeadmConfig` or `KubeadmConfigTemplate`) writes a Secret in the workload namespace with key `value`.
+2. The `Beskar7Machine` reconciler reads `Machine.Spec.Bootstrap.DataSecretName` to confirm the Secret exists. It does NOT read the bytes — that's the manager's bootstrap GET endpoint's job.
+3. The reconciler computes the deterministic per-host URL `<--bootstrap-url-base>/api/v1/bootstrap/<ns>/<host>` and signals it to the PhysicalHost via the `infrastructure.cluster.x-k8s.io/bootstrap-url` annotation. The PhysicalHost reconciler persists it to `Status.Bootstrap.URL`.
+4. The reconciler mints a per-host bearer token (`internal/auth/token.go`), stores the plaintext in a per-host Secret named `<host>-bootstrap-token`, and signals the SHA-256 hash + 30-minute lifetime to the PhysicalHost via `infrastructure.cluster.x-k8s.io/bootstrap-token`. The PhysicalHost reconciler persists the hash and lifetime to `Status.Bootstrap.{TokenHash,IssuedAt,ExpiresAt}`.
+5. The iPXE infrastructure renders the URL and the plaintext token into the kernel cmdline (see [iPXE Setup](ipxe-setup.md)).
+6. After kexec into the target OS, cloud-init / ignition fetches `https://<manager>:8082/api/v1/bootstrap/<ns>/<host>` with `Authorization: Bearer <plaintext>`. The manager validates the token (`controllers/inspection_handler.go:newBearerTokenVerifier`), walks `PhysicalHost → ConsumerRef → Beskar7Machine → owner Machine → Spec.Bootstrap.DataSecretName → Secret`, and serves `secret.data["value"]` with `Cache-Control: no-store`.
 
-Currently, the `RemoteConfig` mode relies on the somewhat standard `UefiTargetBootSourceOverride` Redfish mechanism. If this fails for specific hardware, future versions of Beskar7 might support vendor-specific methods, potentially configured via annotations on the `PhysicalHost` resource.
+If the named Secret does not exist when the Beskar7Machine reconciles, `BootstrapDataReady=False (BootstrapDataUnavailable)` is set and the reconciler stops requeueing — operator must intervene (the bootstrap provider failed or the name is wrong).
 
-For detailed information about vendor-specific behavior and compatibility, see the **[Hardware Compatibility Matrix](./hardware-compatibility.md)**.
+The `--bootstrap-url-base` manager flag controls the base URL used in step 3. The default is `https://beskar7-controller-manager.beskar7-system.svc:8082`, which works when the chart release name is `beskar7`. Override it (`--bootstrap-url-base=https://<service>.<namespace>.svc:8082`) when:
 
-**Example (Conceptual):**
+- You install the chart with a non-default release name; the Service name follows `<release>-controller-manager`.
+- You front the manager with an external load balancer and want hosts to reach it via that VIP rather than the cluster Service DNS.
 
-If a Dell BMC requires setting the `KernelArgs` BIOS attribute instead of using `UefiTargetBootSourceOverride`, a user might apply an annotation like this:
+## Hardware requirements
+
+`Beskar7Machine.spec.hardwareRequirements` is the main "advanced knob" today. The inspection image reports CPU, memory, disk, and NIC details; the Beskar7Machine reconciler validates the report against the configured minimums:
 
 ```yaml
-# physicalhost.yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: PhysicalHost
-metadata:
-  name: dell-server-01
-  namespace: default
-  annotations:
-    # Tell Beskar7 to use the 'KernelArgs' BIOS attribute for boot params
-    beskar7.infrastructure.cluster.x-k8s.io/bios-kernel-arg-attribute: "KernelArgs"
 spec:
-  # ... rest of spec ...
+  hardwareRequirements:
+    minCPUCores: 8       # summed across all CPUs in the report
+    minMemoryGB: 64      # summed across all DIMMs
+    minDiskGB:   500     # summed across all disks
 ```
 
-*Note: This annotation and the logic to handle it are **not yet implemented**.* It represents a potential future direction for handling hardware incompatibility with the default boot parameter method.
+Validation rules:
 
-## Failure Domains
+- `minCPUCores` is summed across `report.cpus[].cores`. A box with 2 CPUs × 4 cores satisfies `minCPUCores: 8`.
+- `minMemoryGB` is summed across `report.memory[].capacity`, parsed by `parseMemoryCapacityGB`. The parser accepts `GB`, `GiB`, `MB`, `MiB`, `TB`, `TiB`. Bare integers are rejected. Fractional results are truncated to whole GB.
+- `minDiskGB` is summed across `report.disks[].sizeGB`.
 
-Cluster API utilizes failure domains (often corresponding to availability zones, racks, etc.) for workload scheduling and resilience.
+If any minimum is violated, the controller calls `markTerminalFailure(HardwareRequirementsNotMet, msg)`, sets `Status.FailureReason` and `Status.FailureMessage`, and stops requeueing. The BMC's hardware does not change at runtime — the failure is terminal. Recovery: lower the requirement, allocate to a different host, or replace the hardware (then delete-and-recreate the Beskar7Machine).
 
-*   **Discovery:** The `Beskar7Cluster` controller attempts to discover available failure domains by listing `PhysicalHost` resources in the same namespace.
-*   **Labeling:** It looks for the standard Kubernetes label `topology.kubernetes.io/zone` on the `PhysicalHost` resources.
-*   **Status:** Unique zone values found are populated into the `Beskar7Cluster`'s `status.failureDomains` map.
-
-To use failure domains, ensure your `PhysicalHost` resources are labeled appropriately:
+You can use `hardwareRequirements` to enforce node-class invariants before bootstrap:
 
 ```yaml
-# physicalhost-rack1.yaml
+# Control-plane: needs CPU + RAM, modest disk
+hardwareRequirements:
+  minCPUCores: 4
+  minMemoryGB: 16
+  minDiskGB:   100
+
+# Memory-heavy worker for caching workloads
+hardwareRequirements:
+  minCPUCores: 8
+  minMemoryGB: 256
+  minDiskGB:   500
+
+# Storage worker
+hardwareRequirements:
+  minCPUCores: 4
+  minMemoryGB: 32
+  minDiskGB:   8000
+```
+
+Pair this with manual host labelling (`topology.kubernetes.io/zone`, vendor labels) and per-namespace separation to steer machines to the right hardware class.
+
+## Failure domains
+
+The `Beskar7Cluster` reconciler discovers failure domains by listing `PhysicalHost` resources in the same namespace and extracting unique values from the `topology.kubernetes.io/zone` label. It populates `Beskar7Cluster.status.failureDomains`; CAPI uses this for placement.
+
+```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
-  name: server-rack1-01
-  namespace: default
+  name: server-01
   labels:
-    topology.kubernetes.io/zone: "rack-1" # Assign zone label
+    topology.kubernetes.io/zone: rack-1     # consumed by Beskar7Cluster
 spec:
-  # ... rest of spec ...
+  redfishConnection:
+    address: "https://192.168.1.100"
+    credentialsSecretRef: "bmc-credentials"
 ```
 
-## Redfish Client Configuration
+Hosts without the label are not part of any failure domain; the reconciler ignores them for placement purposes.
 
-*(To be added: Details on configuring timeouts or other Redfish client parameters, if such configuration options are implemented in the future.)*
+## Force-release a stuck host
 
-For additional advanced topics, see:
+A normal Beskar7Machine deletion runs:
 
-*   **[Hardware Compatibility Matrix](./hardware-compatibility.md)** - Vendor-specific configurations and limitations
-*   **[Troubleshooting Guide](./troubleshooting.md)** - Hardware/BMC interaction issues
-*   **[Deployment Best Practices](./deployment-best-practices.md)** - Production configuration scenarios
-*   **[API Reference](./api-reference.md)** - Complete field documentation and validation rules 
+1. Best-effort `ClearBootSourceOverride` on the BMC.
+2. Best-effort graceful `SetPowerState(Off)`.
+3. Patch `ConsumerRef = nil` on the host.
+4. Remove the finalizer.
+
+Steps 1 and 2 can take time if the BMC is unreachable (the controller logs and swallows errors so a dead BMC cannot strand the finalizer; the timeouts come from `internal/redfish/gofish_client.go:newHTTPClient`). To skip the BMC steps entirely:
+
+```bash
+kubectl annotate beskar7machine <name> \
+  -n <namespace> \
+  infrastructure.cluster.x-k8s.io/force-release=true
+kubectl delete beskar7machine <name> -n <namespace>
+```
+
+Use only when the BMC is permanently unreachable. The host will return to `Available` immediately, but it will retain whatever boot source / power state the BMC currently has — clean up out-of-band.
+
+## See also
+
+- [iPXE Setup](ipxe-setup.md) — how the kernel cmdline is constructed.
+- [Security Configuration](security/configuration.md) — TLS, bearer tokens, manager flags.
+- [Beskar7Machine](beskar7machine.md) — full reconcile flow.
+- [API Reference](api-reference.md) — every field that exists.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,501 +1,127 @@
 # API Reference
 
-This document provides comprehensive reference documentation for all Beskar7 Custom Resource Definitions (CRDs).
+This document is the field-by-field reference for every Beskar7 CRD in `infrastructure.cluster.x-k8s.io/v1beta1`.
 
-## API Groups and Versions
+The source of truth for every field listed here is `api/v1beta1/*_types.go`. If this document and the Go types disagree, the types win.
 
-Beskar7 defines resources in the `infrastructure.cluster.x-k8s.io` API group with version `v1beta1`.
+## API groups and versions
 
-**API Group:** `infrastructure.cluster.x-k8s.io`  
-**Version:** `v1beta1`  
-**Categories:** `cluster-api`
+- **Group:** `infrastructure.cluster.x-k8s.io`
+- **Version:** `v1beta1` (storage version)
+- **Categories:** `cluster-api`
 
-## Resource Overview
+## Resource overview
 
-| Resource | Kind | Short Name | Purpose |
-|----------|------|------------|---------|
-| PhysicalHost | `PhysicalHost` | `ph` | Represents a physical server manageable via Redfish |
-| Beskar7Machine | `Beskar7Machine` | - | Infrastructure provider for CAPI Machine resources |
-| Beskar7Cluster | `Beskar7Cluster` | - | Infrastructure provider for CAPI Cluster resources |
-| Beskar7MachineTemplate | `Beskar7MachineTemplate` | - | Template for creating Beskar7Machine resources |
+| Kind | Short name | Scope | Purpose |
+|---|---|---|---|
+| `PhysicalHost` | `ph` | Namespaced | Inventory record for a bare-metal box; owns BMC connection, observed power state, inspection report. |
+| `Beskar7Machine` | – | Namespaced | CAPI infra-machine; claims a `PhysicalHost`, drives PXE boot + kexec to target image. |
+| `Beskar7MachineTemplate` | `b7mt` | Namespaced | Template referenced by `KubeadmControlPlane` / `MachineDeployment` to mint `Beskar7Machine` objects. |
+| `Beskar7Cluster` | – | Namespaced | CAPI infra-cluster; tracks control-plane endpoint and failure domains. |
+
+---
 
 ## PhysicalHost
 
-Represents a physical server that can be managed via Redfish BMC.
-
-### API Definition
+A `PhysicalHost` represents one physical server. The reconciler in `controllers/physicalhost_controller.go` owns its lifecycle.
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 ```
 
-### Specification Fields
+### `spec`
 
-#### spec.redfishConnection
+#### `spec.redfishConnection` (required)
 
-**Type:** `RedfishConnection` (required)
-
-Connection details for the Redfish BMC endpoint.
+Connection coordinates for the Redfish BMC.
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `address` | string | Yes | URL of the Redfish service (e.g., `https://192.168.1.100`) |
-| `credentialsSecretRef` | string | Yes | Name of the Secret containing Redfish credentials |
-| `insecureSkipVerify` | boolean | No | Skip TLS certificate verification (default: false) |
-
-**Validation:**
-- `address` must match pattern: `^(https?://)[a-zA-Z0-9.-]+(:[0-9]+)?(/.*)?$`
-- `credentialsSecretRef` minimum length: 1
-
-#### spec.consumerRef
-
-**Type:** `ObjectReference` (optional)
-
-Reference to the Beskar7Machine using this host. Set automatically by the Beskar7Machine controller.
-
-#### spec.bootIsoSource
-
-**Type:** `string` (optional)
-
-URL of the ISO image for provisioning. Set by the consuming Beskar7Machine controller.
-
-#### spec.userDataSecretRef
-
-**Type:** `ObjectReference` (optional)
-
-Reference to a Secret containing cloud-init user data.
-
-**Status:** Currently accepted but not yet integrated into the provisioning process. This field is validated and can be set, but user data injection is pending implementation. Future versions will integrate this with OS-specific provisioning methods (cloud-init for Kairos, Ignition for Flatcar, Combustion for LeapMicro).
-
-### Status Fields
-
-#### status.ready
-
-**Type:** `boolean`
-
-Indicates if the host is ready and enrolled.
-
-#### status.state
-
-**Type:** `string`
-
-Current provisioning state. Possible values:
-
-| State | Description |
-|-------|-------------|
-| `""` (empty) | Initial state before reconciliation |
-| `Enrolling` | Controller establishing connection |
-| `Available` | Host ready to be claimed |
-| `Claimed` | Host reserved by a consumer |
-| `Provisioning` | Host being configured |
-| `Provisioned` | Host successfully configured |
-| `Deprovisioning` | Host being cleaned up |
-| `Error` | Host in error state |
-| `Unknown` | State could not be determined |
-
-#### status.observedPowerState
-
-**Type:** `string`
-
-Last observed power state from Redfish endpoint.
-
-#### status.errorMessage
-
-**Type:** `string`
-
-Details about any error encountered.
-
-#### status.hardwareDetails
-
-**Type:** `HardwareDetails`
-
-Information about the physical hardware.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `manufacturer` | string | Hardware manufacturer |
-| `model` | string | Hardware model |
-| `serialNumber` | string | Hardware serial number |
-| `status.health` | string | Health status |
-| `status.healthRollup` | string | Overall health status |
-| `status.state` | string | Hardware state |
-
-#### status.addresses
-
-**Type:** `[]MachineAddress`
-
-Network addresses associated with the host.
-
-#### status.conditions
-
-**Type:** `[]Condition`
-
-Current service state conditions.
-
-### Example
-
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: PhysicalHost
-metadata:
-  name: server-01
-  namespace: default
-  labels:
-    topology.kubernetes.io/zone: "rack-1"
-spec:
-  redfishConnection:
-    address: "https://192.168.1.100"
-    credentialsSecretRef: "bmc-credentials"
-    insecureSkipVerify: false
-status:
-  ready: true
-  state: "Available"
-  observedPowerState: "On"
-  hardwareDetails:
-    manufacturer: "Dell Inc."
-    model: "PowerEdge R750"
-    serialNumber: "ABC123DEF"
-    status:
-      health: "OK"
-      healthRollup: "OK"
-      state: "Enabled"
-  addresses:
-  - type: InternalIP
-    address: "192.168.1.100"
-  conditions:
-  - type: RedfishConnectionReady
-    status: "True"
-    reason: "Connected"
-    message: "Successfully connected to Redfish endpoint"
-```
-
-## Beskar7Machine
-
-Infrastructure provider resource for CAPI Machine objects.
-
-### API Definition
-
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7Machine
-```
-
-### Specification Fields
-
-#### spec.providerID
-
-**Type:** `string` (optional)
-
-Unique identifier set by the infrastructure provider.
-
-#### spec.imageURL
-
-**Type:** `string` (required)
-
-URL of the OS image to use for the machine.
-
-**Validation:**
-- Must match pattern for valid image files: `.iso`, `.img`, `.qcow2`, `.vmdk`, `.raw`, `.vhd`, `.vhdx`, `.ova`, `.ovf`
-- Supports compressed formats: `.gz`, `.bz2`, `.xz`, `.zip`, `.tar`, `.tgz`, `.tbz2`, `.txz`
-- Must use supported schemes: `http`, `https`, `ftp`, `file`
-
-#### spec.osFamily
-
-**Type:** `string` (required)
-
-Operating system family to use.
-
-**Valid Values:**
-- `kairos` - Kairos cloud-native OS (recommended)
-- `flatcar` - Flatcar Container Linux
-- `LeapMicro` - openSUSE Leap Micro
-
-**Note:** Only the OS families listed above are currently supported with full RemoteConfig provisioning capabilities. Each OS family has specific kernel parameter requirements for configuration URL passing.
-
-#### spec.configURL
-
-**Type:** `string` (optional)
-
-URL of the configuration file for the machine.
-
-**Validation:**
-- Must match pattern for configuration files: `.yaml`, `.yml`, `.json`, `.toml`, `.conf`, `.cfg`, `.ini`, `.properties`
-- Must use supported schemes: `http`, `https`, `file`
-
-#### spec.provisioningMode
-
-**Type:** `string` (optional, default: "RemoteConfig")
-
-Mode to use for provisioning the machine.
-
-**Valid Values:**
-- `RemoteConfig` - Boot generic ISO with configuration URL
-- `PreBakedISO` - Boot pre-configured ISO. Use this when the OS config is embedded into the ISO for `kairos`, `talos`, `flatcar`, or `LeapMicro`.
-- `PXE` - PXE boot (future)
-- `iPXE` - iPXE boot (future)
-
-**Cross-field Validation:**
-- `configURL` is required when `provisioningMode` is `RemoteConfig`
-- `configURL` should not be set when `provisioningMode` is `PreBakedISO`
-
-### Status Fields
-
-#### status.ready
-
-**Type:** `boolean`
-
-Indicates if the machine is ready.
-
-#### status.phase
-
-**Type:** `string`
-
-Current phase of the machine lifecycle.
-
-#### status.failureReason
-
-**Type:** `string`
-
-Reason for any terminal failure.
-
-#### status.failureMessage
-
-**Type:** `string`
-
-Detailed message about any terminal failure.
-
-#### status.addresses
-
-**Type:** `[]MachineAddress`
-
-Network addresses for the machine.
-
-#### status.conditions
-
-**Type:** `[]Condition`
-
-Current service state conditions.
-
-**Standard Conditions:**
-- `InfrastructureReady` - Infrastructure is ready
-- `PhysicalHostAssociated` - Associated with a PhysicalHost
-
-### Example
-
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7Machine
-metadata:
-  name: control-plane-01
-  namespace: default
-  labels:
-    cluster.x-k8s.io/cluster-name: "production-cluster"
-    cluster.x-k8s.io/control-plane: ""
-spec:
-  imageURL: "https://releases.kairos.io/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-  osFamily: "kairos"
-  provisioningMode: "RemoteConfig"
-  configURL: "https://config.example.com/control-plane.yaml"
-status:
-  ready: true
-  phase: "Running"
-  addresses:
-  - type: InternalIP
-    address: "10.0.1.10"
-  - type: ExternalIP
-    address: "203.0.113.10"
-  conditions:
-  - type: InfrastructureReady
-    status: "True"
-    reason: "ProvisioningComplete"
-    message: "Infrastructure is ready"
-  - type: PhysicalHostAssociated
-    status: "True"
-    reason: "HostClaimed"
-    message: "Successfully associated with PhysicalHost server-01"
-```
-
-## Beskar7Cluster
-
-Infrastructure provider resource for CAPI Cluster objects.
-
-### API Definition
-
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7Cluster
-```
-
-### Specification Fields
-
-#### spec.controlPlaneEndpoint
-
-**Type:** `APIEndpoint` (optional)
-
-Endpoint for the cluster's control plane API.
+|---|---|---|---|
+| `address` | string | yes | URL of the Redfish service. Validated against `^(https?://)[a-zA-Z0-9.-]+(:[0-9]+)?(/.*)?$`. |
+| `credentialsSecretRef` | string | yes | Name of a Secret in the same namespace holding `username` and `password` keys. Min length 1. |
+| `insecureSkipVerify` | `*bool` | no | Skip TLS verification of the BMC certificate. Defaults to `false`. Mutually exclusive with `caBundleSecretRef`. |
+| `caBundleSecretRef` | `*LocalObjectReference` | no | Reference to a Secret in the same namespace holding PEM CA certificates. Data key `ca.crt` is preferred; `tls.crt` is the fallback. Mutually exclusive with `insecureSkipVerify=true`. |
+
+When `caBundleSecretRef` is set the manager builds an `*http.Client` whose root pool includes the supplied bundle and passes it to gofish. Setting both `insecureSkipVerify=true` and `caBundleSecretRef` is rejected by the controller with the `InsecureCABundleConflict` reason on `RedfishConnectionReady`; the host is moved to `Error`.
+
+#### `spec.consumerRef`
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `host` | string | Yes | Hostname or IP address |
-| `port` | int32 | Yes | Port number (1-65535) |
+|---|---|---|---|
+| `consumerRef` | `*ObjectReference` | no | Set by the `Beskar7Machine` reconciler when it claims the host. Acts as the lock. Cleared on Beskar7Machine deletion (best-effort BMC cleanup runs first; see `controllers/beskar7machine_controller.go:reconcileDelete`). |
 
-**Validation:**
-- `host` must be valid IP address or hostname
-- `port` must be between 1 and 65535
+There are no other spec fields. Provisioning is driven by the consumer (the `Beskar7Machine`); the host itself only carries connection info and the consumer reference.
 
-### Status Fields
+### `status`
 
-#### status.ready
+| Field | Type | Description |
+|---|---|---|
+| `ready` | bool | True when the host is reachable via Redfish and has a current state. |
+| `state` | string | One of the constants in `api/v1beta1/physicalhost_types.go:10-26`: `""`, `"Unknown"`, `"Enrolling"`, `"Available"`, `"InUse"`, `"Inspecting"`, `"Ready"`, `"Error"`. See [State Management](state-management.md). |
+| `observedPowerState` | string | Last observed Redfish power state (e.g. `On`, `Off`). |
+| `errorMessage` | string | Set when state is `Error`; cleared when the host recovers. |
+| `hardwareDetails` | `HardwareDetails` | Manufacturer, model, serial, and BMC-reported health. Populated from `GetSystemInfo`. |
+| `addresses` | `[]MachineAddress` | Network addresses discovered via Redfish (BMC + system NICs). |
+| `inspectionReport` | `*InspectionReport` | Hardware report from the inspection image. Populated by the `PhysicalHost` reconciler after consuming the inspection-result ConfigMap (see [Inspection workflow](architecture.md#inspection-workflow)). |
+| `inspectionPhase` | string | One of `Pending`, `Booting`, `InProgress`, `Complete`, `Failed`, `Timeout`. |
+| `inspectionTimestamp` | `*metav1.Time` | Time the inspection started. |
+| `bootstrap` | `*BootstrapStatus` | Per-host bootstrap data fetch coordinates and the hashed bearer token. See below. |
+| `conditions` | `clusterv1.Conditions` | CAPI-style conditions; key types listed below. |
 
-**Type:** `boolean`
+#### `HardwareDetails`
 
-Indicates if the cluster infrastructure is ready.
+| Field | Type | Description |
+|---|---|---|
+| `manufacturer` | string | Reported by Redfish. |
+| `model` | string | Reported by Redfish. |
+| `serialNumber` | string | Reported by Redfish. |
+| `status.health` | string | `OK`, `Warning`, `Critical` (Redfish enum). |
+| `status.healthRollup` | string | Aggregated health across subsystems. |
+| `status.state` | string | Hardware state string from Redfish (`Enabled`, `Disabled`, etc.). |
 
-#### status.controlPlaneEndpoint
+#### `InspectionReport`
 
-**Type:** `APIEndpoint`
+The report is an array-of-structs shape — never a single flat object. Source: `api/v1beta1/physicalhost_types.go:140-180`.
 
-Discovered or configured control plane endpoint.
+| Field | Type | Description |
+|---|---|---|
+| `timestamp` | `metav1.Time` | When the report was produced. |
+| `manufacturer`, `model`, `serialNumber`, `bootModeDetected`, `firmwareVersion` | string | System-level identification. |
+| `cpus` | `[]CPUInfo` | One entry per physical CPU. |
+| `memory` | `[]MemoryInfo` | One entry per DIMM. |
+| `disks` | `[]DiskInfo` | One entry per storage device. |
+| `nics` | `[]NICInfo` | One entry per network interface. |
 
-#### status.failureDomains
+`CPUInfo`: `id`, `vendor`, `model`, `cores`, `threads`, `frequency`.
 
-**Type:** `FailureDomains`
+`MemoryInfo`: `id`, `type`, `capacity` (string, e.g. `"32GB"` or `"32GiB"`; parser accepts `GB`/`GiB`/`MB`/`MiB`/`TB`/`TiB`), `speed`.
 
-Map of failure domain information discovered from PhysicalHost labels.
+`DiskInfo`: `name`, `model`, `sizeGB` (int), `type` (`SSD`/`HDD`/`NVMe`), `serialNumber`.
 
-#### status.conditions
+`NICInfo`: `name`, `macAddress`, `driver`, `speed`, `ipAddresses` (`[]string`).
 
-**Type:** `[]Condition`
+#### `BootstrapStatus`
 
-Current service state conditions.
+Per-host bootstrap fetch coordinates and the hashed bearer token used to authenticate the inspection POST and bootstrap GET. The plaintext token is never stored on this object; it lives in a per-host Secret named `<host-name>-bootstrap-token`. See decision D-004 in `.claude/context/PROJECT_CONTEXT.md`.
 
-**Standard Conditions:**
-- `ControlPlaneEndpointReady` - Control plane endpoint is available
+| Field | Type | Description |
+|---|---|---|
+| `url` | string | The manager-served HTTPS URL that returns the host's bootstrap user-data. Computed as `<--bootstrap-url-base>/api/v1/bootstrap/<namespace>/<name>`. |
+| `tokenHash` | string | Hex-encoded SHA-256 of the per-host bearer token. 64 chars. |
+| `issuedAt` | `*metav1.Time` | When the current token was minted. |
+| `expiresAt` | `*metav1.Time` | When the current token stops being accepted. Defaults to `issuedAt + 30m`. |
+
+#### Conditions
+
+| Type | Set by | Meaning |
+|---|---|---|
+| `RedfishConnectionReady` | `PhysicalHost` | True when the BMC connection is healthy. False reasons include `MissingCredentials`, `SecretGetFailed`, `RedfishConnectionFailed`, `RedfishQueryFailed`, `InsecureCABundleConflict`, `CABundleFetchFailed`. |
+| `HostAvailable` | `PhysicalHost` | True when the host is `Available` (no consumer claim). |
+| `HostInspected` | `PhysicalHost` | True after the inspection report is persisted to status. |
 
 ### Example
 
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7Cluster
-metadata:
-  name: production-cluster
-  namespace: default
-spec:
-  controlPlaneEndpoint:
-    host: "10.0.1.10"
-    port: 6443
-status:
-  ready: true
-  controlPlaneEndpoint:
-    host: "10.0.1.10"
-    port: 6443
-  failureDomains:
-    rack-1:
-      controlPlane: true
-      attributes:
-        zone: "rack-1"
-    rack-2:
-      controlPlane: true
-      attributes:
-        zone: "rack-2"
-  conditions:
-  - type: ControlPlaneEndpointReady
-    status: "True"
-    reason: "EndpointDiscovered"
-    message: "Control plane endpoint is ready"
-```
-
-## Beskar7MachineTemplate
-
-Template for creating Beskar7Machine resources, used by CAPI MachineDeployment and other templating resources.
-
-### API Definition
-
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7MachineTemplate
-```
-
-### Specification Fields
-
-#### spec.template
-
-**Type:** `Beskar7MachineTemplateResource` (required)
-
-Template for creating Beskar7Machine resources.
-
-#### spec.template.spec
-
-**Type:** `Beskar7MachineSpec` (required)
-
-Specification for the Beskar7Machine (same fields as Beskar7Machine.spec).
-
-### Example
-
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7MachineTemplate
-metadata:
-  name: worker-template
-  namespace: default
-spec:
-  template:
-    spec:
-      imageURL: "https://releases.kairos.io/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-      osFamily: "kairos"
-      provisioningMode: "RemoteConfig"
-      configURL: "https://config.example.com/worker.yaml"
-```
-
-## Common Types
-
-### ObjectReference
-
-Standard Kubernetes object reference.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `apiVersion` | string | API version of the referenced object |
-| `kind` | string | Kind of the referenced object |
-| `name` | string | Name of the referenced object |
-| `namespace` | string | Namespace of the referenced object |
-| `uid` | string | UID of the referenced object |
-
-### MachineAddress
-
-Network address information.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `type` | string | Type of address (InternalIP, ExternalIP, etc.) |
-| `address` | string | The address value |
-
-**Address Types:**
-- `Hostname` - DNS hostname
-- `ExternalIP` - Public IP address
-- `InternalIP` - Private IP address
-- `ExternalDNS` - External DNS name
-- `InternalDNS` - Internal DNS name
-
-### Condition
-
-Standard Kubernetes condition type.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `type` | string | Type of condition |
-| `status` | string | Status of condition (True, False, Unknown) |
-| `reason` | string | Machine-readable reason for condition |
-| `message` | string | Human-readable message |
-| `lastTransitionTime` | string | Time when condition last changed |
-| `severity` | string | Severity of the condition |
-
-## Usage Patterns
-
-### Basic PhysicalHost Setup
-
-1. **Create BMC credentials secret:**
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -505,146 +131,210 @@ metadata:
 type: Opaque
 stringData:
   username: "admin"
-  password: "password123"
-```
-
-2. **Create PhysicalHost:**
-```yaml
+  password: "changeme"
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
   name: server-01
   namespace: default
+  labels:
+    topology.kubernetes.io/zone: rack-1
 spec:
   redfishConnection:
     address: "https://192.168.1.100"
     credentialsSecretRef: "bmc-credentials"
+    insecureSkipVerify: false
 ```
-
-### Machine Provisioning Patterns
-
-#### RemoteConfig Pattern
-
-Used when you have a generic OS installer ISO and want to provide configuration via URL:
-
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7Machine
-metadata:
-  name: worker-01
-spec:
-  imageURL: "https://releases.kairos.io/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-  osFamily: "kairos"
-  provisioningMode: "RemoteConfig"
-  configURL: "https://config.example.com/worker.yaml"
-```
-
-#### PreBakedISO Pattern
-
-Used when you have a pre-configured ISO with all settings embedded:
-
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7Machine
-metadata:
-  name: worker-02
-spec:
-  imageURL: "https://storage.example.com/custom-kairos-worker.iso"
-  osFamily: "kairos"
-  provisioningMode: "PreBakedISO"
-```
-
-### Cluster API Integration
-
-Beskar7 resources are typically created by Cluster API controllers, not directly by users:
-
-```yaml
-# CAPI Cluster - creates Beskar7Cluster
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  name: production-cluster
-spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Beskar7Cluster
-    name: production-cluster
 
 ---
-# CAPI Machine - creates Beskar7Machine
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Machine
+
+## Beskar7Machine
+
+A `Beskar7Machine` is a CAPI infra-machine. The reconciler in `controllers/beskar7machine_controller.go` claims a `PhysicalHost`, runs the inspection workflow, validates hardware, and signals readiness.
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Beskar7Machine
+```
+
+### `spec`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `providerID` | `*string` | no | Set by the controller when the host is claimed. Format: `b7://<namespace>/<name>`. Do not set manually. |
+| `inspectionImageURL` | string | yes | iPXE boot script URL or kernel/initrd URL for the inspection image. Validated against `^https?://.*`. |
+| `targetImageURL` | string | yes | URL of the final OS image (kexec target). Validated against `^https?://.*`. |
+| `configurationURL` | string | no | URL passed to the target OS during kexec. Validated against `^https?://.*`. |
+| `hardwareRequirements` | `*HardwareRequirements` | no | Minimum hardware. The inspection report is validated against these; failures are terminal. |
+
+#### `HardwareRequirements`
+
+| Field | Type | Description |
+|---|---|---|
+| `minCPUCores` | int | Minimum CPU cores summed across all CPUs (`>= 1`). |
+| `minMemoryGB` | int | Minimum installed memory in decimal GB summed across all DIMMs (`>= 1`). The capacity parser accepts `GB`/`GiB`/`MB`/`MiB`/`TB`/`TiB`. |
+| `minDiskGB` | int | Minimum disk space summed across all disks (`>= 1`). |
+
+If the inspection report does not meet any of these, the controller sets `Status.FailureReason = HardwareRequirementsNotMet` and `InfrastructureReady = False (Severity=Error)`. This is terminal — operator must lower requirements, allocate to different hardware, or delete-and-recreate.
+
+### `status`
+
+| Field | Type | Description |
+|---|---|---|
+| `ready` | bool | True after the host is `Ready` and the bootstrap data has been signalled. |
+| `phase` | `*string` | Free-form: `Pending`, `Inspecting`, `Provisioned`, `Failed`. |
+| `failureReason` | `*string` | Set on terminal failures (`HardwareRequirementsNotMet`, `InspectionTimedOut`, `BootstrapDataUnavailable`). Once set, the controller stops requeueing — operator must intervene. |
+| `failureMessage` | `*string` | Human-readable failure detail. Surfaced via `kubectl describe machine`. |
+| `addresses` | `[]MachineAddress` | Copied from the claimed `PhysicalHost.Status.Addresses`. |
+| `conditions` | `clusterv1.Conditions` | See below. |
+
+#### Conditions
+
+| Type | Set by | Meaning |
+|---|---|---|
+| `InfrastructureReady` | `Beskar7Machine` | Standard CAPI infra-ready condition. Summary across the others. |
+| `PhysicalHostAssociated` | `Beskar7Machine` | True after a host is claimed. False reasons: `PhysicalHostAssociationFailed`, `WaitingForPhysicalHost`. |
+| `MachineProvisioned` | `Beskar7Machine` | True after host transitions to `Ready` and the machine has its `ProviderID`. |
+| `BootstrapDataReady` | `Beskar7Machine` | True after `Machine.Spec.Bootstrap.DataSecretName` is set and the bootstrap URL has been signalled to the host. False reasons: `WaitingForBootstrapData`, `BootstrapDataUnavailable`. |
+
+### Example
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Beskar7Machine
 metadata:
   name: control-plane-01
+  namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: production-cluster
+    cluster.x-k8s.io/control-plane: "true"
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Beskar7Machine
-    name: control-plane-01
+  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  configurationURL:   "http://boot-server.local/configs/control-plane.yaml"
+  hardwareRequirements:
+    minCPUCores: 4
+    minMemoryGB: 16
+    minDiskGB:   100
 ```
 
-## Validation and Constraints
+---
 
-### Admission Webhooks
+## Beskar7MachineTemplate
 
-All Beskar7 resources are protected by comprehensive admission webhooks that provide:
+`Beskar7MachineTemplate` is a pure schema. It is referenced by `KubeadmControlPlane` and `MachineDeployment` so they can mint `Beskar7Machine` objects with the same spec. There is no `Beskar7MachineTemplate` controller, no validating/defaulting webhook, and no immutability enforcement; the template's spec is whatever any author writes.
 
-#### Validating Webhooks
-- **Field validation**: URL formats, enum values, cross-field constraints
-- **Security validation**: TLS certificate validation, credential strength requirements
-- **Business logic validation**: Redfish connectivity, resource dependencies
-- **Immutability enforcement**: Critical fields that cannot be changed after creation
-
-#### Mutating Webhooks (Defaulting)
-- **Automatic field defaulting**: Sets sensible defaults for optional fields
-- **Consistent behavior**: Ensures all resources have complete specifications
-- **Version compatibility**: Maintains compatibility across API versions
-
-### Field Validation
-
-All resources include comprehensive field validation via OpenAPI schemas and admission webhooks:
-
-- **URL validation** for `imageURL` and `configURL` (with format and accessibility checks)
-- **Enum validation** for `osFamily` and `provisioningMode` 
-- **Pattern validation** for Redfish addresses and BMC endpoints
-- **Cross-field validation** for provisioning mode constraints and dependencies
-- **Security validation** for TLS settings and credential requirements
-
-### Resource Constraints
-
-#### PhysicalHost Constraints
-- Must have unique Redfish addresses within a namespace
-- Redfish connection parameters are validated on creation/update
-- Credentials secret must exist and contain valid username/password
-- TLS configuration is validated for production environments
-
-#### Beskar7Machine Constraints  
-- Can only claim available PhysicalHost resources
-- ConfigURL is mandatory for RemoteConfig mode but forbidden for PreBakedISO mode
-- ImageURL must point to supported image formats (.iso, .img, .qcow2, etc.)
-- ProviderID is managed by controllers and cannot be set manually
-
-#### Beskar7MachineTemplate Constraints
-- **Immutable after creation**: imageURL, osFamily, provisioningMode, configURL cannot be changed
-- ProviderID cannot be set in templates (managed by controllers)
-- Inherits all validation rules from Beskar7Machine specifications
-- Template changes require creating new template versions
-
-### Status Transitions
-
-Resources follow predictable state transitions:
-
-**PhysicalHost States:**
-```
-None -> Enrolling -> Available -> Claimed -> Provisioning -> Provisioned
-                     v           v
-                   Error <- -> Deprovisioning -> Available
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Beskar7MachineTemplate
 ```
 
-**Beskar7Machine Conditions:**
-```
-PhysicalHostAssociated: False -> True (when host is claimed)
-InfrastructureReady: False -> True (when provisioning completes)
+### `spec`
+
+| Field | Type | Description |
+|---|---|---|
+| `template.spec` | `Beskar7MachineSpec` | Identical schema to a `Beskar7Machine`'s spec. See [Beskar7Machine.spec](#spec-1). |
+
+### Example
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Beskar7MachineTemplate
+metadata:
+  name: my-cluster-workers
+  namespace: default
+spec:
+  template:
+    spec:
+      inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+      targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+      configurationURL:   "http://boot-server.local/configs/worker.yaml"
+      hardwareRequirements:
+        minCPUCores: 4
+        minMemoryGB: 8
+        minDiskGB:   50
 ```
 
-This API reference provides comprehensive information for working with Beskar7 resources. For additional examples and usage scenarios, see the other documentation files. 
+The template carries the `cluster-api` category so `clusterctl move` walks it during workload-cluster migration.
+
+---
+
+## Beskar7Cluster
+
+A `Beskar7Cluster` is a CAPI infra-cluster. The reconciler in `controllers/beskar7cluster_controller.go` derives the control-plane endpoint and discovers failure domains.
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Beskar7Cluster
+```
+
+### `spec`
+
+| Field | Type | Description |
+|---|---|---|
+| `controlPlaneEndpoint.host` | string | Optional. If unset, the controller derives it from the control-plane `Beskar7Machine.Status.Addresses`. |
+| `controlPlaneEndpoint.port` | int32 | Optional. |
+
+### `status`
+
+| Field | Type | Description |
+|---|---|---|
+| `ready` | bool | True when `controlPlaneEndpoint` is populated. |
+| `controlPlaneEndpoint` | `clusterv1.APIEndpoint` | Same shape as `spec.controlPlaneEndpoint`. |
+| `failureDomains` | `clusterv1.FailureDomains` | Map keyed by zone name; values discovered from `topology.kubernetes.io/zone` labels on `PhysicalHost` objects. |
+| `conditions` | `clusterv1.Conditions` | See below. |
+
+#### Conditions
+
+| Type | Set by | Meaning |
+|---|---|---|
+| `ControlPlaneEndpointReady` | `Beskar7Cluster` | True after the endpoint is populated. False reason: `ControlPlaneEndpointNotSet`. |
+
+### Webhooks
+
+`Beskar7Cluster` is the only resource with an admission webhook. The webhook is in `api/v1beta1/webhooks/beskar7cluster_webhook.go`; it validates `controlPlaneEndpoint.host` and `port`. The webhook ships with `failurePolicy: Fail`.
+
+There are **no** webhooks for `PhysicalHost`, `Beskar7Machine`, or `Beskar7MachineTemplate`. Validation for those resources is performed by the controllers themselves and via OpenAPI schema validation.
+
+### Example
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Beskar7Cluster
+metadata:
+  name: production-cluster
+  namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: "10.0.1.10"
+    port: 6443
+```
+
+---
+
+## Common types
+
+### `ObjectReference`
+
+Standard Kubernetes object reference (`apiVersion`, `kind`, `name`, `namespace`, `uid`).
+
+### `MachineAddress`
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | string | One of `Hostname`, `InternalIP`, `ExternalIP`, `InternalDNS`, `ExternalDNS`. |
+| `address` | string | The address. |
+
+### `Condition`
+
+CAPI-style condition: `type`, `status` (`True`/`False`/`Unknown`), `reason`, `message`, `severity`, `lastTransitionTime`.
+
+---
+
+## Cross-references
+
+- Lifecycle and state transitions: [State Management](state-management.md).
+- Per-CRD docs with extended notes: [PhysicalHost](physicalhost.md), [Beskar7Machine](beskar7machine.md), [Beskar7MachineTemplate](beskar7machinetemplate.md), [Beskar7Cluster](beskar7cluster.md).
+- Working YAML: [`examples/`](../examples/).
+- Architecture: [Architecture](architecture.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,15 +286,17 @@ The inspection image is a lightweight Alpine Linux environment with hardware det
 - Scripts: Hardware detection, report generation, kexec boot
 - Size: <100 MB
 
-**Kernel Parameters:**
+**Kernel Parameters** (the iPXE infrastructure renders these per host — see [iPXE Setup](ipxe-setup.md)):
+
 ```
-beskar7.api=http://controller.cluster.local:8082
-beskar7.token=secret-inspection-token
+beskar7.api=https://beskar7-controller-manager.beskar7-system.svc:8082
 beskar7.namespace=default
 beskar7.host=server-01
-beskar7.target=http://boot-server/images/kairos.tar.gz
-beskar7.config=http://boot-server/configs/node-config.yaml
+beskar7.bootstrap-url=https://beskar7-controller-manager.beskar7-system.svc:8082/api/v1/bootstrap/default/server-01
+beskar7.token=<plaintext-bearer-token>
 ```
+
+The inspector POSTs to `${beskar7.api}/api/v1/inspection/${beskar7.namespace}/${beskar7.host}` with `Authorization: Bearer ${beskar7.token}`. The target OS, after kexec, fetches bootstrap data from `${beskar7.bootstrap-url}` with the same `Authorization` header.
 
 ## API Types
 
@@ -320,35 +322,46 @@ status:
   inspectionPhase: Complete  # Pending, Booting, InProgress, Complete, Failed, Timeout
   inspectionReport:
     timestamp: "2025-11-27T10:00:00Z"
+    manufacturer: "Dell Inc."
+    model: "PowerEdge R730"
+    serialNumber: "ABC1234"
+    bootModeDetected: "UEFI"
+    firmwareVersion: "2.15.0"
     cpus:
-      count: 2
-      cores: 16
-      threads: 32
-      model: "Intel Xeon E5-2640 v4"
-      architecture: "x86_64"
-      mhz: 2400
+      - id: cpu0
+        vendor: "GenuineIntel"
+        model: "Intel Xeon E5-2640 v4"
+        cores: 8
+        threads: 16
+        frequency: "2.4GHz"
+      - id: cpu1
+        vendor: "GenuineIntel"
+        model: "Intel Xeon E5-2640 v4"
+        cores: 8
+        threads: 16
+        frequency: "2.4GHz"
     memory:
-      totalBytes: 68719476736
-      totalGB: 64
+      - id: DIMM0
+        type: DDR4
+        capacity: "32GB"
+        speed: "2400MHz"
+      - id: DIMM1
+        type: DDR4
+        capacity: "32GB"
+        speed: "2400MHz"
     disks:
-    - device: "/dev/sda"
-      sizeBytes: 500107862016
-      sizeGB: 500
-      type: "SSD"
-      model: "Samsung 870 EVO"
-      serial: "S5H1NS0T123456"
+      - name: "/dev/sda"
+        model: "Samsung 870 EVO"
+        sizeGB: 500
+        type: SSD
+        serialNumber: "S5H1NS0T123456"
     nics:
-    - interface: "eth0"
-      macAddress: "00:25:90:f0:79:00"
-      linkStatus: "up"
-      speedMbps: 1000
-      driver: "ixgbe"
-    system:
-      manufacturer: "Dell Inc."
-      model: "PowerEdge R730"
-      serialNumber: "ABC1234"
-      biosVersion: "2.15.0"
-      bmcAddress: "192.168.1.100"
+      - name: eth0
+        macAddress: "00:25:90:f0:79:00"
+        driver: ixgbe
+        speed: "1Gbps"
+        ipAddresses:
+          - "192.168.1.50"
 ```
 
 ### Beskar7Machine
@@ -357,28 +370,20 @@ status:
 
 ```yaml
 spec:
-  # Inspection image URL (iPXE boot script or kernel/initrd)
-  inspectionImage: "http://boot-server/ipxe/inspect.ipxe"
-  
-  # Final OS image URL (for kexec)
-  targetOSImage: "http://boot-server/images/kairos-v2.8.1.tar.gz"
-  
-  # Optional: OS configuration
-  configurationURL: "http://boot-server/configs/worker-config.yaml"
-  
-  # Hardware requirements (optional)
+  inspectionImageURL: "http://boot-server/ipxe/inspect.ipxe"   # iPXE boot script or kernel/initrd
+  targetImageURL:     "http://boot-server/images/kairos-v2.8.1.tar.gz"
+  configurationURL:   "http://boot-server/configs/worker-config.yaml"   # optional
   hardwareRequirements:
     minCPUCores: 4
     minMemoryGB: 8
-    minDiskGB: 50
+    minDiskGB:   50
 
 status:
-  phase: Provisioned  # Pending, Claiming, Inspecting, Validating, Provisioning, Provisioned, Failed
+  phase: Provisioned   # Pending, Inspecting, Provisioned, Failed
   ready: true
   conditions:
-  - type: MachineProvisioned
-    status: "True"
-    reason: InspectionComplete
+    - type: MachineProvisioned
+      status: "True"
 ```
 
 ### Beskar7Cluster
@@ -477,13 +482,16 @@ If BMC connection fails:
 
 ## Security Considerations
 
-### Inspection Token
+### Inspection / bootstrap bearer token
 
-The inspection token is used to authenticate inspection reports:
-- Generated per PhysicalHost
-- Passed via iPXE kernel parameters
-- Validated by Inspection Handler
-- Short-lived (10 minute timeout)
+The same per-host bearer token authenticates the inspection POST and the bootstrap GET on `:8082`:
+
+- 32 bytes from `crypto/rand`, encoded as base64-raw-url (43 chars).
+- SHA-256 hash persisted on `PhysicalHost.Status.Bootstrap.TokenHash` (64 hex chars).
+- Plaintext stored in a per-host Secret named `<host>-bootstrap-token` (data key `plaintext-token`); GC'd on host delete via owner-ref.
+- Lifetime: 30 minutes (`auth.TokenLifetime` in `internal/auth/token.go`).
+- Constant-time SHA-256 compare (`crypto/subtle`) on every request.
+- The plaintext travels on the iPXE kernel cmdline as `beskar7.token=<plaintext>`. See [iPXE Setup](ipxe-setup.md).
 
 ### BMC Credentials
 
@@ -503,11 +511,7 @@ Recommended network topology:
 
 ### Metrics
 
-Prometheus metrics exposed on port 8080:
-- `beskar7_physicalhost_state` - Host state gauge
-- `beskar7_inspection_duration_seconds` - Inspection duration histogram
-- `beskar7_provisioning_duration_seconds` - Total provisioning duration
-- `beskar7_inspection_failures_total` - Inspection failure counter
+Prometheus metrics exposed on `:8443` (HTTPS, authenticated). For the full surface, see [Metrics](metrics.md). The metrics endpoint authenticates requests via TokenReview/SubjectAccessReview delegated to the kube-apiserver; scrapers need the `metrics-reader` ClusterRole. For local development, set the manager flag `--secure-metrics=false`.
 
 ### Logs
 

--- a/docs/beskar7cluster.md
+++ b/docs/beskar7cluster.md
@@ -1,58 +1,60 @@
 # Beskar7Cluster
 
-The `Beskar7Cluster` resource represents a cluster in the Beskar7 infrastructure provider.
+`Beskar7Cluster` is the Beskar7 CRD that implements the CAPI infrastructure-cluster contract. The reconciler that owns it is `controllers/beskar7cluster_controller.go`. It is the only Beskar7 resource with an admission webhook (`api/v1beta1/webhooks/beskar7cluster_webhook.go`).
 
-## API Version
+For the full field reference, see [API Reference: Beskar7Cluster](api-reference.md#beskar7cluster). This page covers operational behavior — what the controller derives, when it sets which condition.
 
-`infrastructure.cluster.x-k8s.io/v1beta1`
+## Identity
 
-## Kind
+- **API:** `infrastructure.cluster.x-k8s.io/v1beta1`
+- **Kind:** `Beskar7Cluster`
+- **Scope:** Namespaced
+- **Categories:** `cluster-api`
 
-`Beskar7Cluster`
+## Spec
 
-## Short Name
+```yaml
+spec:
+  controlPlaneEndpoint:
+    host: "10.0.1.10"   # optional; controller derives if unset
+    port: 6443          # optional
+```
 
-`b7c`
+## What the reconciler does
 
-## Namespaced
+### Control-plane endpoint
 
-Yes
+The controller derives the endpoint by:
 
-## Categories
+1. Listing CAPI `Machine` objects with the `cluster.x-k8s.io/cluster-name=<this-cluster>` label and the `cluster.x-k8s.io/control-plane` label.
+2. Picking a `Machine` whose `InfrastructureRef` points at a Beskar7Machine and whose status reports an `InternalIP` (with `ExternalIP` as fallback).
+3. Writing that address to `Status.ControlPlaneEndpoint`.
 
-- cluster-api
+If `Spec.ControlPlaneEndpoint.Host` is non-empty, the controller honors it authoritatively and skips discovery. If only `Spec.ControlPlaneEndpoint.Port` is set, discovery still finds the host but the user's port wins. The default port when neither is supplied is `6443`.
 
-## Specification
+### Failure domains
 
-### Required Fields
+The controller lists `PhysicalHost` resources in the same namespace, extracts unique values from the `topology.kubernetes.io/zone` label, and populates `Status.FailureDomains`:
 
-#### controlPlaneEndpoint
-- **host** (string, required): The hostname or IP address of the control plane endpoint
-- **port** (integer, required): The port number of the control plane endpoint
+```yaml
+metadata:
+  labels:
+    topology.kubernetes.io/zone: rack-1
+```
 
-### Optional Fields
+CAPI uses these for placement.
 
-#### failureDomains
-Map of failure domains with their attributes:
-- **attributes** (map[string]string): Key-value pairs of domain attributes
-- **controlPlane** (boolean): Whether this domain can host control plane nodes
+## Conditions
 
-## Status
+| Type | Meaning | Common reasons |
+|---|---|---|
+| `ControlPlaneEndpointReady` | The endpoint is populated. | `ControlPlaneEndpointNotSet`. |
 
-### ready
-- **ready** (boolean): Indicates if the cluster infrastructure is ready for bootstrapping
+## Webhook
 
-### failureDomains
-Map of failure domains with their current status:
-- **attributes** (map[string]string): Key-value pairs of domain attributes
-- **controlPlane** (boolean): Whether this domain can host control plane nodes
+`Beskar7Cluster` has a validating webhook that checks `controlPlaneEndpoint.host` (IP or hostname) and `port` (1–65535). The webhook ships with `failurePolicy: Fail`, so a Pods/Beskar7Cluster admission attempt without a healthy webhook service is rejected.
 
-## Additional Printer Columns
-
-- **Cluster**: Cluster to which this Beskar7Cluster belongs
-- **Endpoint**: Control Plane Endpoint Host
-- **Ready**: Cluster infrastructure is ready for bootstrapping
-- **Age**: Creation timestamp
+There are no defaulting webhooks. The other CRDs (`PhysicalHost`, `Beskar7Machine`, `Beskar7MachineTemplate`) have no webhooks at all.
 
 ## Example
 
@@ -60,58 +62,47 @@ Map of failure domains with their current status:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Beskar7Cluster
 metadata:
-  name: my-cluster
+  name: production-cluster
   namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: production-cluster
 spec:
   controlPlaneEndpoint:
-    host: 192.168.1.100
+    host: "10.0.1.10"
     port: 6443
 ```
 
-## Fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `spec.controlPlaneEndpoint` | `APIEndpoint` | The endpoint used to communicate with the control plane. |
-| `status.ready` | `bool` | Indicates that the cluster is ready. |
-| `status.controlPlaneEndpoint` | `APIEndpoint` | The endpoint used to communicate with the control plane. |
-| `status.failureDomains` | `FailureDomains` | A list of failure domain objects synced from the infrastructure provider. |
-| `status.conditions` | `Conditions` | Current service state of the Beskar7Cluster. |
+Pair with a CAPI `Cluster`:
 
 ```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7Cluster
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
 metadata:
-  name: example-cluster
+  name: production-cluster
   namespace: default
-  labels:
-    cluster.x-k8s.io/cluster-name: example-cluster
 spec:
-  controlPlaneEndpoint:
-    host: "192.168.1.100"
-    port: 6443
-  failureDomains:
-    rack-1:
-      attributes:
-        rack: "1"
-        row: "A"
-      controlPlane: true
-    rack-2:
-      attributes:
-        rack: "2"
-        row: "A"
-      controlPlane: false
-status:
-  ready: true
-  failureDomains:
-    rack-1:
-      attributes:
-        rack: "1"
-        row: "A"
-      controlPlane: true
-    rack-2:
-      attributes:
-        rack: "2"
-        row: "A"
-      controlPlane: false
-``` 
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["10.244.0.0/16"]
+    services:
+      cidrBlocks: ["10.96.0.0/12"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: Beskar7Cluster
+    name: production-cluster
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: production-cluster-control-plane
+```
+
+## Print columns
+
+`kubectl get beskar7cluster` shows `Cluster`, `Ready`, `Endpoint`, and `Age`.
+
+## See also
+
+- [API Reference: Beskar7Cluster](api-reference.md#beskar7cluster)
+- [Beskar7Machine](beskar7machine.md)
+- [Architecture](architecture.md)
+- [Examples](../examples/)

--- a/docs/beskar7machine.md
+++ b/docs/beskar7machine.md
@@ -1,95 +1,84 @@
 # Beskar7Machine
 
-The `Beskar7Machine` resource represents a machine in the Beskar7 infrastructure provider.
+`Beskar7Machine` is the Beskar7 CRD that implements the CAPI infrastructure-machine contract. The reconciler that owns it is `controllers/beskar7machine_controller.go`. One Beskar7Machine maps to one Kubernetes node.
 
-## API Version
+For the full field reference, see [API Reference: Beskar7Machine](api-reference.md#beskar7machine). This page covers operational behavior — the reconcile flow, what conditions mean, how failures surface.
 
-`infrastructure.cluster.x-k8s.io/v1beta1`
+## Identity
 
-## Kind
+- **API:** `infrastructure.cluster.x-k8s.io/v1beta1`
+- **Kind:** `Beskar7Machine`
+- **Scope:** Namespaced
+- **Categories:** `cluster-api`
 
-`Beskar7Machine`
+## Spec at a glance
 
-## Namespaced
+```yaml
+spec:
+  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  configurationURL:   "http://boot-server.local/configs/worker.yaml"   # optional
+  hardwareRequirements:                                                 # optional
+    minCPUCores: 4
+    minMemoryGB: 8
+    minDiskGB:   50
+  # providerID is set by the controller on claim — do not set manually
+```
 
-Yes
+All three URL fields must match `^https?://.*`. There is no `osFamily`, `imageURL`, `bootMode`, `provisioningMode`, or `configURL` — those v0.3 fields were removed in v0.4.
 
-## Specification
+## Reconcile flow
 
-### Required Fields
+The reconciler runs through these phases. Each phase corresponds to a state of the claimed `PhysicalHost`.
 
-#### imageURL
-- **imageURL** (string, required): URL of the machine image to use
+1. **Wait for owner Machine.** If the owning CAPI `Machine` does not have an `OwnerReference` to this Beskar7Machine yet, requeue.
+2. **Bootstrap data check.** Read `Machine.Spec.Bootstrap.DataSecretName`. If unset, mark `BootstrapDataReady=False (WaitingForBootstrapData)` and requeue. If set but the Secret is not found, mark `BootstrapDataReady=False (BootstrapDataUnavailable)` and set `FailureReason` (terminal).
+3. **Claim a host.** `findAndClaimOrGetAssociatedHost` lists `PhysicalHost` objects in the namespace filtered by the `status.state` field index for `Available`. The first host with no `ConsumerRef` is claimed via an optimistic-locking patch. Concurrent claims fail fast with `Conflict`; the loser requeues. See `controllers/beskar7machine_controller.go:findAndClaimOrGetAssociatedHost`.
+4. **Signal the bootstrap URL.** Compute the URL deterministically as `<--bootstrap-url-base>/api/v1/bootstrap/<ns>/<host>` and patch `infrastructure.cluster.x-k8s.io/bootstrap-url` onto the host's annotations. The host reconciler persists it to `Status.Bootstrap.URL`.
+5. **Trigger inspection.** When the host transitions to `InUse`:
+    - Open a Redfish client with the host's credentials.
+    - `SetBootSourcePXE` then `SetPowerState(On)` if not already powered on.
+    - Mint a per-host bearer token unless an unexpired one is already in `Status.Bootstrap` (re-using avoids invalidating in-flight kernel cmdlines). The plaintext goes into a per-host Secret (`<host>-bootstrap-token`); only the SHA-256 hash and lifetime ride the `bootstrap-token` annotation. See `internal/auth/token.go` and decision D-004.
+    - Patch the `inspection-request` annotation on the host with value `inspect`. The host reconciler transitions to `Inspecting`.
+6. **Wait for inspection.** While the host is `Inspecting`, monitor `Status.InspectionPhase`. If `Status.InspectionTimestamp` is older than `DefaultInspectionTimeout` (10 minutes), call `markTerminalFailure(InspectionTimedOut, ...)` and stop. Inspection timeout is terminal — the operator must investigate (likely an iPXE misconfiguration) and delete-and-recreate.
+7. **Validate hardware.** When `Status.InspectionPhase == Complete`, sum CPU cores across `report.cpus[]`, parse memory across `report.memory[]` (using the `parseMemoryCapacityGB` helper for `GB`/`GiB`/`MB`/`MiB`/`TB`/`TiB` suffixes), and sum disk size across `report.disks[]`. If any minimum is violated, call `markTerminalFailure(HardwareRequirementsNotMet, ...)`. Hardware-validation failures are terminal — the BMC's hardware does not change at runtime.
+8. **Mark ready.** When validation passes, signal the host (`inspection-request: inspect-complete`) which moves the host to `Ready`. The Beskar7Machine then sets `Spec.ProviderID = b7://<ns>/<name>`, copies addresses from the host, and sets `InfrastructureReady=True` and `Status.Ready=true`.
 
-#### osFamily
-- **osFamily** (string, required): The operating system family to use. Must be one of:
-  - `kairos` - Kairos cloud-native OS (recommended)
-  - `flatcar` - Flatcar Container Linux
-  - `LeapMicro` - openSUSE Leap Micro
+## Conditions
 
-**Note:** Only the OS families listed above are currently supported with full RemoteConfig provisioning capabilities.
+| Type | Meaning | Common reasons |
+|---|---|---|
+| `InfrastructureReady` | Standard CAPI infra-ready condition. Summary across the others. | – |
+| `PhysicalHostAssociated` | A host has been claimed. | `WaitingForPhysicalHost`, `PhysicalHostAssociationFailed`. |
+| `MachineProvisioned` | Host is `Ready` and `ProviderID` is set. | – |
+| `BootstrapDataReady` | `Machine.Spec.Bootstrap.DataSecretName` is set and the URL has been signalled. | `WaitingForBootstrapData`, `BootstrapDataUnavailable`. |
 
-### Optional Fields
+## Terminal failures
 
-#### configURL
-- **configURL** (string, optional): URL of the configuration to use for the machine. Required when provisioningMode is "RemoteConfig".
+These set `Status.FailureReason` and `Status.FailureMessage`. Once set, the controller stops requeueing — operator must intervene. CAPI surfaces both fields in `kubectl describe machine`.
 
-#### providerID
-- **providerID** (string, optional): Provider-specific identifier for the machine. Automatically set by the controller.
+| Reason | Trigger |
+|---|---|
+| `BootstrapDataUnavailable` | The Secret named by `Machine.Spec.Bootstrap.DataSecretName` does not exist. |
+| `HardwareRequirementsNotMet` | Inspection report falls below `hardwareRequirements`. |
+| `InspectionTimedOut` | No inspection report received within `DefaultInspectionTimeout` (10 min). |
 
-#### provisioningMode
-- **provisioningMode** (string, optional, default: "RemoteConfig"): The mode to use for provisioning. Must be one of:
-  - `RemoteConfig` - Boot generic ISO with configuration URL (requires configURL)
-  - `PreBakedISO` - Boot pre-configured ISO (configURL should not be set). Use this when the OS config is embedded into the ISO.
-  - `PXE` - PXE network boot (requires external PXE infrastructure)
-  - `iPXE` - iPXE network boot (requires external iPXE infrastructure)
+To recover, delete the Beskar7Machine (and its owner `Machine`); the host returns to `Available` and a fresh attempt can be made.
 
-#### bootMode
-- **bootMode** (string, optional, default: "UEFI"): The firmware boot mode to use. Must be one of:
-  - `UEFI` - UEFI boot mode (recommended for modern systems)
-  - `Legacy` - Legacy BIOS boot mode
+## Deletion
 
-## Status
+`reconcileDelete` runs:
 
-### addresses
-Array of machine addresses:
-- **address** (string, required): The address value
-- **type** (string, required): The type of address. Must be one of:
-  - `Hostname`
-  - `ExternalIP`
-  - `InternalIP`
-  - `ExternalDNS`
-  - `InternalDNS`
+1. If a `ProviderID` is set and the parsed host exists with `ConsumerRef.Name == this.Name`:
+    - Best-effort: open the Redfish client and call `ClearBootSourceOverride` then `SetPowerState(Off)` (graceful). All errors are logged and swallowed so a dead BMC cannot strand the finalizer.
+    - Patch `ConsumerRef = nil` on the host with optimistic locking.
+2. Remove the finalizer (`beskar7machine.infrastructure.cluster.x-k8s.io`).
 
-### conditions
-Array of conditions representing the latest available observations of the object's state:
-- **lastTransitionTime** (string, required): Last time the condition transitioned
-- **message** (string, required): Human-readable message indicating details about the transition
-- **reason** (string, required): One-word CamelCase reason for the condition's last transition
-- **severity** (string): Severity level of the condition
-- **status** (string, required): Status of the condition
-- **type** (string, required): Type of the condition
+The `infrastructure.cluster.x-k8s.io/force-release: "true"` annotation skips the Redfish steps entirely. Use only when the BMC is permanently unreachable.
 
-### failureMessage
-- **failureMessage** (string): Error message describing any failure
+## ProviderID format
 
-### failureReason
-- **failureReason** (string): Reason for any failure
-
-### phase
-- **phase** (string): Current phase of the machine
-
-### ready
-- **ready** (boolean): Indicates if the machine is ready
-
-## Additional Printer Columns
-
-- **Cluster**: Cluster to which this Beskar7Machine belongs
-- **State**: Current state of the Beskar7Machine
-- **Ready**: Machine ready status
-- **ProviderID**: Provider ID
-- **Machine**: Machine object which owns this Beskar7Machine
-- **Age**: Creation timestamp
+The provider ID is `b7://<namespace>/<name>`. The parser uses `strings.CutPrefix` + `strings.SplitN(rest, "/", 2)` and rejects empty segments and multi-segment names. See `controllers/beskar7machine_controller.go:parseProviderID`.
 
 ## Example
 
@@ -100,46 +89,26 @@ metadata:
   name: control-plane-01
   namespace: default
   labels:
-    cluster.x-k8s.io/cluster-name: "my-cluster"
-    cluster.x-k8s.io/control-plane: ""
+    cluster.x-k8s.io/cluster-name: production-cluster
+    cluster.x-k8s.io/control-plane: "true"
 spec:
-  imageURL: "https://releases.kairos.io/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-  configURL: "https://config.example.com/control-plane.yaml"
-  osFamily: "kairos"
-  provisioningMode: "RemoteConfig"
-status:
-  ready: true
-  phase: "Running"
-  addresses:
-    - type: "InternalIP"
-      address: "10.0.1.10"
-    - type: "ExternalIP"
-      address: "203.0.113.10"
-  conditions:
-    - type: "InfrastructureReady"
-      status: "True"
-      lastTransitionTime: "2024-01-01T00:00:00Z"
-      reason: "ProvisioningComplete"
-      message: "Infrastructure is ready"
-    - type: "PhysicalHostAssociated"
-      status: "True"
-      lastTransitionTime: "2024-01-01T00:00:00Z"
-      reason: "HostClaimed"
-      message: "Successfully associated with PhysicalHost server-01"
+  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  configurationURL:   "http://boot-server.local/configs/control-plane.yaml"
+  hardwareRequirements:
+    minCPUCores: 4
+    minMemoryGB: 16
+    minDiskGB:   100
 ```
 
-## Fields
+## Print columns
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `spec.providerID` | `string` | The unique identifier as specified by the cloud provider. |
-| `spec.imageURL` | `string` | The URL of the OS image to use for the machine. |
-| `spec.configURL` | `string` | The URL of the configuration to use for the machine. |
-| `spec.osFamily` | `string` | The operating system family to use for the machine. |
-| `spec.provisioningMode` | `string` | The mode to use for provisioning the machine. |
-| `status.ready` | `bool` | Indicates that the machine is ready. |
-| `status.addresses` | `[]MachineAddress` | The associated addresses for the machine. |
-| `status.phase` | `string` | The current phase of machine actuation. |
-| `status.failureReason` | `string` | A succinct value suitable for machine interpretation in case of terminal problems. |
-| `status.failureMessage` | `string` | A more verbose string suitable for logging and human consumption in case of terminal problems. |
-| `status.conditions` | `Conditions` | Current service state of the Beskar7Machine. | 
+`kubectl get beskar7machine` shows `Cluster`, `Machine`, `Phase`, and `Age`.
+
+## See also
+
+- [API Reference: Beskar7Machine](api-reference.md#beskar7machine)
+- [State Management](state-management.md)
+- [Architecture](architecture.md)
+- [Beskar7MachineTemplate](beskar7machinetemplate.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/beskar7machinetemplate.md
+++ b/docs/beskar7machinetemplate.md
@@ -1,257 +1,135 @@
 # Beskar7MachineTemplate
 
-The Beskar7MachineTemplate custom resource defines a template for creating Beskar7Machine resources. It provides a way to define reusable machine configurations that are validated and enforced by admission webhooks.
+`Beskar7MachineTemplate` is a pure schema. CAPI's `KubeadmControlPlane` and `MachineDeployment` reference it to mint `Beskar7Machine` objects with the same spec.
 
-## API Version
+There is **no** Beskar7MachineTemplate controller, **no** validating or defaulting webhook, and **no** immutability enforcement. The template's `template.spec` is whatever any author writes; CAPI clones it onto each `Beskar7Machine`. Validation of the inner spec happens when the cloned `Beskar7Machine` hits the API server (OpenAPI schema rules from `api/v1beta1/beskar7machine_types.go`).
 
-`infrastructure.cluster.x-k8s.io/v1beta1`
+## Identity
 
-## Kind
+- **API:** `infrastructure.cluster.x-k8s.io/v1beta1`
+- **Kind:** `Beskar7MachineTemplate`
+- **Short name:** `b7mt`
+- **Scope:** Namespaced
+- **Categories:** `cluster-api` (so `clusterctl move` walks it during workload-cluster migration)
 
-`Beskar7MachineTemplate`
+## Spec
 
-## Short Name
-
-`b7mt`
-
-## Namespaced
-
-Yes
-
-## Categories
-
-- cluster-api
-
-## Specification
-
-### Required Fields
-
-#### template
-- **spec** (object, required): The template specification for the machine
-
-##### spec.imageURL
-- **imageURL** (string, required): URL of the machine image to use
-- **Validation**: Must be a valid URL with supported schemes (http, https, file, ftp)
-- **Supported formats**: .iso, .img, .qcow2, .vmdk, .raw, .vhd, .vhdx, .ova, .ovf and compressed variants
-
-##### spec.osFamily
-- **osFamily** (string, required): The operating system family to use. Must be one of:
-  - `kairos` - Kairos cloud-native OS (recommended)
-  - `flatcar` - Flatcar Container Linux
-  - `LeapMicro` - openSUSE Leap Micro
-
-**Note:** Only the OS families listed above are currently supported with full RemoteConfig provisioning capabilities.
-
-### Optional Fields
-
-##### spec.configURL
-- **configURL** (string, optional): URL of the configuration to use for the machine
-- **Validation**: Must be a valid URL pointing to a configuration file (.yaml, .yml, .json, .toml, .conf, .cfg, .ini, .properties)
-- **Required for**: RemoteConfig provisioning mode
-- **Forbidden for**: PreBakedISO provisioning mode
-
-##### spec.provisioningMode
-- **provisioningMode** (string, optional, default: "RemoteConfig"): The mode to use for provisioning. Must be one of:
-  - `RemoteConfig` - Boot generic ISO with configuration URL (requires configURL)
-  - `PreBakedISO` - Boot pre-configured ISO (configURL not allowed)
-  - `PXE` - PXE boot (future implementation)
-  - `iPXE` - iPXE boot (future implementation)
-
-## Webhook Validation
-
-Beskar7MachineTemplate resources are validated by admission webhooks that enforce:
-
-### Creation Validation
-- **Template validation**: Reuses all Beskar7Machine validation logic
-- **ProviderID restriction**: `providerID` cannot be set in templates (it's managed by the controller)
-- **Cross-field validation**: Ensures configURL is provided when required and forbidden when not allowed
-
-### Update Validation (Immutability)
-Templates are **immutable after creation** to ensure consistency for machines created from the template:
-
-- `imageURL` cannot be changed
-- `osFamily` cannot be changed 
-- `provisioningMode` cannot be changed
-- `configURL` cannot be changed
-
-**Rationale**: Changing template specifications could affect existing machines or cause inconsistencies in machine provisioning.
-
-### Defaulting
-- Applies the same defaulting logic as Beskar7Machine webhooks
-- Ensures consistent behavior across all machine-related resources
-
-## Example
+The spec wraps a `Beskar7MachineSpec` exactly:
 
 ```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7MachineTemplate
-metadata:
-  name: worker-template
-  namespace: default
 spec:
   template:
     spec:
-      imageURL: "https://releases.kairos.io/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-      osFamily: "kairos"
-      configURL: "https://config.example.com/worker.yaml"
-      provisioningMode: "RemoteConfig"
+      # Identical to Beskar7Machine.spec
+      inspectionImageURL: ...
+      targetImageURL: ...
+      configurationURL: ...
+      hardwareRequirements:
+        minCPUCores: ...
+        minMemoryGB: ...
+        minDiskGB: ...
 ```
 
-## Common Use Cases
+For the field reference, see [API Reference: Beskar7Machine](api-reference.md#beskar7machine).
 
-### 1. Control Plane Template
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7MachineTemplate
-metadata:
-  name: control-plane-template
-  namespace: cluster-system
-spec:
-  template:
-    spec:
-      imageURL: "https://releases.kairos.io/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-      osFamily: "kairos"
-      configURL: "https://config.example.com/control-plane.yaml"
-      provisioningMode: "RemoteConfig"
-```
+## CAPI integration
 
-### 2. Worker Node Template  
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7MachineTemplate
-metadata:
-  name: worker-template
-  namespace: cluster-system
-spec:
-  template:
-    spec:
-      imageURL: "https://releases.kairos.io/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-      osFamily: "kairos"
-      configURL: "https://config.example.com/worker.yaml" 
-      provisioningMode: "RemoteConfig"
-```
-
-### 3. Pre-baked ISO Template
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7MachineTemplate
-metadata:
-  name: prebaked-template
-  namespace: cluster-system
-spec:
-  template:
-    spec:
-      imageURL: "https://storage.example.com/custom-worker-v1.0.iso"
-      osFamily: "ubuntu"
-      provisioningMode: "PreBakedISO"
-      # Note: configURL is not allowed for PreBakedISO mode
-```
-
-## Integration with Cluster API
-
-Beskar7MachineTemplate is typically used by Cluster API resources:
+### KubeadmControlPlane
 
 ```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: my-cluster-control-plane
+  name: production-control-plane
+  namespace: default
 spec:
+  replicas: 3
+  version: v1.31.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: Beskar7MachineTemplate
-      name: control-plane-template
-      namespace: cluster-system
-  # ... other KubeadmControlPlane fields
+      name: production-control-plane
+  kubeadmConfigSpec:
+    # ... cluster init/join config
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineDeployment
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Beskar7MachineTemplate
 metadata:
-  name: my-cluster-workers
+  name: production-control-plane
+  namespace: default
 spec:
   template:
     spec:
+      inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+      targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+      configurationURL:   "http://boot-server.local/configs/control-plane.yaml"
+      hardwareRequirements:
+        minCPUCores: 4
+        minMemoryGB: 16
+        minDiskGB:   100
+```
+
+### MachineDeployment
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: production-workers
+  namespace: default
+spec:
+  clusterName: production-cluster
+  replicas: 3
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: production-cluster
+      cluster.x-k8s.io/deployment-name: production-workers
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: production-cluster
+        cluster.x-k8s.io/deployment-name: production-workers
+    spec:
+      clusterName: production-cluster
+      version: v1.31.0
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: production-workers
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Beskar7MachineTemplate
-        name: worker-template
-        namespace: cluster-system
-  # ... other MachineDeployment fields
-```
-
-## Troubleshooting
-
-### Common Validation Errors
-
-1. **Invalid imageURL**: 
-   ```
-   Error: "imageURL should point to a valid image file"
-   ```
-   Ensure the URL points to a supported image format.
-
-2. **Unsupported osFamily**:
-   ```
-   Error: "osFamily 'windows' is not supported"
-   ```
-   Use one of the supported OS families listed above.
-
-3. **Immutability violation**:
-   ```
-   Error: "imageURL is immutable in machine templates"
-   ```
-   Template specifications cannot be changed after creation. Create a new template instead.
-
-4. **ProviderID in template**:
-   ```
-   Error: "providerID should not be set in machine templates"
-   ```
-   Remove the providerID field from the template specification.
-
-## Controller Behavior
-
-The Beskar7MachineTemplate controller provides automated lifecycle management for template resources:
-
-### Finalizer Management
-- Automatically adds the `beskar7machinetemplate.infrastructure.cluster.x-k8s.io` finalizer on creation
-- Manages proper cleanup when templates are deleted
-
-### Reference Tracking
-- **Deletion Protection**: Templates cannot be deleted while machines still reference them
-- **Automatic Detection**: Controller watches Beskar7Machine resources for owner references
-- **Graceful Cleanup**: Prevents orphaned machines by blocking template deletion until all references are removed
-
-### Template Validation
-- **Runtime Validation**: Controller performs additional validation beyond webhook checks
-- **Integrity Checks**: Ensures ImageURL and OSFamily are properly specified
-- **Error Reporting**: Validation failures are logged and reported through controller status
-
-### Event Watching
-The controller automatically responds to:
-- **Machine Creation/Deletion**: Updates reference tracking when machines are created/destroyed
-- **Template Changes**: Immediately validates and processes template modifications
-- **Cleanup Events**: Triggers reference checks when machines or templates are deleted
-
-### Metrics Integration
-- **Reconciliation Metrics**: Tracks successful/failed reconciliations with timing data
-- **Error Tracking**: Records error types and frequencies for monitoring
-- **Performance Monitoring**: Provides duration metrics for operations
-
-### Pause Support
-Templates support the standard Cluster API pause annotation:
-```yaml
+        name: production-workers
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Beskar7MachineTemplate
 metadata:
-  annotations:
-    cluster.x-k8s.io/paused: "true"
+  name: production-workers
+  namespace: default
+spec:
+  template:
+    spec:
+      inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+      targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+      configurationURL:   "http://boot-server.local/configs/worker.yaml"
+      hardwareRequirements:
+        minCPUCores: 4
+        minMemoryGB: 8
+        minDiskGB:   50
 ```
-When paused, the controller skips reconciliation until the annotation is removed.
 
-### Best Practices
+## Versioning
 
-- **Version your templates**: Use descriptive names with versions (e.g., `worker-template-v1.2`)
-- **Test before deployment**: Validate templates in development environments
-- **Create new templates for changes**: Since templates are immutable, create new versions instead of trying to modify existing ones
-- **Use appropriate provisioning modes**: Choose RemoteConfig for flexibility or PreBakedISO for speed
-- **Validate URLs**: Ensure imageURL and configURL are accessible from your cluster nodes
-- **Monitor references**: Use `kubectl describe` to check which machines reference a template before deletion
-- **Clean deletion**: Ensure all machines using a template are deleted before removing the template 
+Because there is no immutability webhook, editing a template's `template.spec` is silently allowed by the API server. CAPI's behavior is to keep existing `Beskar7Machine` objects unchanged but use the new template for any future replicas. If you want strict separation, version the template's name (`worker-template-v1`, `worker-template-v2`) and update the consuming `MachineDeployment` / `KubeadmControlPlane` to reference the new name.
+
+## Print columns
+
+`kubectl get beskar7machinetemplate` shows the standard `kubectl` columns (no custom print columns are defined).
+
+## See also
+
+- [API Reference: Beskar7Machine](api-reference.md#beskar7machine)
+- [Beskar7Machine](beskar7machine.md)
+- [Examples](../examples/)

--- a/docs/deployment-best-practices.md
+++ b/docs/deployment-best-practices.md
@@ -238,10 +238,10 @@ networkPolicy:
       - protocol: TCP
         port: 9443
 
-# Monitoring
+# Monitoring (metrics are HTTPS on :8443; see docs/metrics.md)
 metrics:
   enabled: true
-  port: 8080
+  port: 8443
   
 # Webhook configuration
 webhook:
@@ -352,14 +352,14 @@ spec:
     ports:
     - protocol: TCP
       port: 9443
-  # Metrics scraping
+  # Metrics scraping (HTTPS, kube-apiserver-authenticated; see docs/metrics.md)
   - from:
     - namespaceSelector:
         matchLabels:
           name: monitoring
     ports:
     - protocol: TCP
-      port: 8080
+      port: 8443
   egress:
   # DNS resolution
   - to: []
@@ -457,13 +457,14 @@ spec:
 
 **Structured Logging:**
 ```yaml
-# Manager deployment logging configuration
+# Manager deployment logging configuration. The default zap logger emits
+# structured JSON suitable for ingestion. To get the development encoder
+# (console output, stack traces from Warn), pass --zap-devel=true.
 args:
 - --health-probe-bind-address=:8081
-- --metrics-bind-address=127.0.0.1:8080
-- --leader-elect
-- --v=2  # Production log level
-- --log-format=json  # Structured logging
+- --metrics-bind-address=:8443     # HTTPS, kube-apiserver-authenticated
+- --secure-metrics=true
+- --leader-elect=true
 ```
 
 **Log Aggregation:**
@@ -540,19 +541,21 @@ spec:
         summary: "High reconciliation error rate"
         description: "Beskar7 controller error rate is {{ $value }} errors/sec"
         
-    - alert: PhysicalHostStuckProvisioning
+    - alert: PhysicalHostStuckInspecting
+      # PhysicalHost states (api/v1beta1/physicalhost_types.go): Available, InUse,
+      # Inspecting, Ready, Error, Enrolling, Unknown. The metric is
+      # beskar7_controller_physicalhost_states_total (see docs/metrics.md).
       expr: |
-        (
-          increase(physical_host_state_total{state="Provisioning"}[1h]) == 0
-        ) and (
-          physical_host_state_total{state="Provisioning"} > 0
+        beskar7_controller_physicalhost_states_total{state="Inspecting"} > 0
+        unless on (namespace) (
+          increase(beskar7_controller_physicalhost_states_total{state="Inspecting"}[15m]) > 0
         )
-      for: 30m
+      for: 15m
       labels:
         severity: warning
       annotations:
-        summary: "PhysicalHost stuck in provisioning state"
-        description: "One or more PhysicalHosts have been stuck in Provisioning state for over 30 minutes"
+        summary: "PhysicalHost stuck in Inspecting state"
+        description: "PhysicalHosts have been in Inspecting state for over 15 minutes (> DefaultInspectionTimeout)."
 ```
 
 ## Operational Procedures
@@ -655,9 +658,11 @@ kubectl get secret -n beskar7-system
 kubectl get physicalhost -A
 kubectl describe physicalhost HOSTNAME
 
-# Check metrics
-kubectl port-forward -n beskar7-system svc/controller-manager-metrics-service 8080:8080
-curl http://localhost:8080/metrics
+# Check metrics (HTTPS on 8443; for plain-HTTP local debugging, restart the
+# manager with --secure-metrics=false). See docs/metrics.md.
+kubectl port-forward -n beskar7-system svc/beskar7-controller-manager-metrics-service 8443:8443
+TOKEN=$(kubectl create token -n monitoring prometheus)
+curl -k -H "Authorization: Bearer $TOKEN" https://localhost:8443/metrics
 ```
 
 ## Multi-Tenancy Considerations

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -8,9 +8,10 @@ Beskar7 acts as a bridge between the declarative Kubernetes API and the physical
 
 *   Define your bare-metal infrastructure (`PhysicalHost` resources) within Kubernetes.
 *   Provision Kubernetes nodes onto these physical hosts using `Beskar7Machine` resources, which integrate with CAPI `Machine` objects.
-*   Leverage immutable, cloud-native OSes like Kairos, Flatcar, and openSUSE Leap Micro using their specific provisioning methods (Remote Configuration via kernel parameters or Pre-Baked ISOs).
+*   Boot nodes via iPXE network boot to a hardware-inspection image, validate the report against operator-supplied hardware requirements, then kexec into the target OS (Kairos, Flatcar, or any image you host).
 *   Orchestrate cluster-level infrastructure using `Beskar7Cluster` resources.
-*   Support multiple provisioning modes including PXE and iPXE network boot.
+
+Beskar7 uses only universally-supported Redfish features (power state, one-time PXE boot, system info, network interface enumeration). It does not rely on Virtual Media, BIOS attribute editing, or vendor-specific Redfish extensions.
 
 ## Why Beskar7?
 

--- a/docs/ipxe-setup.md
+++ b/docs/ipxe-setup.md
@@ -302,7 +302,10 @@ echo MAC: ${net0/mac}
 echo IP: ${net0/ip}
 
 # Set variables
-set beskar7-api http://beskar7-controller.cluster.local:8080
+# The Beskar7 callback endpoint is HTTPS on :8082. It hosts both the inspection
+# POST and the bootstrap GET. Both require an Authorization: Bearer header — the
+# token is per-host and is rendered into the kernel cmdline (see below).
+set beskar7-api https://beskar7-controller-manager.beskar7-system.svc:8082
 set boot-server http://boot-server.local
 
 # Boot inspection image
@@ -314,24 +317,48 @@ sleep 30
 reboot
 EOF
 
-# Create inspection boot script
+# Create inspection boot script.
+#
+# The inspection kernel cmdline must include four Beskar7-specific variables:
+#
+#   beskar7.api              Base URL of the manager's callback endpoint (https://...:8082).
+#                             Used by the inspector to POST the report and by the target OS
+#                             to GET bootstrap data.
+#   beskar7.namespace        Namespace of the PhysicalHost (path component for both endpoints).
+#   beskar7.host             Name of the PhysicalHost (path component for both endpoints).
+#   beskar7.token            Plaintext per-host bearer token. Sent in the Authorization
+#                             header of every request to :8082. Lifetime: 30 minutes.
+#                             Source: Secret <host>-bootstrap-token, key plaintext-token.
+#
+# The bootstrap endpoint URL is computed deterministically from --bootstrap-url-base
+# and exposed as beskar7.bootstrap-url for consumers (cloud-init, ignition) that
+# prefer reading a single URL over assembling one from parts.
+#
+# In a real deployment the iPXE script is rendered per host by your boot infrastructure
+# (Tinkerbell, dnsmasq + a CGI script, an internal HTTP service, etc.) — the snippets
+# below show the variable shape that infrastructure must produce.
 cat > /var/www/boot/ipxe/inspect.ipxe << 'EOF'
 #!ipxe
 
 echo Booting Beskar7 Inspector...
 
-# Beskar7 API endpoint
-set api-url http://beskar7-controller.cluster.local:8080
-
-# Host identification
-set host-mac ${net0/mac}
-set host-ip ${net0/ip}
+# Operator-controlled variables. In production these come from your DHCP/iPXE
+# infrastructure rendering a per-host boot script.
+set api-url       https://beskar7-controller-manager.beskar7-system.svc:8082
+set namespace     default
+set host-name     ${net0/mac:hexhyp}      # adapt to your naming scheme
+set bootstrap-url ${api-url}/api/v1/bootstrap/${namespace}/${host-name}
+# Plaintext bearer token for THIS host — render from the per-host Secret
+# <host>-bootstrap-token, data key plaintext-token. NEVER bake into a static script.
+set bearer-token  REPLACE_WITH_PER_HOST_TOKEN
 
 # Boot Alpine inspection kernel
 kernel http://boot-server.local/inspector/vmlinuz \
     beskar7.api=${api-url} \
-    beskar7.mac=${host-mac} \
-    beskar7.ip=${host-ip} \
+    beskar7.namespace=${namespace} \
+    beskar7.host=${host-name} \
+    beskar7.bootstrap-url=${bootstrap-url} \
+    beskar7.token=${bearer-token} \
     console=tty0 \
     console=ttyS0,115200
 
@@ -466,12 +493,19 @@ sudo ufw allow 443/tcp
 
 ### Beskar7 Controller
 
-```bash
-# Allow webhook (if inspection reports via HTTP)
-sudo ufw allow 8080/tcp
+The manager listens on:
 
-# Allow Kubernetes API
-sudo ufw allow 6443/tcp
+- `:8443` — Prometheus metrics (HTTPS, authenticated; see [Security](security/README.md)).
+- `:8082` — host callback endpoint (HTTPS, bearer-token-gated; receives inspection POST and serves bootstrap GET).
+- `:9443` — Beskar7Cluster webhook (when `--enable-webhook=true`).
+
+If the boot network is segregated from the cluster network, ensure the boot subnet can reach the manager on `:8082`. The chart's NetworkPolicy already allows ingress on `:8082` cluster-wide; bare-metal IPs are not allow-listed there because the bearer token is the access control. On host firewalls (controller pods aside):
+
+```bash
+# On any iptables-based firewall between the boot subnet and the cluster:
+# allow TCP/8082 to the manager Service IP / NodePort.
+sudo ufw allow 6443/tcp     # Kubernetes API
+sudo ufw allow 8082/tcp     # Beskar7 callback endpoint
 ```
 
 ## DNS Configuration

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,10 +1,12 @@
 # Monitoring and Metrics
 
-Beskar7 provides comprehensive monitoring and observability through Prometheus metrics. This document describes the available metrics, how to set up monitoring, and how to interpret the data.
+Beskar7 exposes Prometheus metrics for the controllers and the host-callback endpoint. This page lists what's actually registered (source of truth: `internal/metrics/metrics.go`), how to scrape them, and which ones are useful for alerting.
 
 ## Overview
 
-The Beskar7 controllers expose metrics on the `/metrics` endpoint (default port 8080) that can be scraped by Prometheus. These metrics provide insights into:
+The manager serves `/metrics` on `:8443` (HTTPS, authenticated via TokenReview/SubjectAccessReview delegated to the kube-apiserver — see [Security Configuration](security/configuration.md)). Scrapers must authenticate as a SA bound to the `metrics-reader` ClusterRole. For local development, set the manager flag `--secure-metrics=false`.
+
+The metrics provide insights into:
 
 - Controller reconciliation performance
 - PhysicalHost provisioning success/failure rates
@@ -62,13 +64,14 @@ These metrics track the state and health of physical hosts managed by Beskar7.
 **Labels:** `state`, `namespace`  
 **Description:** Number of PhysicalHosts in each state.
 
-**States:**
-- `available` - Host is available for provisioning
-- `claimed` - Host has been claimed by a machine
-- `provisioning` - Host is being provisioned
-- `provisioned` - Host has been successfully provisioned
-- `deprovisioning` - Host is being cleaned up
-- `error` - Host is in an error state
+**States** (match the `Status.State` strings — see `api/v1beta1/physicalhost_types.go:10-26`):
+- `Available`
+- `InUse`
+- `Inspecting`
+- `Ready`
+- `Error`
+- `Enrolling`
+- `Unknown`
 
 #### `beskar7_controller_physicalhost_provisioning_total`
 **Type:** Counter  
@@ -150,20 +153,22 @@ These metrics track cluster-level operations and failure domain discovery.
 
 ### Prometheus Configuration
 
-Add the following scrape configuration to your Prometheus config:
+Metrics are HTTPS-only and require a Kubernetes-authenticated bearer token. The simplest path is via the Prometheus Operator's `ServiceMonitor` with a SA bound to `metrics-reader`:
 
 ```yaml
-scrape_configs:
-  - job_name: 'beskar7-controller'
-    static_configs:
-      - targets: ['<beskar7-controller-service>:8080']
-    metrics_path: /metrics
-    scrape_interval: 30s
-```
-
-### ServiceMonitor (Prometheus Operator)
-
-```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: metrics-reader
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -172,12 +177,17 @@ metadata:
 spec:
   selector:
     matchLabels:
-      control-plane: beskar7-controller-manager
+      app.kubernetes.io/name: beskar7
   endpoints:
-  - port: metrics
-    interval: 30s
-    path: /metrics
+    - port: https-metrics            # match the chart's Service port name
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true     # cert-manager-issued cert covers the in-cluster Service DNS
+      interval: 30s
 ```
+
+For static scrape configs (no Operator), point Prometheus at the manager Service over HTTPS on port 8443 with bearer-token auth using the Prometheus SA's token.
 
 ### Grafana Dashboard
 

--- a/docs/physicalhost.md
+++ b/docs/physicalhost.md
@@ -1,134 +1,115 @@
 # PhysicalHost
 
-The `PhysicalHost` resource represents a physical host in the Beskar7 infrastructure provider.
+`PhysicalHost` is the Beskar7 CRD that represents one bare-metal server and its BMC connection. The reconciler that owns it is `controllers/physicalhost_controller.go`.
 
-## API Version
+For the full field reference, see [API Reference: PhysicalHost](api-reference.md#physicalhost). This page covers operational behavior — when fields move, what conditions mean, how the lifecycle works.
 
-`infrastructure.cluster.x-k8s.io/v1beta1`
+## Identity
 
-## Kind
+- **API:** `infrastructure.cluster.x-k8s.io/v1beta1`
+- **Kind:** `PhysicalHost`
+- **Short name:** `ph`
+- **Scope:** Namespaced
+- **Categories:** `cluster-api` (so `clusterctl move` walks it)
 
-`PhysicalHost`
+## Spec at a glance
 
-## Short Name
+```yaml
+spec:
+  redfishConnection:
+    address: "https://192.168.1.100"
+    credentialsSecretRef: "bmc-credentials"
+    insecureSkipVerify: false        # default
+    # caBundleSecretRef:             # optional, mutually exclusive with insecureSkipVerify=true
+    #   name: bmc-ca-bundle
+  # consumerRef is set by the Beskar7Machine controller; do not set manually
+```
 
-`ph`
+The credentials Secret must contain `username` and `password` keys (Opaque). It must live in the same namespace as the PhysicalHost.
 
-## Namespaced
+When `caBundleSecretRef` is set, the manager builds an HTTP client whose TLS roots include the CA bundle. The Secret data must contain a `ca.crt` (preferred) or `tls.crt` key with PEM bytes. Setting `caBundleSecretRef` together with `insecureSkipVerify: true` is rejected — the controller marks `RedfishConnectionReady = False (InsecureCABundleConflict)` and stops reconciling until the operator fixes the spec.
 
-Yes
+## Lifecycle
 
-## Specification
+The reconciler drives `Status.State` through these transitions:
 
-### Required Fields
+```
+created → Available           (BMC reachable, no consumer)
+Available → InUse             (Beskar7Machine claims via spec.consumerRef)
+InUse → Inspecting            (Beskar7Machine sets the inspection-request annotation)
+Inspecting → Ready            (inspection report consumed from ConfigMap)
+Ready → InUse                 (back to InUse after the host stays claimed)
+any → Error                   (BMC unreachable, TLS conflict, inspection timeout)
+Error → Available             (operator fixes spec, BMC recovers)
+Ready/InUse → Available       (Beskar7Machine deletion clears consumerRef)
+```
 
-#### redfishConnection
-- **address** (string, required): URL of the Redfish API endpoint (e.g., https://192.168.1.100)
-- **credentialsSecretRef** (string, required): Reference to a Secret containing username and password for Redfish authentication
-- **insecureSkipVerify** (boolean, optional): Whether to skip TLS certificate verification
+For the diagram and the full transition table, see [State Management](state-management.md).
 
-### Optional Fields
+## Bootstrap signaling
 
-#### consumerRef
-Reference to the Beskar7Machine that is using this host. Contains standard Kubernetes object reference fields:
-- **apiVersion** (string)
-- **kind** (string)
-- **name** (string)
-- **namespace** (string)
-- **fieldPath** (string)
-- **resourceVersion** (string)
-- **uid** (string)
+When the Beskar7Machine controller has bootstrap data ready, it patches two annotations on the PhysicalHost. The PhysicalHost reconciler reads them on its next pass, persists the values to status, and clears the annotation:
 
-#### bootIsoSource
-- **bootIsoSource** (string, optional): URL of the ISO image to use for provisioning. Set by the consumer (Beskar7Machine controller) to trigger provisioning.
+| Annotation | Persisted to | Source code |
+|---|---|---|
+| `infrastructure.cluster.x-k8s.io/bootstrap-url` | `Status.Bootstrap.URL` | `controllers/physicalhost_controller.go:applyBootstrapURLAnnotation` |
+| `infrastructure.cluster.x-k8s.io/bootstrap-token` | `Status.Bootstrap.{TokenHash, IssuedAt, ExpiresAt}` | `controllers/physicalhost_controller.go:applyBootstrapTokenAnnotation` |
 
-#### userDataSecretRef
-- **name** (string, optional): Reference to a secret containing cloud-init user data
+The plaintext bearer token is delivered out-of-band via a Secret named `<host-name>-bootstrap-token`, owned by the PhysicalHost (so it is GC'd when the host is deleted). The Secret has a single key: `plaintext-token`.
 
-## Status
+## Inspection result handoff
 
-### ready
-- **ready** (boolean, default: false): Indicates if the host is ready and enrolled
+The inspection HTTP handler does not write to `PhysicalHost.Status` directly. Instead, it stores the validated `InspectionReport` on a ConfigMap named `<host>-inspection-result` (owner-ref → PhysicalHost) and patches an `infrastructure.cluster.x-k8s.io/inspection-result-ref` annotation onto the host. The reconciler consumes the ConfigMap, writes the report to `Status.InspectionReport`, marks `HostInspected=True`, deletes the ConfigMap, and clears the annotation. This keeps the controller as the sole writer of the host's status (decision D-005 in `.claude/context/PROJECT_CONTEXT.md`).
 
-### state
-- **state** (string): Current provisioning state, which can be one of:
-  - `""` (empty string) - StateNone: Default state before reconciliation
-  - `"Enrolling"` - StateEnrolling: Controller is trying to establish connection
-  - `"Available"` - StateAvailable: Host is ready to be claimed
-  - `"Claimed"` - StateClaimed: Host is reserved by a consumer
-  - `"Provisioning"` - StateProvisioning: Host is being configured
-  - `"Provisioned"` - StateProvisioned: Host has been successfully configured
-  - `"Deprovisioning"` - StateDeprovisioning: Host is being cleaned up
-  - `"Error"` - StateError: Host is in an error state
-  - `"Unknown"` - StateUnknown: Host state could not be determined
+## Conditions
 
-### observedPowerState
-- **observedPowerState** (string): Last observed power state from Redfish endpoint
+| Type | Meaning | Common reasons |
+|---|---|---|
+| `RedfishConnectionReady` | BMC reachable and authenticating successfully. | `MissingCredentials`, `SecretGetFailed`, `SecretNotFound`, `MissingSecretData`, `RedfishConnectionFailed`, `RedfishQueryFailed`, `InsecureCABundleConflict`, `CABundleFetchFailed`. |
+| `HostAvailable` | Host has no consumer claim. | – |
+| `HostInspected` | An inspection report has been persisted. | – |
 
-### errorMessage
-- **errorMessage** (string): Details on the last error encountered
+## Deletion
 
-### hardwareDetails
-- **manufacturer** (string): Manufacturer of the physical host
-- **model** (string): Model of the physical host
-- **serialNumber** (string): Serial number of the physical host
-- **status** (object):
-  - **Health** (string): Health status of the host
-  - **HealthRollup** (string): Overall health status
-  - **State** (string): Current state of the host
+`reconcileDelete` removes the finalizer and lets Kubernetes garbage-collect the host. The PhysicalHost reconciler does NOT call Redfish during deletion; that is the job of the consuming `Beskar7Machine` (best-effort `ClearBootSourceOverride` + graceful `SetPowerState(Off)` before clearing `ConsumerRef`). If a host is deleted while still claimed, the controller emits a warning event but does not block.
 
-### conditions
-Array of conditions representing the latest available observations of the object's state.
+## Operator escape hatches
 
-## Additional Printer Columns
-
-- **State**: Current state of the Physical Host
-- **Ready**: Whether the host is ready
-- **Age**: Creation timestamp
+- **Force release:** Set `infrastructure.cluster.x-k8s.io/force-release: "true"` on the consuming `Beskar7Machine` before deletion. The Beskar7Machine controller will skip the BMC power-off / boot-clear during release. Use only when the BMC is permanently unreachable.
 
 ## Example
 
 ```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: "admin"
+  password: "changeme"
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
-  name: my-host
+  name: server-01
   namespace: default
+  labels:
+    topology.kubernetes.io/zone: rack-1   # consumed by Beskar7Cluster failure domains
 spec:
   redfishConnection:
     address: "https://192.168.1.100"
-    credentialsSecretRef: "redfish-credentials"
-    insecureSkipVerify: false
-  bootIsoSource: "http://example.com/boot.iso"
-  userDataSecretRef:
-    name: "user-data"
-status:
-  ready: true
-  state: "Available"
-  observedPowerState: "On"
-  hardwareDetails:
-    manufacturer: "Example Corp"
-    model: "Server-123"
-    serialNumber: "SN123456"
-    status:
-      Health: "OK"
-      HealthRollup: "OK"
-      State: "Enabled"
-  addresses:
-    - type: InternalIP
-      address: 192.168.1.100
+    credentialsSecretRef: "bmc-credentials"
 ```
 
-## Fields
+## Print columns
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `spec.redfishConnection` | `RedfishConnection` | The Redfish connection configuration. |
-| `spec.bootIsoSource` | `string` | The URL of the ISO image to use for provisioning. |
-| `spec.userDataSecretRef` | `ObjectReference` | Reference to a secret containing cloud-init user data. |
-| `status.ready` | `boolean` | Indicates if the host is ready and enrolled. |
-| `status.state` | `string` | The current state of the host. |
-| `status.observedPowerState` | `string` | The last observed power state from the Redfish endpoint. |
-| `status.hardwareDetails` | `HardwareDetails` | Details about the hardware of the physical host. |
-| `status.errorMessage` | `string` | Error message if the host is in an error state. |
-| `status.addresses` | `[]MachineAddress` | The associated addresses for the host. | 
+`kubectl get physicalhost` shows `State`, `Ready`, and `Age`.
+
+## See also
+
+- [API Reference: PhysicalHost](api-reference.md#physicalhost)
+- [State Management](state-management.md)
+- [Architecture](architecture.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,7 +4,7 @@ This guide provides the steps to get the Beskar7 controller manager built, deplo
 
 ## Prerequisites
 
-*   [Go](https://golang.org/dl/) (version 1.24 or later required)
+*   [Go](https://golang.org/dl/) 1.25 (matches `go.mod` and the CI toolchain in `.github/workflows/ci.yml`)
 *   [Docker](https://docs.docker.com/get-docker/) (for building the manager image)
 *   `docker buildx` configured for multi-arch builds (if needed, e.g., Mac M1/M2 building for amd64):
     ```bash
@@ -51,10 +51,10 @@ kubectl get pods -n cert-manager
     # export CR_PAT=YOUR_GITHUB_PAT # Use a PAT with write:packages scope for GHCR
     # echo $CR_PAT | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
 
-    # Build and push the image 
-    # (Uses values from Makefile: ghcr.io/projectbeskar/beskar7/beskar7:v0.2.7 by default)
-    # This builds for linux/amd64 by default due to Makefile configuration.
-    make docker-build docker-push 
+    # Build and push the image. The default tag is set in the Makefile:
+    #   IMG ?= ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha
+    # Builds for linux/amd64 by default.
+    make docker-build docker-push
     ```
     *(Note: If using a different registry/repo/tag, override Makefile variables: `make docker-push IMG=my-registry/my-repo:my-tag`)*
 
@@ -77,11 +77,19 @@ kubectl get pods -n cert-manager
     make install
     ```
 3.  **Deploy the Controller Manager:**
-    This will deploy the controller using the image defined in the Makefile (`ghcr.io/projectbeskar/beskar7/beskar7:v0.2.7` by default).
+    This will deploy the controller using the image defined in the Makefile (`ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha` by default — see `Makefile:15`).
     ```bash
     make deploy
     ```
     *(Note: If you pushed the image to a different location than specified in the Makefile, ensure the `IMG` variable was set correctly during the `make deploy` step, or modify the deployment manifests manually/via kustomize before applying).*
+
+    **Helm install (alternative):**
+    ```bash
+    helm repo add beskar7 https://projectbeskar.github.io/beskar7
+    helm repo update
+    helm install beskar7 beskar7/beskar7 --namespace beskar7-system --create-namespace
+    ```
+    The chart's default `bootstrap.urlBase` value is `https://beskar7-controller-manager.beskar7-system.svc:8082`, which matches the Service name created when the release is named `beskar7`. If you install with a different release name (e.g. `helm install b7 ...`), pass `--set bootstrap.urlBase=https://b7-controller-manager.beskar7-system.svc:8082` so the per-host bootstrap URL on `PhysicalHost.Status.Bootstrap.URL` resolves correctly.
 
 4.  **Verify Deployment:**
     Check that the controller manager pod is running in the `beskar7-system` namespace:

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -169,14 +169,17 @@ Memory Limit = (Host Count × 0.5MB) + (Webhook Concurrency × 10MB) + 100MB (ba
 Configure reconciliation intervals based on your needs:
 
 ```yaml
+# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.
 args:
-- --leader-elect
-- --enable-security-monitoring=true
-- --metrics-bind-address=:8080
+- --leader-elect=true
+- --metrics-bind-address=:8443
+- --secure-metrics=true
 - --health-probe-bind-address=:8081
-- --max-concurrent-reconciles=5          # Increase for large deployments
-- --reconciliation-interval=30s           # Adjust based on requirements
+- --inspection-port=8082
+- --bootstrap-url-base=https://beskar7-controller-manager.beskar7-system.svc:8082
 ```
+
+There is no `--max-concurrent-reconciles*` or `--reconciliation-interval` flag; the controller-runtime defaults apply (one reconciler per controller; per-resource requeue intervals encoded in the controllers themselves). Per-controller concurrency would have to be raised in code in `controllers/<kind>_controller.go:SetupWithManager`.
 
 ### Health Check Tuning
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,226 +1,115 @@
-# Beskar7 Security Guide
+# Beskar7 Security
 
-Beskar7 provides comprehensive security features to ensure secure bare-metal infrastructure provisioning. This guide covers all security capabilities, configuration options, and best practices.
+This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha. Each item is anchored to source code so you can verify the claim.
 
-## Overview
+If you are looking for hardening recommendations, see [Configuration](configuration.md). For RBAC details, see [RBAC Hardening](rbac-hardening.md). For incident debugging, see [Troubleshooting](troubleshooting.md).
 
-Beskar7's security framework includes:
+## Threat model in scope
 
-- **TLS Certificate Validation**: Comprehensive certificate verification for BMC communications
-- **RBAC Security**: Principle of least privilege with granular permissions
-- **Credential Security**: Secure handling, validation, and rotation of BMC credentials
-- **Security Monitoring**: Real-time security scanning and threat detection
-- **Network Security**: Network policies and secure communication protocols
-- **Container Security**: Hardened container configurations and security contexts
+- A misconfigured operator: BMC with self-signed cert, weak credentials, lax NetworkPolicy, etc.
+- A compromised host on the management network attempting to talk to the manager's callback endpoint.
+- A multi-tenant control-plane cluster where tenants must not read each other's BMC credentials or bootstrap data.
 
-## Quick Start
+Out of scope: kernel exploits on the inspection image, BMC firmware vulnerabilities, supply-chain attacks on the operator's iPXE image hosting.
 
-### Enable Security Features
+## Controls
 
-Security monitoring is enabled by default. To configure:
+### 1. BMC TLS verification with optional custom CA bundle
 
-```bash
-# Enable security monitoring (default)
-kubectl apply -f config/default
+`PhysicalHost.spec.redfishConnection.caBundleSecretRef` references a Secret in the host's namespace containing PEM CA certificates. The manager builds an `*http.Client` whose root pool includes that bundle and passes it to gofish.
 
-# Disable security monitoring
-kubectl patch deployment beskar7-controller-manager -n beskar7-system \
-  --patch '{"spec":{"template":{"spec":{"containers":[{"name":"manager","args":["--leader-elect","--enable-security-monitoring=false"]}]}}}}'
-```
+`insecureSkipVerify: true` and `caBundleSecretRef` are mutually exclusive. The reconciler rejects the combination terminally with `RedfishConnectionReady=False (InsecureCABundleConflict)`.
 
-### Check Security Status
+Source: `controllers/redfish_tls.go:fetchRedfishCABundle`, `validateRedfishTLSCombination`.
 
-```bash
-# View security events
-kubectl get events -n beskar7-system --field-selector type=Warning
-
-# Check security policy
-kubectl get configmap beskar7-security-policy -n beskar7-system -o yaml
-
-# View network policies
-kubectl get networkpolicy -n beskar7-system
-```
-
-## Security Features
-
-### 1. TLS Certificate Validation
-
-Beskar7 validates TLS certificates for all BMC connections to prevent man-in-the-middle attacks.
-
-#### Features:
-- Certificate chain validation
-- Hostname verification
-- Expiry date checking
-- Self-signed certificate detection
-- Key usage validation
-- Certificate authority verification
-
-#### Configuration:
+Concrete cert-manager-issued example:
 
 ```yaml
+# 1. Issue a CA bundle Secret with cert-manager.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: bmc-ca-bundle
+  namespace: default
+spec:
+  secretName: bmc-ca-bundle           # Secret data["ca.crt"] will hold the CA cert
+  isCA: true
+  commonName: "BMC Issuing CA"
+  issuerRef:
+    name: my-root-issuer
+    kind: ClusterIssuer
+---
+# 2. Reference it from the PhysicalHost.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
   name: server-01
+  namespace: default
 spec:
   redfishConnection:
-    address: "https://bmc.example.com"
-    credentialsSecretRef:
-      name: bmc-credentials
-    # Security options
-    insecureSkipVerify: false  # Enforce certificate validation
-    # Optional: Custom CA certificate
-    # caCertificateSecretRef:
-    #   name: custom-ca-cert
+    address: "https://bmc.internal.example.com"
+    credentialsSecretRef: "bmc-credentials"
+    insecureSkipVerify: false
+    caBundleSecretRef:
+      name: bmc-ca-bundle
 ```
 
-#### Certificate Warnings:
+The Secret data must include either a `ca.crt` (preferred) or `tls.crt` key. If both are present, `ca.crt` wins. Empty values are rejected with `CABundleFetchFailed`.
 
-The system provides warnings for:
-- Certificates expiring within 30 days (WARNING)
-- Certificates expiring within 7 days (CRITICAL)
-- Self-signed certificates (INFO)
-- Invalid certificate chains (ERROR)
+### 2. BMC credentials in a referenced Secret
 
-### 2. RBAC Security
+`PhysicalHost.spec.redfishConnection.credentialsSecretRef` names an Opaque Secret in the same namespace as the host. The Secret must contain `username` and `password` data keys. Beskar7 fetches by name only — there is no List/Watch on Secrets across the cluster outside the existing PhysicalHost-scoped informer.
 
-Beskar7 follows the principle of least privilege with minimal required permissions.
+Source: `controllers/physicalhost_controller.go:getRedfishCredentials`, `controllers/beskar7machine_controller.go:getRedfishClientForHost`.
 
-#### Default Permissions:
+Beskar7 does not log usernames or passwords at any verbosity level. The structured logger emits `passwordProvided` (a boolean) at V(1) when constructing the gofish client. See `internal/redfish/gofish_client.go`.
 
-```yaml
-# Infrastructure resources - Full access for our CRDs
-- apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources: ["physicalhosts", "beskar7machines", "beskar7clusters"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+### 3. Per-host bearer-token authentication on the callback endpoint
 
-# Status updates
-- apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources: ["physicalhosts/status", "beskar7machines/status", "beskar7clusters/status"]
-  verbs: ["get", "update", "patch"]
+The manager runs an HTTPS server on `:8082` that hosts two host-scoped endpoints:
 
-# Cluster API resources - Read-only
-- apiGroups: ["cluster.x-k8s.io"]
-  resources: ["clusters", "machines"]
-  verbs: ["get", "list", "watch"]
+- `POST /api/v1/inspection/{namespace}/{hostName}` — receives inspection reports.
+- `GET  /api/v1/bootstrap/{namespace}/{hostName}` — serves bootstrap data Secret bytes.
 
-# Secrets - Read-only for credentials
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch"]
+Both are gated by the same `auth.RequireBearer` middleware. The verifier:
 
-# Events - Create/update for logging
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create", "patch"]
-```
+1. Resolves `{namespace,hostName}` from the URL path.
+2. Loads the targeted `PhysicalHost` and reads `Status.Bootstrap.TokenHash` and `ExpiresAt`.
+3. Rejects the request if no token has been issued, the token has expired, or `auth.Verify(presented, storedHash)` returns false (constant-time SHA-256 compare via `crypto/subtle`).
 
-#### Security Validation:
+All authentication failures collapse to an opaque `401 Unauthorized` body — the verifier's specific error is logged at V(1) only, never echoed to the client.
 
-The RBAC validator checks for:
-- Wildcard permissions (`*,*,*`)
-- Overly broad verb permissions
-- Impersonation capabilities
-- Cluster-admin equivalent permissions
-- Principle of least privilege compliance
+Token shape (decision D-004 in `.claude/context/PROJECT_CONTEXT.md`):
 
-### 3. Credential Security
+- 32 bytes from `crypto/rand`, encoded as `base64.RawURLEncoding` (43 chars), suitable for an iPXE kernel cmdline.
+- SHA-256 hash (64 hex chars) is persisted to `PhysicalHost.Status.Bootstrap.TokenHash`.
+- Lifetime: 30 minutes (`auth.TokenLifetime`). Above the 10-minute `DefaultInspectionTimeout`, with headroom for slow BIOS POST + first-boot inspector.
 
-Secure handling of BMC credentials with validation and rotation tracking.
+The plaintext is stored in a per-host Secret named `<host-name>-bootstrap-token` (data key `plaintext-token`), owned by the PhysicalHost so it is GC'd on host delete. Decision D-006.
 
-#### Credential Requirements:
+Source: `internal/auth/token.go`, `internal/auth/middleware.go`, `controllers/inspection_handler.go:newBearerTokenVerifier`, `controllers/bootstrap_handler.go`.
 
-**Password Policy:**
-- Minimum 12 characters
-- Must include uppercase, lowercase, numbers, and special characters
-- Prohibited common passwords
-- Regular rotation (recommended: 90 days)
+### 4. Body cap on inspection POST
 
-**Secret Format:**
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: bmc-credentials
-type: Opaque
-data:
-  username: <base64-encoded-username>
-  password: <base64-encoded-password>
-```
+`http.MaxBytesReader` caps the inspection POST body at 1 MiB. Over-limit reads return `413 Request Entity Too Large`. Real inspector payloads (CPUs + DIMMs + NICs + disks) are low single-digit kilobytes; the cap is a defense against runaway clients.
 
-#### Security Validation:
+Source: `controllers/inspection_handler.go` (`inspectionMaxBodyBytes = 1 << 20`).
 
-The system validates:
-- Required fields (username, password)
-- Password strength and complexity
-- Credential age and rotation needs
-- Secure storage in Kubernetes secrets
-- Plaintext credential storage
+### 5. Per-namespace Secret/ConfigMap RBAC scope
 
-### 4. Security Monitoring
+The controllers' RBAC markers grant Secret read access only as needed:
 
-Real-time security monitoring with automated threat detection.
+- `PhysicalHost` reconciler: `secrets: get, list, watch` (the watch is required by the controller-runtime informer that triggers reconciles on credential rotation).
+- `Beskar7Machine` reconciler: `secrets: get, create, update, patch, delete` (no list/watch — Secret access is by name only).
+- ConfigMaps: `get, create, update, patch, delete` (no list/watch — fetched by name).
 
-#### Monitoring Capabilities:
+Source: `controllers/physicalhost_controller.go:81-98`, `controllers/beskar7machine_controller.go:87-103`.
 
-- **TLS Security**: Certificate validation and expiry tracking
-- **RBAC Security**: Permission analysis and violation detection
-- **Credential Security**: Secret age tracking and rotation monitoring
-- **Configuration Drift**: Security policy compliance checking
+The cluster-wide list/watch on Secret remains as a residual scope (tracked as `SEC-2` / D-007 in `.claude/context/PROJECT_CONTEXT.md`); a label-selected partial cache is an open v0.5 follow-up. See [RBAC Hardening](rbac-hardening.md) for detail.
 
-#### Security Reports:
+### 6. Pod security context
 
-```json
-{
-  "timestamp": "2024-01-15T10:30:00Z",
-  "total_issues": 5,
-  "critical_issues": 1,
-  "high_issues": 2,
-  "medium_issues": 2,
-  "low_issues": 0,
-  "tls_findings": [...],
-  "rbac_findings": [...],
-  "secret_findings": [...],
-  "recommendations": [...]
-}
-```
-
-#### Alerting:
-
-Critical and high-severity issues generate Kubernetes events:
-
-```bash
-kubectl get events -n beskar7-system --field-selector type=Warning,reason=TLSSecurityIssue
-kubectl get events -n beskar7-system --field-selector type=Warning,reason=RBACSecurityIssue
-kubectl get events -n beskar7-system --field-selector type=Warning,reason=SecretSecurityIssue
-```
-
-### 5. Network Security
-
-Network policies enforce secure communication patterns.
-
-#### Network Policies:
-
-- **Default Deny**: All traffic denied by default
-- **Selective Allow**: Explicit rules for required communication
-- **Monitoring Integration**: Metrics scraping allowed from monitoring systems
-- **API Access**: Controlled access to Kubernetes API server
-
-#### BMC Communication:
-
-```yaml
-# Allowed BMC ports
-- protocol: TCP
-  port: 443   # HTTPS/Redfish
-- protocol: TCP
-  port: 8443  # Alternative HTTPS
-```
-
-### 6. Container Security
-
-Hardened container configuration following security best practices.
-
-#### Security Context:
+The kustomize manifests under `config/manager/` and the Helm chart in `charts/beskar7/templates/deployment.yaml` set:
 
 ```yaml
 securityContext:
@@ -235,229 +124,54 @@ securityContext:
     type: RuntimeDefault
 ```
 
-#### Resource Limits:
+### 7. NetworkPolicy
 
-```yaml
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-    ephemeral-storage: 1Gi
-  requests:
-    cpu: 100m
-    memory: 128Mi
-    ephemeral-storage: 100Mi
+The chart ships a NetworkPolicy that allows ingress on:
+
+- `:8443` — metrics (HTTPS, authenticated; see #9).
+- `:9443` — webhook server (when `webhook.enabled=true`).
+- `:8082` — callback endpoint for the inspection POST and bootstrap GET. Bare-metal IPs cannot be allow-listed at the policy level — the bearer token is the access control.
+
+Source: `charts/beskar7/templates/networkpolicy.yaml`.
+
+### 8. Container image
+
+The Dockerfile uses a multi-stage build with `CGO_ENABLED=0` and a distroless `nonroot` runtime base, both pinned by digest:
+
+```Dockerfile
+FROM golang:1.25@sha256:8a7adc288b77e9b787cd2695029eb54d10ae80571b21d44fed68d067ad0a9c96 as builder
+...
+FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
 ```
 
-## Security Configuration
+### 9. Authenticated metrics on `:8443`
 
-### Environment-Specific Settings
+The manager serves `/metrics` over HTTPS on `:8443` directly (no `kube-rbac-proxy` sidecar — removed in PR-11.1). Authentication and authorization are delegated to the kube-apiserver via TokenReview/SubjectAccessReview (`controller-runtime`'s `filters.WithAuthenticationAndAuthorization`). To scrape, your Prometheus ServiceAccount needs the `metrics_reader` ClusterRole (see `config/rbac/metrics_reader_role.yaml`). For local development you can opt out with `--secure-metrics=false`.
 
-#### Production Environment:
+Source: `cmd/manager/main.go:135-145`.
 
-```yaml
-security:
-  tls:
-    enforce_certificate_validation: true
-    allow_insecure_skip_verify: false
-    min_tls_version: "1.2"
-  
-  rbac:
-    enforce_least_privilege: true
-  
-  credentials:
-    password_policy:
-      min_length: 12
-      require_complexity: true
-    rotation_policy:
-      max_age_days: 90
-  
-  monitoring:
-    security_monitoring:
-      enabled: true
-      scan_interval: "1h"
-      alert_on_critical: true
-```
+## Configuration entry points
 
-#### Development Environment:
+| What | How |
+|---|---|
+| Disable TLS verification on a single BMC (test only) | `PhysicalHost.spec.redfishConnection.insecureSkipVerify: true` |
+| Use a private CA on a BMC | `PhysicalHost.spec.redfishConnection.caBundleSecretRef.name: <secret>` |
+| Force-release a host whose BMC is dead | annotate the consuming Beskar7Machine: `infrastructure.cluster.x-k8s.io/force-release=true` |
+| Open metrics for plain-HTTP development | manager flag `--secure-metrics=false` |
 
-```yaml
-security:
-  exceptions:
-    development:
-      allow_insecure_skip_verify: true
-      allow_self_signed_certificates: true
-      reduced_password_requirements: true
-```
+## What is NOT enforced
 
-### Custom CA Certificates
+To avoid cargo-cult security claims:
 
-For environments with custom certificate authorities:
+- There is no built-in password-strength policy. The Secret can hold any bytes.
+- There is no automatic credential rotation. Operators rotate Secret values manually; the `PhysicalHost` reconciler watches Secrets and re-reconciles on change.
+- There is no CIS / NIST / SOC 2 / ISO 27001 audit. Don't claim compliance you haven't measured.
+- There is no security-scanning CronJob shipped with the chart. Use your platform's standard tooling.
 
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: custom-ca-cert
-  namespace: beskar7-system
-type: Opaque
-data:
-  ca.crt: <base64-encoded-ca-certificate>
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: PhysicalHost
-metadata:
-  name: server-01
-spec:
-  redfishConnection:
-    address: "https://bmc.internal.com"
-    credentialsSecretRef:
-      name: bmc-credentials
-    caCertificateSecretRef:
-      name: custom-ca-cert
-```
+## See also
 
-## Security Metrics
-
-Beskar7 exposes security metrics for monitoring:
-
-### Prometheus Metrics:
-
-```
-# TLS certificate metrics
-beskar7_tls_certificate_expiry_days
-beskar7_tls_certificate_valid
-beskar7_tls_insecure_skip_verify_total
-
-# RBAC security metrics
-beskar7_rbac_overly_broad_permissions_total
-beskar7_rbac_security_violations_total
-
-# Credential security metrics
-beskar7_credential_age_days
-beskar7_credential_rotation_required_total
-
-# Security scan metrics
-beskar7_security_scan_issues_total
-beskar7_security_scan_duration_seconds
-```
-
-### Grafana Dashboard:
-
-Use the provided Grafana dashboard to visualize security metrics:
-
-```bash
-kubectl apply -f examples/monitoring/grafana-dashboard-security.yaml
-```
-
-## Compliance
-
-Beskar7 security features support compliance with:
-
-- **CIS Kubernetes Benchmark**: Container and cluster security
-- **NIST Cybersecurity Framework**: Risk management and security controls
-- **SOC 2 Type II**: Security and availability controls
-- **ISO 27001**: Information security management
-
-### Compliance Reports:
-
-Generate compliance reports:
-
-```bash
-# Run compliance scan
-kubectl create job beskar7-compliance-scan --from=cronjob/beskar7-security-monitor
-
-# View compliance report
-kubectl logs job/beskar7-compliance-scan
-```
-
-## Troubleshooting
-
-### Common Security Issues:
-
-#### TLS Certificate Problems:
-
-```bash
-# Check certificate validation errors
-kubectl get events -n beskar7-system --field-selector reason=TLSSecurityIssue
-
-# Validate certificate manually
-openssl s_client -connect bmc.example.com:443 -verify_return_error
-```
-
-#### RBAC Permission Issues:
-
-```bash
-# Check RBAC violations
-kubectl get events -n beskar7-system --field-selector reason=RBACSecurityIssue
-
-# Validate current permissions
-kubectl auth can-i --list --as=system:serviceaccount:beskar7-system:controller-manager
-```
-
-#### Credential Problems:
-
-```bash
-# Check credential validation
-kubectl get events -n beskar7-system --field-selector reason=SecretSecurityIssue
-
-# Validate secret format
-kubectl get secret bmc-credentials -o yaml
-```
-
-### Security Logs:
-
-Enable detailed security logging:
-
-```bash
-# Increase log level for security components
-kubectl patch deployment beskar7-controller-manager -n beskar7-system \
-  --patch '{"spec":{"template":{"spec":{"containers":[{"name":"manager","args":["--leader-elect","--v=2"]}]}}}}'
-```
-
-## Best Practices
-
-### 1. Certificate Management:
-- Use proper CA-signed certificates for production
-- Implement certificate rotation procedures
-- Monitor certificate expiry dates
-- Validate certificate chains regularly
-
-### 2. Credential Management:
-- Rotate credentials every 90 days
-- Use strong, unique passwords
-- Store credentials securely in Kubernetes secrets
-- Implement credential rotation automation
-
-### 3. RBAC Security:
-- Follow principle of least privilege
-- Regularly audit permissions
-- Avoid wildcard permissions
-- Use namespace-scoped roles when possible
-
-### 4. Monitoring:
-- Enable security monitoring in production
-- Set up alerting for critical issues
-- Review security reports regularly
-- Investigate security events promptly
-
-### 5. Network Security:
-- Implement network policies
-- Use TLS for all communications
-- Restrict network access to BMCs
-- Monitor network traffic patterns
-
-## Security Contacts
-
-For security-related issues:
-
-- **Security Issues**: Open an issue with the `security` label
-- **Vulnerability Reports**: Email security@beskar7.io
-- **Security Questions**: Join the `#security` channel in Slack
-
-## Related Documentation
-
-- [Quick Start Guide](../quick-start.md)
-- [Deployment Best Practices](../deployment-best-practices.md)
-- [Troubleshooting Guide](../troubleshooting.md)
-- [API Reference](../api-reference.md) 
+- [Security Configuration](configuration.md)
+- [RBAC Hardening](rbac-hardening.md)
+- [Security Troubleshooting](troubleshooting.md)
+- [Quick Start](../quick-start.md)
+- [API Reference: PhysicalHost](../api-reference.md#physicalhost)

--- a/docs/security/configuration.md
+++ b/docs/security/configuration.md
@@ -1,647 +1,206 @@
-# Security Configuration Guide
+# Security Configuration
 
-This guide provides detailed configuration options for Beskar7's security features.
+How to configure the security features Beskar7 actually enforces. For an inventory of those features, see [Security](README.md).
 
-## Security Policy Configuration
+## BMC TLS
 
-The security policy is defined in a ConfigMap and controls all security behavior.
-
-### Location
-
-```bash
-kubectl get configmap beskar7-security-policy -n beskar7-system -o yaml
-```
-
-### Full Configuration Reference
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: beskar7-security-policy
-  namespace: beskar7-system
-data:
-  policy.yaml: |
-    security:
-      # TLS Security Configuration
-      tls:
-        # Enforce certificate validation (recommended: true for production)
-        enforce_certificate_validation: true
-        
-        # Allow insecureSkipVerify (recommended: false for production)
-        allow_insecure_skip_verify: false
-        
-        # Minimum TLS version (options: "1.0", "1.1", "1.2", "1.3")
-        min_tls_version: "1.2"
-        
-        # Certificate expiry warning thresholds (days)
-        expiry_warning_days: 30
-        expiry_critical_days: 7
-        
-        # Trusted certificate authorities
-        trusted_cas:
-          - system  # Use system CA bundle
-          # Add custom CAs:
-          # - custom-ca-secret
-        
-        # Certificate validation requirements
-        require_hostname_verification: true
-        require_valid_certificate_chain: true
-        
-      # RBAC Security Configuration
-      rbac:
-        # Enforce principle of least privilege
-        enforce_least_privilege: true
-        
-        # Prohibited permissions (never allow)
-        prohibited_permissions:
-          - apiGroups: ["*"]
-            resources: ["*"]
-            verbs: ["*"]
-          - apiGroups: ["rbac.authorization.k8s.io"]
-            resources: ["*"]
-            verbs: ["*"]
-          - verbs: ["impersonate"]
-        
-        # Maximum allowed permissions
-        max_allowed_permissions:
-          beskar7-controller:
-            - apiGroups: ["infrastructure.cluster.x-k8s.io"]
-              resources: ["physicalhosts", "beskar7machines", "beskar7clusters"]
-              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-```
-
-## TLS Configuration
-
-### Basic TLS Setup
+### Strict verification (default, recommended)
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
   name: server-01
+  namespace: default
 spec:
   redfishConnection:
     address: "https://bmc.example.com"
-    credentialsSecretRef:
-      name: bmc-credentials
-    # Basic TLS settings
-    insecureSkipVerify: false  # Always validate certificates
+    credentialsSecretRef: "bmc-credentials"
+    insecureSkipVerify: false   # default
 ```
 
-### Custom CA Certificate
+The manager uses the system root CA pool. If the BMC presents a certificate that the system pool trusts, this works out of the box.
 
-For private CAs or self-signed certificates:
+### Custom CA bundle
+
+When the BMC's certificate chains to an organisation-internal CA:
 
 ```yaml
-# 1. Create CA certificate secret
 apiVersion: v1
 kind: Secret
 metadata:
-  name: custom-ca-cert
-  namespace: beskar7-system
+  name: bmc-ca-bundle
+  namespace: default
 type: Opaque
 data:
-  ca.crt: LS0tLS1CRUdJTi... # Base64 encoded CA certificate
-
+  ca.crt: <base64 PEM>          # preferred key
+  # tls.crt: <base64 PEM>       # fallback key, used only if ca.crt is absent
 ---
-# 2. Reference in PhysicalHost
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
   name: server-01
+  namespace: default
 spec:
   redfishConnection:
-    address: "https://bmc.internal.com"
-    credentialsSecretRef:
-      name: bmc-credentials
-    caCertificateSecretRef:
-      name: custom-ca-cert
+    address: "https://bmc.internal.example.com"
+    credentialsSecretRef: "bmc-credentials"
+    insecureSkipVerify: false
+    caBundleSecretRef:
+      name: bmc-ca-bundle
 ```
 
-### TLS Version Control
-
-Configure minimum TLS version in security policy:
+Cert-manager-driven equivalent (auto-rotates the CA Secret):
 
 ```yaml
-security:
-  tls:
-    min_tls_version: "1.2"  # Options: "1.0", "1.1", "1.2", "1.3"
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: bmc-ca-bundle
+  namespace: default
+spec:
+  secretName: bmc-ca-bundle      # data["ca.crt"] holds the issued CA cert
+  isCA: true
+  commonName: "BMC Issuing CA"
+  issuerRef:
+    name: my-root-issuer
+    kind: ClusterIssuer
 ```
 
-### Certificate Expiry Monitoring
+The CA bundle Secret must live in the same namespace as the PhysicalHost. The reconciler refreshes its TLS roots on each reconcile, so rotating the Secret takes effect at the next reconcile cycle (default 5 minutes; trigger sooner with a no-op `kubectl annotate physicalhost <name> reconcile-now=...`).
 
-Configure certificate expiry warnings:
+If the Secret is missing or has empty `ca.crt`/`tls.crt`, the controller marks `RedfishConnectionReady=False (CABundleFetchFailed)` and the host moves to `Error`.
+
+### Skipping verification (development only)
 
 ```yaml
-security:
-  tls:
-    expiry_warning_days: 30   # Warning threshold
-    expiry_critical_days: 7   # Critical threshold
+spec:
+  redfishConnection:
+    insecureSkipVerify: true
 ```
 
-## Credential Configuration
+`insecureSkipVerify: true` and `caBundleSecretRef` together is a hard error: the controller marks `RedfishConnectionReady=False (InsecureCABundleConflict)` and stops reconciling until you fix the spec.
 
-### Password Policy
+## BMC credentials
 
-Configure password requirements:
-
-```yaml
-security:
-  credentials:
-    password_policy:
-      min_length: 12                    # Minimum password length
-      require_uppercase: true           # Require uppercase letters
-      require_lowercase: true           # Require lowercase letters
-      require_numbers: true             # Require numbers
-      require_special_chars: true       # Require special characters
-      prohibited_common_passwords: true # Block common passwords
-```
-
-### Credential Rotation
-
-Configure rotation policies:
-
-```yaml
-security:
-  credentials:
-    rotation_policy:
-      max_age_days: 90           # Maximum credential age
-      warning_age_days: 60       # Warning threshold
-      force_rotation_age_days: 365  # Force rotation threshold
-```
-
-### Credential Storage
-
-Enforce secure storage:
-
-```yaml
-security:
-  credentials:
-    storage_policy:
-      require_encryption_at_rest: true
-      require_kubernetes_secrets: true
-      prohibit_plaintext_storage: true
-```
-
-### Creating Secure Credentials
-
-```bash
-# Generate strong password
-PASSWORD=$(openssl rand -base64 32)
-
-# Create credential secret
-kubectl create secret generic bmc-credentials \
-  --from-literal=username=admin \
-  --from-literal=password="$PASSWORD" \
-  --namespace=default
-```
-
-## RBAC Configuration
-
-### Service Account Setup
+Required Secret shape:
 
 ```yaml
 apiVersion: v1
-kind: ServiceAccount
+kind: Secret
 metadata:
-  name: beskar7-controller-manager
-  namespace: beskar7-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: manager-role
-rules:
-# Minimal required permissions
-- apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources: ["physicalhosts", "beskar7machines", "beskar7clusters"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources: ["physicalhosts/status", "beskar7machines/status", "beskar7clusters/status"]
-  verbs: ["get", "update", "patch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: manager-role
-subjects:
-- kind: ServiceAccount
-  name: beskar7-controller-manager
-  namespace: beskar7-system
+  name: bmc-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: "admin"
+  password: "..."
 ```
 
-### RBAC Validation
-
-Enable RBAC security validation:
-
-```yaml
-security:
-  rbac:
-    enforce_least_privilege: true
-    
-    # Define prohibited permissions
-    prohibited_permissions:
-      - apiGroups: ["*"]
-        resources: ["*"]
-        verbs: ["*"]
-      - verbs: ["impersonate"]
-```
-
-## Network Security Configuration
-
-### Network Policies
-
-#### Manager Network Policy
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: beskar7-manager-policy
-  namespace: beskar7-system
-spec:
-  podSelector:
-    matchLabels:
-      control-plane: beskar7-controller-manager
-  policyTypes:
-  - Ingress
-  - Egress
-  
-  ingress:
-  # Webhook traffic from API server
-  - from:
-    - namespaceSelector: {}
-    ports:
-    - protocol: TCP
-      port: 9443
-  
-  # Metrics scraping
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          name: monitoring
-    ports:
-    - protocol: TCP
-      port: 8080
-  
-  egress:
-  # DNS resolution
-  - to: []
-    ports:
-    - protocol: UDP
-      port: 53
-  
-  # Kubernetes API
-  - to: []
-    ports:
-    - protocol: TCP
-      port: 443
-  
-  # BMC communication
-  - to: []
-    ports:
-    - protocol: TCP
-      port: 443
-    - protocol: TCP
-      port: 8443
-```
-
-#### Default Deny Policy
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: default-deny-all
-  namespace: beskar7-system
-spec:
-  podSelector: {}
-  policyTypes:
-  - Ingress
-  - Egress
-```
-
-### BMC Network Configuration
-
-Configure BMC network access:
-
-```yaml
-security:
-  network:
-    # Default to secure communication
-    default_tls: true
-    
-    # Prohibited protocols
-    prohibited_protocols:
-      - http
-      - telnet
-      - ftp
-    
-    # Required encryption for BMC
-    bmc_encryption: true
-```
-
-## Container Security Configuration
-
-### Security Context
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-spec:
-  template:
-    spec:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
-        seccompProfile:
-          type: RuntimeDefault
-      
-      containers:
-      - name: manager
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 65532
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
-```
-
-### Resource Limits
-
-```yaml
-security:
-  container:
-    resource_limits:
-      enforce_resource_limits: true
-      default_cpu_limit: "500m"
-      default_memory_limit: "512Mi"
-      max_cpu_limit: "2000m"
-      max_memory_limit: "4Gi"
-```
-
-## Monitoring Configuration
-
-### Security Monitoring
-
-Enable/disable security monitoring:
-
-```yaml
-# Via command line arguments
-args:
-- --enable-security-monitoring=true
-- --security-scan-interval=1h
-
-# Via security policy
-security:
-  monitoring:
-    security_monitoring:
-      enabled: true
-      scan_interval: "1h"
-      alert_on_critical: true
-      alert_on_high: true
-```
-
-### Metrics Configuration
-
-Configure security metrics:
-
-```yaml
-security:
-  monitoring:
-    metrics:
-      expose_security_metrics: true
-      alert_on_policy_violations: true
-      alert_on_certificate_expiry: true
-      alert_on_credential_age: true
-```
-
-### Audit Logging
-
-Enable audit logging:
-
-```yaml
-security:
-  monitoring:
-    audit_logging:
-      enabled: true
-      log_failed_authentications: true
-      log_privilege_escalations: true
-      log_secret_access: true
-      log_rbac_changes: true
-```
-
-## Environment-Specific Configurations
-
-### Production Environment
-
-```yaml
-security:
-  tls:
-    enforce_certificate_validation: true
-    allow_insecure_skip_verify: false
-    min_tls_version: "1.2"
-  
-  rbac:
-    enforce_least_privilege: true
-  
-  credentials:
-    password_policy:
-      min_length: 16
-      require_complexity: true
-    rotation_policy:
-      max_age_days: 90
-  
-  monitoring:
-    security_monitoring:
-      enabled: true
-      scan_interval: "30m"
-      alert_on_critical: true
-      alert_on_high: true
-  
-  compliance:
-    standards:
-      cis_kubernetes: true
-      nist_cybersecurity: true
-      soc2: true
-```
-
-### Development Environment
-
-```yaml
-security:
-  # Enable development exceptions
-  exceptions:
-    development:
-      allow_insecure_skip_verify: true
-      allow_self_signed_certificates: true
-      reduced_password_requirements: true
-      extended_credential_rotation: true
-  
-  # Relaxed monitoring
-  monitoring:
-    security_monitoring:
-      enabled: true
-      scan_interval: "4h"
-      alert_on_critical: true
-      alert_on_high: false
-```
-
-### Testing Environment
-
-```yaml
-security:
-  exceptions:
-    testing:
-      allow_test_credentials: true
-      allow_mock_certificates: true
-      relaxed_rbac_validation: true
-  
-  monitoring:
-    security_monitoring:
-      enabled: false
-```
-
-## Advanced Configuration
-
-### Custom Security Validators
-
-Extend security validation with custom validators:
-
-```yaml
-security:
-  custom_validators:
-    - name: "corporate-policy"
-      type: "rbac"
-      config:
-        max_permissions_per_role: 10
-        require_justification: true
-    
-    - name: "certificate-pinning"
-      type: "tls"
-      config:
-        pinned_certificates:
-          - fingerprint: "sha256:..."
-            hosts: ["bmc.internal.com"]
-```
-
-### Integration with External Systems
-
-#### LDAP/Active Directory
-
-```yaml
-security:
-  authentication:
-    ldap:
-      enabled: true
-      server: "ldap.corporate.com"
-      base_dn: "dc=corporate,dc=com"
-      user_filter: "(uid=%s)"
-      tls_config:
-        min_version: "1.2"
-        certificate_validation: true
-```
-
-#### External Secret Management
-
-```yaml
-security:
-  credentials:
-    external_secret_manager:
-      enabled: true
-      provider: "vault"  # Options: vault, aws-secrets, azure-keyvault
-      config:
-        vault_address: "https://vault.corporate.com"
-        vault_role: "beskar7"
-        secret_path: "secret/beskar7/bmc-credentials"
-```
-
-## Troubleshooting Configuration
-
-### Debug Mode
-
-Enable debug logging for security components:
-
-```yaml
-# In deployment args
-args:
-- --v=2  # Verbose logging
-- --security-debug=true
-
-# Environment variables
-env:
-- name: BESKAR7_SECURITY_DEBUG
-  value: "true"
-```
-
-### Configuration Validation
-
-Validate security configuration:
+Generate strong passwords externally (Beskar7 does not enforce any strength policy). Example:
 
 ```bash
-# Validate security policy
-kubectl get configmap beskar7-security-policy -n beskar7-system -o yaml | yq eval '.data."policy.yaml"'
-
-# Check current security status
-kubectl get events -n beskar7-system --field-selector type=Warning
-
-# Test RBAC permissions
-kubectl auth can-i --list --as=system:serviceaccount:beskar7-system:controller-manager
+PASS=$(openssl rand -base64 32)
+kubectl create secret generic bmc-credentials \
+  --from-literal=username=admin \
+  --from-literal=password="$PASS" \
+  -n default
 ```
 
-### Common Configuration Issues
+To rotate, update the Secret. The PhysicalHost reconciler watches the Secret and re-reconciles on change; the manager rebuilds the gofish client with the new credentials on the next reconcile.
 
-1. **Certificate Validation Failures**
-   ```yaml
-   # Fix: Add custom CA or disable validation for testing
-   insecureSkipVerify: true  # Only for development!
-   ```
+## Bearer-token authentication on the callback endpoint
 
-2. **RBAC Permission Denied**
-   ```bash
-   # Fix: Check and update ClusterRole permissions
-   kubectl get clusterrole manager-role -o yaml
-   ```
+This is automatic — the operator does not configure it directly. Per host:
 
-3. **Network Policy Blocking Traffic**
-   ```bash
-   # Fix: Review and update network policies
-   kubectl get networkpolicy -n beskar7-system
-   ```
+1. The `Beskar7Machine` reconciler mints a 32-byte token (`internal/auth/token.go:MintToken`).
+2. The plaintext is written to a per-host Secret named `<host-name>-bootstrap-token`, owner-ref'd to the PhysicalHost.
+3. The SHA-256 hash is signalled to the PhysicalHost via the `infrastructure.cluster.x-k8s.io/bootstrap-token` annotation, then persisted to `Status.Bootstrap.{TokenHash, IssuedAt, ExpiresAt}`.
+4. The iPXE infrastructure renders the plaintext into the kernel cmdline as `beskar7.token=<plaintext>`. See [iPXE Setup](../ipxe-setup.md).
+5. The inspector and target OS present `Authorization: Bearer <token>` on every call to `:8082`.
+6. After 30 minutes, or on Beskar7Machine deletion, the token Secret is GC'd.
 
-4. **Resource Limits Too Restrictive**
-   ```yaml
-   # Fix: Increase resource limits
-   resources:
-     limits:
-       memory: "1Gi"  # Increase from default
-   ```
+The plaintext is never logged at any verbosity. The hash on Status is safe to log — it cannot be used to forge a valid bearer header.
 
-## Configuration Best Practices
+## Manager flags relevant to security
 
-1. **Start Secure**: Begin with restrictive settings and relax as needed
-2. **Environment Separation**: Use different configurations for dev/test/prod
-3. **Regular Updates**: Review and update security configurations regularly
-4. **Validate Changes**: Test configuration changes in non-production first
-5. **Monitor Impact**: Watch for security events after configuration changes
-6. **Document Exceptions**: Clearly document any security exceptions and their justification
+The manager flags that affect security posture (`cmd/manager/main.go`):
 
-## Configuration Examples
+| Flag | Default | Purpose |
+|---|---|---|
+| `--metrics-bind-address` | `:8443` | Metrics endpoint. |
+| `--secure-metrics` | `true` | When true, `/metrics` requires a TokenReview-validated SA bearer; metrics_reader role required. Set false only for local dev. |
+| `--bootstrap-url-base` | `https://beskar7-controller-manager.beskar7-system.svc:8082` | Base URL for the per-host bootstrap URL written to `PhysicalHost.Status.Bootstrap.URL`. Override when the manager Service has a non-default DNS name (e.g. you installed with a release name other than `beskar7`). |
+| `--inspection-port` | `8082` | Port the callback HTTPS endpoint listens on. |
+| `--inspection-cert-dir` | `/tmp/k8s-webhook-server/serving-certs` | Directory containing `tls.crt` + `tls.key` for the callback endpoint. Defaults to the webhook cert dir; both endpoints share a cert covering the controller-manager Service DNS name when cert-manager issues the chart's Certificate. |
+| `--enable-webhook` | `false` | Run the Beskar7Cluster webhook server. |
+| `--webhook-port` | `9443` | Webhook server port. |
+| `--webhook-cert-dir` | `/tmp/k8s-webhook-server/serving-certs` | Webhook cert dir. |
 
-See the `examples/security/` directory for complete configuration examples:
+## RBAC
 
-- `examples/security/production.yaml` - Production security configuration
-- `examples/security/development.yaml` - Development configuration
-- `examples/security/high-security.yaml` - High-security environment configuration 
+Beskar7 follows the principle of least privilege by default. See [RBAC Hardening](rbac-hardening.md) for the full ClusterRole.
+
+### Verifying the deployed RBAC
+
+```bash
+kubectl get clusterrole -l app.kubernetes.io/name=beskar7 -o yaml
+kubectl get clusterrolebinding -l app.kubernetes.io/name=beskar7 -o yaml
+```
+
+Or, if you installed via the kustomize overlay:
+
+```bash
+kubectl get clusterrole manager-role -o yaml
+kubectl get clusterrolebinding manager-rolebinding -o yaml
+```
+
+There is no Helm value or operator flag to relax the ClusterRole at install time. To extend it (e.g. to add a custom resource the controller needs to read), edit `config/rbac/role.yaml` or the chart's `templates/rbac.yaml` directly and re-deploy.
+
+## NetworkPolicy
+
+The Helm chart ships a NetworkPolicy in `templates/networkpolicy.yaml` that allows ingress on `:8443` (metrics), `:9443` (webhook), and `:8082` (callback). Egress is unrestricted by default (Beskar7 needs to reach BMCs at arbitrary IPs, the kube-apiserver, and DNS).
+
+To narrow egress to a known BMC subnet, edit the NetworkPolicy in your installation:
+
+```yaml
+egress:
+  # DNS
+  - ports:
+      - protocol: UDP
+        port: 53
+  # Kubernetes API
+  - to:
+      - namespaceSelector: {}
+    ports:
+      - protocol: TCP
+        port: 443
+  # BMC subnet only
+  - to:
+      - ipBlock:
+          cidr: 10.100.0.0/16
+    ports:
+      - protocol: TCP
+        port: 443
+      - protocol: TCP
+        port: 5000
+```
+
+## Pod security
+
+The `Deployment` template (kustomize and Helm) sets `runAsNonRoot: true`, `runAsUser: 65532`, `readOnlyRootFilesystem: true`, drops all capabilities, and uses the `RuntimeDefault` seccomp profile. None of this is configurable via Helm values; if you need to relax it (e.g. to debug with an ephemeral container), patch the Deployment after install.
+
+## Auditing
+
+There is no built-in security-scanning or compliance-reporting CronJob. Use your platform's normal tooling:
+
+- Kubernetes audit logs from the kube-apiserver.
+- A workload-CVE scanner (e.g. Trivy, Grype) against the manager image.
+- A Pod Security Admission profile (`baseline` or `restricted`) on the `beskar7-system` namespace.
+
+## See also
+
+- [Security](README.md)
+- [RBAC Hardening](rbac-hardening.md)
+- [Security Troubleshooting](troubleshooting.md)
+- [Quick Start](../quick-start.md)

--- a/docs/security/rbac-hardening.md
+++ b/docs/security/rbac-hardening.md
@@ -1,255 +1,136 @@
-# RBAC Security Hardening
+# RBAC Hardening
 
-This document describes the RBAC (Role-Based Access Control) security hardening implemented for Beskar7, which replaces dangerous wildcard permissions with minimal, specific permissions following the principle of least privilege.
+This page documents the ClusterRole that ships with Beskar7, the rationale behind each rule, and what to verify before exposing the controller to a multi-tenant or untrusted environment.
 
-## Security Issue Resolved
+The deployed ClusterRole is generated from kubebuilder markers on the controllers in `controllers/*.go` plus a few markers in `cmd/manager/main.go`. The resulting YAML is `config/rbac/role.yaml` (kustomize) and `charts/beskar7/templates/rbac.yaml` (Helm).
 
-### Previous Security Vulnerability
-
-The original RBAC configuration contained **CRITICAL** security vulnerability:
+## Default ClusterRole
 
 ```yaml
-# DANGEROUS - DO NOT USE
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
-```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
 
-This granted **cluster-admin equivalent permissions**, allowing the Beskar7 controller to:
-- No Access ALL Kubernetes resources 
-- No Perform ANY operation (create, delete, modify)
-- No Access sensitive resources like secrets, nodes, RBAC
-- No Potentially escalate privileges
-- No Bypass all security controls
+# ConfigMaps: only fetched by name (inspection-result handoff) and
+# created/updated/deleted by the controllers. No informer; list/watch are
+# intentionally omitted.
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create", "delete", "get", "patch", "update"]
 
-**Risk Level:** **CRITICAL** - This configuration is unsuitable for production use and violates security best practices.
+# Events: emitted by the controllers for major lifecycle changes.
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 
-### Security Hardening Solution
-
-The RBAC configuration has been completely rewritten to follow the **principle of least privilege**:
-
-## Current Secure RBAC Configuration
-
-### ClusterRole: `manager-role`
-
-The Beskar7 controller now has only the minimal permissions required for operation:
-
-#### Core Kubernetes Resources (Read-Only)
-```yaml
-# Secrets - Read-only access for Redfish credentials
+# Secrets: get for BMC credentials, bootstrap data, and CA bundles (all by name);
+# create/update/patch/delete for the per-host bootstrap-token Secret. list/watch
+# are required because PhysicalHostReconciler.SetupWithManager registers a
+# Watches(&Secret{}, ...) informer for credential rotation.
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list", "watch"]
-
-# Events - Write access for logging/monitoring
-- apiGroups: [""]
-  resources: ["events"] 
-  verbs: ["create", "patch"]
-```
-
-#### Cluster API Resources (Read-Only)
-```yaml
-# Cluster API clusters - Read-only monitoring
-- apiGroups: ["cluster.x-k8s.io"]
-  resources: ["clusters", "clusters/status"]
-  verbs: ["get", "list", "watch"]
-
-# Cluster API machines - Read-only monitoring
-- apiGroups: ["cluster.x-k8s.io"]
-  resources: ["machines", "machines/status"]
-  verbs: ["get", "list", "watch"]
-```
-
-#### Beskar7 Infrastructure Resources (Full Management)
-```yaml
-# Full management of Beskar7 CRDs
-- apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources: 
-    - "beskar7clusters"
-    - "beskar7machines" 
-    - "beskar7machinetemplates"
-    - "physicalhosts"
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 
-# Status subresource management
+# Cluster API: read-only on Cluster and Machine for owner-walks and endpoint
+# derivation.
+- apiGroups: ["cluster.x-k8s.io"]
+  resources: ["clusters", "clusters/status", "machines", "machines/status"]
+  verbs: ["get", "list", "watch"]
+
+# Leases: leader election.
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+
+# Beskar7 CRDs: full management.
 - apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources:
-    - "beskar7clusters/status"
-    - "beskar7machines/status"
-    - "beskar7machinetemplates/status"
-    - "physicalhosts/status"
+  resources: ["beskar7clusters", "beskar7machines", "physicalhosts"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["infrastructure.cluster.x-k8s.io"]
+  resources: ["beskar7clusters/finalizers", "beskar7machines/finalizers", "physicalhosts/finalizers"]
+  verbs: ["update"]
+- apiGroups: ["infrastructure.cluster.x-k8s.io"]
+  resources: ["beskar7clusters/status", "beskar7machines/status", "physicalhosts/status"]
   verbs: ["get", "patch", "update"]
 
-# Finalizer management
+# Beskar7MachineTemplate: read-only — there is no template controller, just CAPI
+# walks via shared informer cache.
 - apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources:
-    - "beskar7clusters/finalizers"
-    - "beskar7machines/finalizers"
-    - "beskar7machinetemplates/finalizers"
-    - "physicalhosts/finalizers"
-  verbs: ["update"]
-```
+  resources: ["beskar7machinetemplates"]
+  verbs: ["get", "list", "watch"]
 
-#### Security Monitoring (Read-Only)
-```yaml
-# RBAC monitoring for security validation
+# RBAC introspection: required for the controller to read its own ClusterRole at
+# startup (logged for diagnostics).
 - apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterroles", "clusterrolebindings"]
+  resources: ["clusterrolebindings", "clusterroles"]
   verbs: ["get", "list", "watch"]
 ```
 
-### Namespace Role: `manager-role` (beskar7-system)
+(The Helm chart variant is identical apart from name templating; the chart does not relax any rule.)
 
-Limited namespace-scoped permissions for webhook certificate management:
+## What is intentionally absent
 
-```yaml
-# Certificate and webhook management in beskar7-system namespace
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["rolebindings", "roles"]
-  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
-```
+- No `*` apiGroups, resources, or verbs.
+- No `secrets: create/update/patch/delete` cluster-wide. The controller writes Secrets only via `controllerutil.CreateOrUpdate` on a deterministic name (`<host>-bootstrap-token`) in the host's namespace.
+- No write access to `cluster.x-k8s.io` resources. Beskar7 only reads CAPI Cluster and Machine.
+- No `nodes`, `pods`, `services`, `serviceaccounts`, `roles`, or `rolebindings`. The controller does not need them.
+- No `impersonate` verb on any resource.
 
-## Security Validation
+## Per-controller breakdown
 
-The RBAC configuration has been validated using Beskar7's internal security monitoring system:
+| Controller | What it accesses | Why |
+|---|---|---|
+| `PhysicalHostReconciler` | `physicalhosts`, `physicalhosts/status`, `physicalhosts/finalizers`, `secrets` (get + list/watch via informer), `configmaps` (get + create/delete/patch/update), `events` | Manage the host's lifecycle, fetch BMC credentials, consume the inspection-result ConfigMap. |
+| `Beskar7MachineReconciler` | `beskar7machines`, `beskar7machines/status`, `beskar7machines/finalizers`, `physicalhosts` (get + patch), `secrets` (get + create/update/patch/delete), `machines` / `machines/status` (read), `cluster.x-k8s.io` resources (read) | Claim a host, read bootstrap data, mint per-host token Secret, walk to owner Machine. |
+| `Beskar7ClusterReconciler` | `beskar7clusters`, `beskar7clusters/status`, `beskar7clusters/finalizers`, `machines` (read), `physicalhosts` (read for failure-domain discovery) | Derive the control-plane endpoint and failure domains. |
 
-### Validation Results
-- **No CRITICAL security issues**
-- **No HIGH security issues**
-- **No overly broad permissions**
-- **No wildcard permissions**
-- **Follows principle of least privilege**
+## Residual cluster-wide scope
 
-### Security Monitoring Integration
+The Secret `list, watch` verbs are cluster-wide, not namespace-scoped. This is required by the controller-runtime informer registered by `PhysicalHostReconciler` to trigger reconciles on credential rotation. The data path of every controller fetches Secrets by name only; the cluster-wide scope is for the watch only.
 
-The controller includes built-in security monitoring that:
-- Validates RBAC configurations at runtime
-- Detects overly broad permissions
-- Monitors for security violations
-- Reports security findings via Kubernetes events
+This residual scope is tracked as `SEC-2` (the partial closure decision is `D-007`) in `.claude/context/PROJECT_CONTEXT.md`. A label-selected partial cache is the planned v0.5 follow-up: change the informer to watch only Secrets carrying a Beskar7-owned label, narrowing the cache to BMC-credentials + bootstrap-token Secrets.
 
-## Implementation Details
+## Verification
 
-### Code Changes
+After install, confirm the deployed ClusterRole:
 
-1. **Removed wildcard annotations in `cmd/manager/main.go`:**
-   ```diff
-   - //+kubebuilder:rbac:groups=*,resources=*,verbs=*
-   + //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch
-   + //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-   ```
-
-2. **Updated `config/rbac/role.yaml`** with minimal permissions
-
-3. **Regenerated manifests** using `make manifests`
-
-### Controller Requirements Analysis
-
-Each permission was justified based on actual controller functionality:
-
-- **Secrets (read-only):** Required for Redfish BMC credentials
-- **Events (create/patch):** Required for logging and monitoring
-- **Cluster API resources (read-only):** Required for monitoring machine states
-- **Beskar7 CRDs (full):** Required for primary controller functionality
-- **RBAC (read-only):** Required for security monitoring
-- **Namespace RBAC:** Required for webhook certificate management
-
-## Deployment Impact
-
-### Production Benefits
-
-- **Significantly reduced attack surface**
-- **Compliance with security best practices**  
-- **Suitable for production environments**
-- **Passes security audits**
-- **Prevents privilege escalation**
-
-### No Functional Impact
-
-- *All controller functionality preserved**
-- **No breaking changes to APIs**
-- **Existing deployments continue to work**
-- **All webhooks function normally**
-
-## Verification Commands
-
-### Validate Current Permissions
 ```bash
-# Check ClusterRole permissions
+# Helm install:
+kubectl get clusterrole -l app.kubernetes.io/name=beskar7 -o yaml
+
+# Kustomize install:
 kubectl get clusterrole manager-role -o yaml
-
-# Check ClusterRoleBinding
 kubectl get clusterrolebinding manager-rolebinding -o yaml
-
-# Verify no wildcard permissions
-kubectl get clusterrole manager-role -o jsonpath='{.rules[*].resources}' | grep -c '\*' || echo "No wildcards found"
 ```
 
-### Security Monitoring
+Look for any wildcards or unexpected verbs:
+
 ```bash
-# Check security monitoring status
-kubectl logs -n beskar7-system -l control-plane=beskar7-controller-manager | grep "security"
-
-# Check for security events
-kubectl get events -n beskar7-system --field-selector reason=RBACSecurityIssue
+kubectl get clusterrole manager-role -o jsonpath='{range .rules[*]}{.apiGroups}{" / "}{.resources}{" / "}{.verbs}{"\n"}{end}' | grep -E "\\*|impersonate"
 ```
 
-## Comparison with Industry Standards
+That command should return nothing.
 
-| Security Aspect | Before | After | Industry Standard |
-|------------------|--------|-------|-------------------|
-| Wildcard Permissions | No Full wildcards | Yes None | Yes None allowed |
-| Privilege Level | No Cluster Admin | Yes Minimal required | Yes Least privilege |
-| Resource Scope | No All resources | Yes Specific resources | Yes Scoped access |
-| Verb Scope | No All operations | Yes Required operations | Yes Limited verbs |
-| Security Monitoring | No None | Yes Built-in | Yes Recommended |
+Test what the controller can do as its ServiceAccount:
 
-## Migration Guide
+```bash
+kubectl auth can-i --list --as=system:serviceaccount:beskar7-system:beskar7-controller-manager
+```
 
-### For Existing Deployments
+## Customising
 
-1. **Update manifests:** New deployments automatically use secure RBAC
-2. **Existing deployments:** Upgrade using Helm or apply new manifests
-3. **No manual intervention required:** Changes are backward compatible
+There is no Helm value to relax or extend the ClusterRole at install time. To grant additional access:
 
-### For Custom Deployments
+1. Edit `charts/beskar7/templates/rbac.yaml` (Helm) or `config/rbac/role.yaml` (kustomize) directly.
+2. Re-render and apply.
+3. Add a kubebuilder marker on the controller that needs the access, so `make manifests` regenerates the YAML correctly on the next round-trip.
 
-If you have customized RBAC configurations:
+Do **not** add `*` rules. Reviewers will reject them; production operators will not deploy them.
 
-1. **Review your changes** against the new secure baseline
-2. **Remove any wildcard permissions** (`*` in apiGroups, resources, or verbs)
-3. **Apply principle of least privilege**
-4. **Test functionality** in development environment first
+## See also
 
-## Best Practices for RBAC Security
-
-### Do's
-- Grant only minimum required permissions
-- Use specific resource names when possible
-- Regular security audits of RBAC configurations
-- Monitor for security violations
-- Document permission requirements
-
-### Don'ts  
-- Never use wildcard permissions (`*`) in production
-- Never grant cluster-admin unless absolutely necessary
-- Never grant broad cross-namespace access
-- Never ignore security monitoring alerts
-- Never deploy without security review
-
-## Related Security Features
-
-- **TLS Security Configuration** - TLS certificate validation (see configuration.md)
-- **Credential Management** - Secure credential handling (see configuration.md)
-- **Network Policies** - Network segmentation (see configuration.md)
-- **Security Monitoring** - Continuous security validation (see troubleshooting.md)
-
-## References
-
-- [Kubernetes RBAC Documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
-- [Principle of Least Privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege)
-- [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes)
-- [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) 
+- [Security](README.md)
+- [Configuration](configuration.md)
+- [Security Troubleshooting](troubleshooting.md)

--- a/docs/security/troubleshooting.md
+++ b/docs/security/troubleshooting.md
@@ -1,652 +1,198 @@
-# Security Troubleshooting Guide
+# Security Troubleshooting
 
-This guide helps diagnose and resolve security-related issues in Beskar7.
+How to diagnose security-control failures in Beskar7.
 
-## Common Security Issues
+For an inventory of what's enforced, see [Security](README.md). For configuration recipes, see [Configuration](configuration.md). For general operational issues, see [Troubleshooting](../troubleshooting.md).
 
-### TLS Certificate Problems
+## TLS to the BMC
 
-#### Issue: Certificate Validation Failures
+### Symptom: `RedfishConnectionReady=False (CABundleFetchFailed)`
 
-**Symptoms:**
-- PhysicalHost webhook validation errors
-- Connection failures to BMC endpoints
-- TLS certificate validation errors in logs
-
-**Diagnosis:**
-```bash
-# Check PhysicalHost webhook events
-kubectl get events -n beskar7-system --field-selector reason=TLSSecurityIssue
-
-# Check certificate manually
-openssl s_client -connect bmc.example.com:443 -verify_return_error
-
-# Test TLS connection
-curl -v https://bmc.example.com
-```
-
-**Common Causes & Solutions:**
-
-1. **Self-signed certificates**
-   ```yaml
-   # Temporary fix for development
-   spec:
-     redfishConnection:
-       insecureSkipVerify: true  # Only for development!
-   
-   # Proper fix: Add custom CA
-   spec:
-     redfishConnection:
-       caCertificateSecretRef:
-         name: custom-ca-cert
-   ```
-
-2. **Expired certificates**
-   ```bash
-   # Check certificate expiry
-   echo | openssl s_client -connect bmc.example.com:443 2>/dev/null | openssl x509 -noout -dates
-   
-   # Solution: Renew BMC certificate
-   ```
-
-3. **Hostname mismatch**
-   ```bash
-   # Check certificate SANs
-   echo | openssl s_client -connect bmc.example.com:443 2>/dev/null | openssl x509 -noout -text | grep -A1 "Subject Alternative Name"
-   
-   # Solution: Use correct hostname or update certificate
-   ```
-
-4. **CA certificate not trusted**
-   ```yaml
-   # Add custom CA certificate
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: custom-ca-cert
-   data:
-     ca.crt: <base64-encoded-ca-cert>
-   ```
-
-#### Issue: Certificate Expiry Warnings
-
-**Symptoms:**
-- Warning events about certificate expiry
-- Security monitor alerts
-
-**Diagnosis:**
-```bash
-# Check certificate expiry events
-kubectl get events -n beskar7-system --field-selector reason=TLSSecurityIssue,type=Warning
-
-# View security report for certificate issues
-kubectl logs deployment/controller-manager -n beskar7-system | grep "certificate.*expir"
-```
-
-**Solutions:**
-```bash
-# Plan certificate renewal
-# 1. Generate new certificate
-# 2. Update BMC with new certificate
-# 3. Update custom CA if needed
-```
-
-### RBAC Permission Issues
-
-#### Issue: Permission Denied Errors
-
-**Symptoms:**
-- Controller unable to create/update resources
-- "forbidden" errors in logs
-- RBAC security violations
-
-**Diagnosis:**
-```bash
-# Check current permissions
-kubectl auth can-i --list --as=system:serviceaccount:beskar7-system:controller-manager
-
-# Check RBAC events
-kubectl get events -n beskar7-system --field-selector reason=RBACSecurityIssue
-
-# Verify ClusterRole
-kubectl get clusterrole manager-role -o yaml
-
-# Check ClusterRoleBinding
-kubectl get clusterrolebinding manager-rolebinding -o yaml
-```
-
-**Common Causes & Solutions:**
-
-1. **Missing permissions**
-   ```yaml
-   # Add missing permission to ClusterRole
-   rules:
-   - apiGroups: ["infrastructure.cluster.x-k8s.io"]
-     resources: ["physicalhosts"]
-     verbs: ["create"]  # Add missing verb
-   ```
-
-2. **Overly restrictive security policy**
-   ```yaml
-   # Update security policy to allow required permissions
-   security:
-     rbac:
-       max_allowed_permissions:
-         beskar7-controller:
-           - apiGroups: ["new-api-group"]
-             resources: ["new-resource"]
-             verbs: ["get", "list"]
-   ```
-
-3. **Service account not bound to role**
-   ```bash
-   # Check binding
-   kubectl get clusterrolebinding manager-rolebinding -o yaml
-   
-   # Fix: Ensure correct service account
-   subjects:
-   - kind: ServiceAccount
-     name: controller-manager
-     namespace: beskar7-system
-   ```
-
-#### Issue: Overly Broad Permissions Detected
-
-**Symptoms:**
-- Security monitor alerts about broad permissions
-- RBAC security warnings
-
-**Diagnosis:**
-```bash
-# Check RBAC security events
-kubectl get events -n beskar7-system --field-selector reason=RBACSecurityIssue
-
-# Review current permissions
-kubectl get clusterrole manager-role -o yaml
-```
-
-**Solutions:**
-```yaml
-# Replace broad permissions with specific ones
-# Bad:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
-
-# Good:
-- apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources: ["physicalhosts", "beskar7machines"]
-  verbs: ["get", "list", "watch", "create", "update", "patch"]
-```
-
-### Credential Security Issues
-
-#### Issue: Credential Validation Failures
-
-**Symptoms:**
-- PhysicalHost webhook validation errors
-- Secret validation failures
-- Password policy violations
-
-**Diagnosis:**
-```bash
-# Check credential events
-kubectl get events -n beskar7-system --field-selector reason=SecretSecurityIssue
-
-# Validate secret format
-kubectl get secret bmc-credentials -o yaml
-
-# Check password policy
-kubectl get configmap beskar7-security-policy -n beskar7-system -o yaml
-```
-
-**Common Causes & Solutions:**
-
-1. **Missing required fields**
-   ```yaml
-   # Ensure secret has required fields
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: bmc-credentials
-   data:
-     username: <base64-encoded>  # Required
-     password: <base64-encoded>  # Required
-   ```
-
-2. **Weak password**
-   ```bash
-   # Generate strong password
-   PASSWORD=$(openssl rand -base64 32)
-   kubectl patch secret bmc-credentials --patch='{"data":{"password":"'$(echo -n "$PASSWORD" | base64)'"}}'
-   ```
-
-3. **Old credentials**
-   ```bash
-   # Check credential age
-   kubectl get secret bmc-credentials -o jsonpath='{.metadata.creationTimestamp}'
-   
-   # Rotate credentials if needed
-   ```
-
-#### Issue: Authentication Failures to BMC
-
-**Symptoms:**
-- Redfish authentication errors
-- BMC connection failures
-- Invalid credentials errors
-
-**Diagnosis:**
-```bash
-# Test credentials manually
-USERNAME=$(kubectl get secret bmc-credentials -o jsonpath='{.data.username}' | base64 -d)
-PASSWORD=$(kubectl get secret bmc-credentials -o jsonpath='{.data.password}' | base64 -d)
-curl -k -u "$USERNAME:$PASSWORD" https://bmc.example.com/redfish/v1/Systems
-
-# Check PhysicalHost status
-kubectl get physicalhost server-01 -o yaml
-```
-
-**Solutions:**
-1. Verify credentials are correct
-2. Check BMC user account status
-3. Ensure account has required permissions
-4. Rotate credentials if compromised
-
-### Network Security Issues
-
-#### Issue: Network Policy Blocking Traffic
-
-**Symptoms:**
-- Connection timeouts
-- Network connectivity failures
-- Webhook failures
-
-**Diagnosis:**
-```bash
-# Check network policies
-kubectl get networkpolicy -n beskar7-system
-
-# Check pod connectivity
-kubectl exec -it deployment/controller-manager -n beskar7-system -- curl -v https://bmc.example.com
-
-# Check network policy logs (if supported)
-```
-
-**Solutions:**
-```yaml
-# Add missing egress rule for BMC communication
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-bmc-egress
-spec:
-  podSelector:
-    matchLabels:
-      control-plane: controller-manager
-  policyTypes:
-  - Egress
-  egress:
-  - to: []
-    ports:
-    - protocol: TCP
-      port: 443
-```
-
-#### Issue: Webhook Certificate Problems
-
-**Symptoms:**
-- Webhook validation failures
-- TLS handshake errors
-- Certificate verification errors
-
-**Diagnosis:**
-```bash
-# Check webhook certificate
-kubectl get secret beskar7-webhook-server-cert -n beskar7-system -o yaml
-
-# Check webhook configuration
-kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io
-
-# Test webhook manually
-kubectl create -f test-physicalhost.yaml --dry-run=server
-```
-
-**Solutions:**
-```bash
-# Recreate webhook certificates
-kubectl delete secret beskar7-webhook-server-cert -n beskar7-system
-# Restart manager to regenerate certs
-kubectl rollout restart deployment/beskar7-controller-manager -n beskar7-system
-```
-
-### Container Security Issues
-
-#### Issue: Security Context Violations
-
-**Symptoms:**
-- Pod creation failures
-- Security policy violations
-- Container startup errors
-
-**Diagnosis:**
-```bash
-# Check pod security violations
-kubectl get events -n beskar7-system --field-selector type=Warning
-
-# Check pod security context
-kubectl get pod -l control-plane=controller-manager -n beskar7-system -o yaml
-```
-
-**Solutions:**
-```yaml
-# Fix security context
-securityContext:
-  runAsNonRoot: true
-  runAsUser: 65532
-  runAsGroup: 65532
-  allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: true
-  capabilities:
-    drop: ["ALL"]
-```
-
-#### Issue: Resource Limit Violations
-
-**Symptoms:**
-- OOMKilled pods
-- CPU throttling
-- Performance issues
-
-**Diagnosis:**
-```bash
-# Check resource usage
-kubectl top pod -l control-plane=beskar7-controller-manager -n beskar7-system
-
-# Check resource limits
-kubectl get pod -l control-plane=controller-manager -n beskar7-system -o yaml | grep -A5 resources
-```
-
-**Solutions:**
-```yaml
-# Increase resource limits
-resources:
-  limits:
-    cpu: 1000m      # Increase from 500m
-    memory: 1Gi     # Increase from 512Mi
-  requests:
-    cpu: 200m       # Increase from 100m
-    memory: 256Mi   # Increase from 128Mi
-```
-
-## Security Monitoring Issues
-
-### Issue: Security Monitor Not Running
-
-**Symptoms:**
-- No security events generated
-- Missing security metrics
-- No security reports
-
-**Diagnosis:**
-```bash
-# Check if security monitoring is enabled
-kubectl get deployment controller-manager -n beskar7-system -o yaml | grep enable-security-monitoring
-
-# Check manager logs
-kubectl logs deployment/controller-manager -n beskar7-system | grep security
-
-# Check security monitor status
-kubectl get events -n beskar7-system | grep security
-```
-
-**Solutions:**
-```bash
-# Enable security monitoring
-kubectl patch deployment controller-manager -n beskar7-system \
-  --patch '{"spec":{"template":{"spec":{"containers":[{"name":"manager","args":["--leader-elect","--enable-security-monitoring=true"]}]}}}}'
-
-# Restart manager
-kubectl rollout restart deployment/controller-manager -n beskar7-system
-```
-
-### Issue: False Positive Security Alerts
-
-**Symptoms:**
-- Excessive security warnings
-- Valid configurations flagged as violations
-- Alert fatigue
-
-**Diagnosis:**
-```bash
-# Review security events
-kubectl get events -n beskar7-system --field-selector type=Warning
-
-# Check security policy configuration
-kubectl get configmap beskar7-security-policy -n beskar7-system -o yaml
-```
-
-**Solutions:**
-```yaml
-# Adjust security policy thresholds
-security:
-  tls:
-    expiry_warning_days: 15  # Reduce from 30 days
-  
-  credentials:
-    rotation_policy:
-      max_age_days: 180      # Increase from 90 days
-  
-  monitoring:
-    security_monitoring:
-      alert_on_medium: false # Disable medium alerts
-```
-
-## Debugging Tools and Commands
-
-### Security Status Commands
+The controller could not fetch or parse the CA bundle Secret named by `caBundleSecretRef`.
 
 ```bash
-# Overall security status
-kubectl get events -n beskar7-system --field-selector type=Warning
+kubectl describe physicalhost <name>
+# look for the RedfishConnectionReady condition
 
-# TLS security status
-kubectl get events -n beskar7-system --field-selector reason=TLSSecurityIssue
-
-# RBAC security status
-kubectl get events -n beskar7-system --field-selector reason=RBACSecurityIssue
-
-# Credential security status
-kubectl get events -n beskar7-system --field-selector reason=SecretSecurityIssue
-
-# Network policy status
-kubectl get networkpolicy -n beskar7-system
-
-# Security policy
-kubectl get configmap beskar7-security-policy -n beskar7-system -o yaml
+kubectl get secret <ca-secret-name> -n <namespace> -o yaml
 ```
 
-### Certificate Debugging
+Causes and fixes:
+
+- The Secret does not exist in the host's namespace. Create it.
+- The Secret has neither `ca.crt` nor `tls.crt` data keys. Add one (PEM-encoded, base64).
+- Both keys are empty. Populate `ca.crt`.
+
+### Symptom: `RedfishConnectionReady=False (InsecureCABundleConflict)`
+
+The PhysicalHost has both `insecureSkipVerify: true` and `caBundleSecretRef` set. These are mutually exclusive — pick one:
 
 ```bash
-# Check certificate details
-openssl s_client -connect bmc.example.com:443 -showcerts
+# Either remove caBundleSecretRef:
+kubectl patch physicalhost <name> --type=json -p='[{"op":"remove","path":"/spec/redfishConnection/caBundleSecretRef"}]'
 
-# Check certificate chain
-openssl s_client -connect bmc.example.com:443 -verify_return_error
-
-# Check certificate expiry
-echo | openssl s_client -connect bmc.example.com:443 2>/dev/null | openssl x509 -noout -dates
-
-# Check certificate SANs
-echo | openssl s_client -connect bmc.example.com:443 2>/dev/null | openssl x509 -noout -text | grep -A1 "Subject Alternative Name"
+# Or flip insecureSkipVerify to false:
+kubectl patch physicalhost <name> --type=merge -p='{"spec":{"redfishConnection":{"insecureSkipVerify":false}}}'
 ```
 
-### RBAC Debugging
+### Symptom: certificate validation fails for a public-CA-signed BMC
+
+Verify the chain manually:
 
 ```bash
-# Check current permissions
-kubectl auth can-i --list --as=system:serviceaccount:beskar7-system:controller-manager
-
-# Check specific permission
-kubectl auth can-i create physicalhosts --as=system:serviceaccount:beskar7-system:controller-manager
-
-# List all ClusterRoles
-kubectl get clusterrole | grep beskar7
-
-# Check ClusterRoleBinding
-kubectl get clusterrolebinding | grep beskar7
+openssl s_client -connect bmc.example.com:443 -showcerts -verify_return_error </dev/null
 ```
 
-### Network Debugging
+If `openssl` is happy but Beskar7 isn't, check the manager pod's CA pool. The default `gcr.io/distroless/static:nonroot` image includes the standard Mozilla bundle; an internal CA must be provided via `caBundleSecretRef`.
+
+## BMC credentials
+
+### Symptom: `RedfishConnectionReady=False (MissingCredentials)` / `(SecretNotFound)` / `(MissingSecretData)`
 
 ```bash
-# Test network connectivity
-kubectl exec -it deployment/controller-manager -n beskar7-system -- curl -v https://bmc.example.com
-
-# Check DNS resolution
-kubectl exec -it deployment/controller-manager -n beskar7-system -- nslookup bmc.example.com
-
-# Check network policies
-kubectl get networkpolicy -n beskar7-system -o yaml
-
-# Test webhook connectivity
-kubectl exec -it deployment/controller-manager -n beskar7-system -- curl -v https://kubernetes.default.svc/api/v1
+kubectl get physicalhost <name> -o jsonpath='{.status.errorMessage}'
+kubectl get secret <secret-name> -n <namespace>
+kubectl get secret <secret-name> -n <namespace> -o yaml | grep -A2 data:
 ```
 
-## Log Analysis
-
-### Enable Debug Logging
+The Secret needs `username` and `password` data keys (Opaque). If both keys are present but the BMC still rejects authentication, test manually:
 
 ```bash
-# Enable verbose logging
-kubectl patch deployment controller-manager -n beskar7-system \
-  --patch '{"spec":{"template":{"spec":{"containers":[{"name":"manager","args":["--leader-elect","--v=2"]}]}}}}'
-
-# Enable security debug logging
-kubectl patch deployment controller-manager -n beskar7-system \
-  --patch '{"spec":{"template":{"spec":{"containers":[{"name":"manager","env":[{"name":"BESKAR7_SECURITY_DEBUG","value":"true"}]}]}}}}'
+USER=$(kubectl get secret <secret-name> -n <ns> -o jsonpath='{.data.username}' | base64 -d)
+PASS=$(kubectl get secret <secret-name> -n <ns> -o jsonpath='{.data.password}' | base64 -d)
+curl -sk -u "$USER:$PASS" https://<bmc-address>/redfish/v1/Systems
 ```
 
-### Log Patterns to Look For
+If `curl` succeeds, the credentials are correct — the problem is elsewhere (BMC firewall, BMC user disabled, BMC role lacks required privilege).
+
+## Bearer-token failures (`401 Unauthorized` from `:8082`)
+
+The callback endpoint returns an opaque `401` for every authentication failure. The verifier's specific error is logged at V(1) on the manager. To see why a request failed:
 
 ```bash
-# TLS errors
-kubectl logs deployment/controller-manager -n beskar7-system | grep -i "tls\|certificate\|x509"
+# Restart the manager with --zap-devel=true (development log encoder, V(1) included)
+kubectl edit deployment beskar7-controller-manager -n beskar7-system
+# Add --zap-devel=true to args, save, wait for rollout
 
-# RBAC errors
-kubectl logs deployment/controller-manager -n beskar7-system | grep -i "forbidden\|rbac\|permission"
-
-# Credential errors
-kubectl logs deployment/controller-manager -n beskar7-system | grep -i "auth\|credential\|password"
-
-# Security violations
-kubectl logs deployment/controller-manager -n beskar7-system | grep -i "security\|violation\|policy"
+# Tail the logs while the inspector retries:
+kubectl logs -n beskar7-system deployment/beskar7-controller-manager -f | grep -i bearer
 ```
 
-## Emergency Procedures
+Possible causes:
 
-### Disable Security Features
+| Log message | Cause | Fix |
+|---|---|---|
+| `get PhysicalHost: ... not found` | URL path references a host that does not exist. | Check the iPXE-rendered cmdline matches the actual `<namespace>/<host>`. |
+| `no bootstrap token issued for host ...` | `Status.Bootstrap.TokenHash` is empty. | The Beskar7Machine reconciler has not yet run `triggerInspection` for this host. Wait, or check Beskar7Machine status. |
+| `bootstrap token expired for host ...` | The token's `ExpiresAt` is in the past (30-min lifetime). | Trigger a re-mint — easiest is to delete the per-host Secret (`<host>-bootstrap-token`), the Beskar7Machine reconciler will mint a fresh one. The iPXE cmdline embedding the previous plaintext will be invalid; the host must re-PXE. |
+| `bootstrap token mismatch for host ...` | The plaintext on the wire does not hash to the stored hash. | Likely a stale iPXE cmdline. Rebuild the cmdline from the current Secret (`kubectl get secret <host>-bootstrap-token -o jsonpath='{.data.plaintext-token}' \| base64 -d`) and re-PXE the host. Persistent mismatch suggests cmdline truncation or shell-escape damage in your iPXE template. |
+| Clock skew between manager and host > 30m | Host clock far in the future or past. | NTP. |
 
-If security features are blocking operation:
+## RBAC
+
+### Symptom: controller logs show `forbidden`
 
 ```bash
-# Disable security monitoring temporarily
-kubectl patch deployment controller-manager -n beskar7-system \
-  --patch '{"spec":{"template":{"spec":{"containers":[{"name":"manager","args":["--leader-elect","--enable-security-monitoring=false"]}]}}}}'
-
-# Allow insecure TLS temporarily (development only)
-kubectl patch physicalhost server-01 \
-  --patch '{"spec":{"redfishConnection":{"insecureSkipVerify":true}}}'
-
-# Disable network policies temporarily
-kubectl delete networkpolicy --all -n beskar7-system
+kubectl logs -n beskar7-system deployment/beskar7-controller-manager | grep -i forbidden
 ```
 
-### Recovery from Security Lockout
-
-If RBAC changes lock out the controller:
+Identify the verb + resource being denied. Compare with the deployed ClusterRole:
 
 ```bash
-# Reset to minimal required permissions
-kubectl apply -f config/rbac/role.yaml
-
-# Restart controller
-kubectl rollout restart deployment/controller-manager -n beskar7-system
-
-# Verify permissions
-kubectl auth can-i --list --as=system:serviceaccount:beskar7-system:controller-manager
+kubectl auth can-i --list --as=system:serviceaccount:beskar7-system:beskar7-controller-manager
 ```
 
-## Performance Impact
+If the missing permission is for one of the resources the controller legitimately needs to access (e.g. `beskar7machines/finalizers`), the ClusterRole shipped with the chart is incomplete — file a bug. If it is something Beskar7 should not need, do not grant it; file a bug instead.
 
-Security features may impact performance:
+### Symptom: metrics scraping returns 401/403
 
-### Monitoring Performance
+`/metrics` on `:8443` requires a Kubernetes-authenticated request. Your Prometheus ServiceAccount needs the `metrics_reader` ClusterRole:
 
 ```bash
-# Check resource usage
-kubectl top pod -l control-plane=controller-manager -n beskar7-system
-
-# Monitor security scan duration
-kubectl logs deployment/beskar7-controller-manager -n beskar7-system | grep "security scan"
-
-# Check metrics
-curl http://localhost:8080/metrics | grep beskar7_security
+kubectl get clusterrole metrics-reader -o yaml
+kubectl create clusterrolebinding prometheus-metrics-reader \
+  --clusterrole=metrics-reader \
+  --serviceaccount=monitoring:prometheus
 ```
 
-### Optimization Recommendations
+For local development (`kubectl port-forward`), set `--secure-metrics=false` on the manager and use plain HTTP.
 
-1. **Reduce scan frequency** for non-critical environments
-2. **Disable unnecessary security checks** in development
-3. **Increase resource limits** if security monitoring causes resource pressure
-4. **Use caching** for TLS certificate validation
+## Webhook
 
-## Getting Help
+### Symptom: `failed calling webhook "validation.beskar7cluster..."`
 
-### Collect Diagnostic Information
+The Beskar7Cluster validating webhook is the only webhook in the codebase. Check:
 
 ```bash
-#!/bin/bash
-# Security diagnostic script
-
-echo "=== Beskar7 Security Diagnostics ==="
-echo "Date: $(date)"
-echo
-
-echo "=== Security Events ==="
-kubectl get events -n beskar7-system --field-selector type=Warning
-
-echo "=== Security Policy ==="
-kubectl get configmap beskar7-security-policy -n beskar7-system -o yaml
-
-echo "=== RBAC Configuration ==="
-kubectl get clusterrole manager-role -o yaml
-kubectl get clusterrolebinding manager-rolebinding -o yaml
-
-echo "=== Network Policies ==="
-kubectl get networkpolicy -n beskar7-system -o yaml
-
-echo "=== Controller Logs (last 100 lines) ==="
-kubectl logs deployment/beskar7-controller-manager -n beskar7-system --tail=100
-
-echo "=== Controller Status ==="
-kubectl get deployment beskar7-controller-manager -n beskar7-system -o yaml
+kubectl get validatingwebhookconfigurations -l app.kubernetes.io/name=beskar7
+kubectl get certificate -n beskar7-system
+kubectl get pods -n beskar7-system
 ```
 
-### Contact Support
+Common causes:
 
-When reporting security issues, include:
+- cert-manager not installed or not Ready. The chart's `Certificate` resource issues the webhook serving cert; without it the webhook server fails the TLS handshake. Install cert-manager and wait for the Certificate to reach `Ready=True`.
+- `webhook.enabled=false` in Helm values, but the operator still applied a `ValidatingWebhookConfiguration`. Either delete the orphaned config or re-enable the webhook.
+- The manager pod's webhook server is not running. Inspect logs for cert-load errors.
 
-1. Diagnostic information from the script above
-2. Description of the issue and steps to reproduce
-3. Environment details (Kubernetes version, deployment method)
-4. Any custom security configurations
-5. Timeline of when the issue started
+### Symptom: a PhysicalHost / Beskar7Machine / Beskar7MachineTemplate validation error from a webhook
 
-### Community Resources
+There is **no** webhook for those three CRDs. Any "webhook denied" error mentioning them is from a stale `ValidatingWebhookConfiguration` or `MutatingWebhookConfiguration` left over from a v0.3 install. Remove the orphaned configurations:
 
-- **GitHub Issues**: https://github.com/projectbeskar/beskar7/issues
-- **Security Advisory**: security@beskar7.io
-- **Community Slack**: #beskar7-security
-- **Documentation**: https://docs.beskar7.io/security/ 
+```bash
+kubectl get validatingwebhookconfigurations | grep beskar7
+kubectl get mutatingwebhookconfigurations | grep beskar7
+# delete any that reference physicalhost, beskar7machine, or beskar7machinetemplate paths
+```
+
+## NetworkPolicy
+
+### Symptom: callback endpoint timeouts from booted hosts
+
+Bare-metal nodes typically come up on a different network than the Pod CIDR. The chart's NetworkPolicy allows ingress on `:8082` from any source — the bearer token is the access control. If a Pod-network NetworkPolicy in your cluster blocks `:8082`, edit it.
+
+To debug from inside a Pod that has cluster network access:
+
+```bash
+kubectl run -it --rm debug --image=curlimages/curl --restart=Never -- \
+  curl -kv -H "Authorization: Bearer test" \
+       https://<release>-controller-manager.<namespace>.svc.cluster.local:8082/healthz
+```
+
+`/healthz` does not require authentication; if even that times out, the issue is network plumbing, not auth.
+
+## Container security
+
+### Symptom: pod fails to start with security-context error
+
+If a Pod Security Admission profile is enforced on the namespace, verify the pod manifest matches the chart's expectations:
+
+```bash
+kubectl get pod -n beskar7-system -l app.kubernetes.io/name=beskar7 -o yaml | grep -A20 securityContext
+```
+
+The chart's `Deployment` is compatible with `restricted`; if you have customised the manifest and dropped a required field, restore it.
+
+## Diagnostic bundle
+
+When opening an issue with a security symptom:
+
+```bash
+kubectl get pods -n beskar7-system -o yaml > pods.yaml
+kubectl get clusterrole -l app.kubernetes.io/name=beskar7 -o yaml > rbac-clusterrole.yaml
+kubectl get networkpolicy -n beskar7-system -o yaml > networkpolicy.yaml
+kubectl get validatingwebhookconfigurations -l app.kubernetes.io/name=beskar7 -o yaml > webhooks.yaml
+kubectl logs -n beskar7-system deployment/beskar7-controller-manager --tail=500 > controller.log
+
+kubectl get physicalhost -o yaml > physicalhosts.yaml          # redact BMC addresses if shareable
+kubectl get events -A --sort-by='.lastTimestamp' > events.txt
+```
+
+Do not include the BMC credentials Secret or any per-host bootstrap-token Secret — both contain plaintext secrets.
+
+## See also
+
+- [Security](README.md)
+- [Configuration](configuration.md)
+- [RBAC Hardening](rbac-hardening.md)
+- [General Troubleshooting](../troubleshooting.md)

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -1,318 +1,164 @@
-# State Management and Recovery
+# State Management
 
-Beskar7 implements a hardened state machine for PhysicalHost resources that ensures reliable state transitions, automatic recovery from stuck states, and protection against race conditions.
+This page describes the lifecycle of a `PhysicalHost` — the states it moves through, what triggers each transition, and how to recover when it gets stuck.
 
-## Overview
+The state constants are defined in `api/v1beta1/physicalhost_types.go:10-26`. The transitions are driven by `controllers/physicalhost_controller.go` and the `Beskar7Machine` reconciler in `controllers/beskar7machine_controller.go`.
 
-The state management system provides:
-- **Validated State Transitions**: All state changes are validated before execution
-- **Automatic Recovery**: Detects and recovers from stuck or inconsistent states
-- **Race Condition Protection**: Prevents concurrent modifications from causing invalid states
-- **Comprehensive Logging**: Events and logs for troubleshooting state issues
+## States
 
-## PhysicalHost State Machine
+| Constant | Status string | Meaning |
+|---|---|---|
+| `StateNone` | `""` | Initial state before the first reconcile. |
+| `StateUnknown` | `"Unknown"` | The reconciler could not determine state (rare; transient). |
+| `StateEnrolling` | `"Enrolling"` | The reconciler is establishing the BMC connection for the first time. |
+| `StateAvailable` | `"Available"` | BMC reachable; no consumer claim. Eligible for a Beskar7Machine to claim. |
+| `StateInUse` | `"InUse"` | A Beskar7Machine has claimed the host (`Spec.ConsumerRef` is set). |
+| `StateInspecting` | `"Inspecting"` | The inspection image is booting / running on the host. |
+| `StateReady` | `"Ready"` | The inspection report has been validated and persisted; the host is ready for the target OS. |
+| `StateError` | `"Error"` | A terminal-or-recoverable error condition. See `Status.ErrorMessage`. |
 
-### State Diagram
+The legacy `Claimed`, `Provisioning`, `Provisioned`, `Deprovisioning` strings from v0.3 are gone. The Go code retains deprecated aliases (`StateClaimed = "InUse"`, etc.) for backward compatibility, but they all map to the new state strings — do not rely on the old strings appearing in `kubectl get`.
+
+## State diagram
 
 ```
-            
-    None     ▶ Enrolling   ▶ Available   ▶   Claimed   
-            
-                                                                
-                                                                v
-                                                       
-                                                       Provisioning 
-                                                       
-                                                                
-                                                                v
-                                                       
-                                                        Provisioned 
-                                                       
-                                                                
-                                                                v
-       ▶
-                                           Error                    
-                           
-                                               
-                                               v
-                                    
-                                    Deprovisioning
-                                    
+            (object created)
+                  │
+                  ▼
+              Available  ◀───────────────────────────────────────┐
+                  │                                              │
+   Beskar7Machine │ sets spec.consumerRef                        │ Beskar7Machine
+   (atomic claim) │                                              │ deletion releases
+                  ▼                                              │ ConsumerRef
+                InUse                                            │
+                  │                                              │
+   Beskar7Machine │ patches inspection-request="inspect"         │
+                  ▼                                              │
+              Inspecting                                         │
+                  │                                              │
+   Beskar7Machine │ patches inspection-request="inspect-complete"│
+                  │ after validating the report                  │
+                  ▼                                              │
+                Ready  ───────────────────────────────────────► (deletion)
+                  
+              ┌───────────────────────────┐
+              │   Error  (any state)      │  recovers when the underlying
+              └───────────────────────────┘  problem clears (e.g. BMC reachable)
 ```
 
-### State Definitions
+## What drives each transition
 
-| State | Description | Valid Transitions |
-|-------|-------------|-------------------|
-| `None` | Initial state before enrollment | `Enrolling` |
-| `Enrolling` | Connecting to Redfish endpoint | `Available`, `Error` |
-| `Available` | Ready to be claimed | `Claimed`, `Error`, `Deprovisioning` |
-| `Claimed` | Reserved by a consumer | `Provisioning`, `Available`, `Error` |
-| `Provisioning` | Being configured | `Provisioned`, `Available`, `Error` |
-| `Provisioned` | Successfully configured | `Available`, `Deprovisioning` |
-| `Error` | Error state requiring intervention | `Enrolling`, `Available`, `Deprovisioning` |
-| `Deprovisioning` | Being cleaned up | *(final state)* |
+| From | To | Trigger | Where |
+|---|---|---|---|
+| (no state) | `Available` | First successful Redfish reconcile, no `ConsumerRef`. | `physicalhost_controller.go:reconcileNormal` |
+| `Available` | `InUse` | A Beskar7Machine writes `Spec.ConsumerRef`. | `beskar7machine_controller.go:findAndClaimOrGetAssociatedHost` |
+| `InUse` | `Inspecting` | Beskar7Machine writes `inspection-request: inspect` annotation. | `beskar7machine_controller.go:triggerInspection` |
+| `Inspecting` | `Ready` | Beskar7Machine writes `inspection-request: inspect-complete` after hardware validation, OR the inspection-result ConfigMap is consumed and the report is good. | `beskar7machine_controller.go:validateInspectionReport`, `physicalhost_controller.go:applyInspectionResultAnnotation` |
+| `Inspecting` | `Error` | Inspection timeout (10 min default) — Beskar7Machine writes `inspection-request: timeout`. | `beskar7machine_controller.go:handleInspectingHost` |
+| any | `Error` | BMC unreachable, credentials missing, TLS-config conflict, Redfish query failed. | `physicalhost_controller.go:reconcileNormal` |
+| `Error` | `Available` | The underlying error clears (BMC reachable again, secret fixed, TLS config fixed). | `physicalhost_controller.go:reconcileNormal` |
+| `InUse` / `Inspecting` / `Ready` | `Available` | Beskar7Machine deletion clears `Spec.ConsumerRef`. | `beskar7machine_controller.go:reconcileDelete` |
 
-### Transition Requirements
+## Atomic claim
 
-#### Enrolling -> Available
-- Redfish connection successful
-- Hardware details retrieved
+Two Beskar7Machines can race to claim the same `Available` host. The race is resolved server-side:
 
-#### Available -> Claimed  
-- `ConsumerRef` must be set
-- Host must not be in error state
+1. The reconciler lists `PhysicalHost` filtered by the `status.state` field index for `Available`.
+2. It selects the first host with `ConsumerRef == nil`.
+3. It patches the host with `MergeFromWithOptions(base, MergeFromWithOptimisticLock{})`. The optimistic-locking option means the patch carries the host's current `resourceVersion`, so a concurrent claim from another reconciler fails fast with `409 Conflict`.
+4. The losing reconciler gets the conflict, requeues, re-lists, and either picks a different host or returns empty.
 
-#### Claimed -> Provisioning
-- `ConsumerRef` must be set
-- `BootISOSource` must be set
+This means exactly one Beskar7Machine succeeds per host. There is no separate state for "claim in flight" — the claim is the patch.
 
-#### Provisioning -> Provisioned
-- Boot configuration successful
-- Host powered on
+## Bootstrap and inspection signaling
 
-#### Any State -> Error
-- Always allowed (for error handling)
+The `Beskar7Machine` reconciler signals work to the host through annotations on `Spec` (never via `Status`); the `PhysicalHost` reconciler is the sole writer of the host's status. This pattern (decision D-005 in `.claude/context/PROJECT_CONTEXT.md`) ensures every controller owns its own resource's status.
 
-#### Error -> Recovery States
-- `Error -> Enrolling`: Redfish connection info present
-- `Error -> Available`: Host not claimed, connection healthy
+Annotations consumed by the `PhysicalHost` reconciler:
 
-## Automatic Recovery
+| Annotation | Producer | Consumer action |
+|---|---|---|
+| `infrastructure.cluster.x-k8s.io/inspection-request` | `Beskar7Machine` controller | Drive `Status.State` and `Status.InspectionPhase`. Values: `inspect`, `inspect-complete`, `timeout`. |
+| `infrastructure.cluster.x-k8s.io/bootstrap-url` | `Beskar7Machine` controller | Persist URL to `Status.Bootstrap.URL`. |
+| `infrastructure.cluster.x-k8s.io/bootstrap-token` | `Beskar7Machine` controller | Persist hash + lifetime to `Status.Bootstrap.{TokenHash,IssuedAt,ExpiresAt}`. |
+| `infrastructure.cluster.x-k8s.io/inspection-result-ref` | Inspection HTTP handler | Read referenced ConfigMap, persist the `InspectionReport`, mark `HostInspected=True`, delete the ConfigMap. |
 
-### Stuck State Detection
+## Recovery
 
-The system automatically detects hosts stuck in transitional states:
+### Stuck in `Enrolling`
 
-- **Detection Timeout**: 15 minutes (configurable)
-- **Check Frequency**: Every reconciliation cycle
-- **Recovery Actions**: Automatic state transition or error reporting
+The reconciler is unable to complete the first BMC handshake.
 
-### Recovery Strategies
-
-#### Enrolling State (Stuck)
-- Retry Redfish connection
-- Transition to `Error` if connection fails repeatedly
-
-#### Provisioning State (Stuck)  
-- Check boot configuration status
-- Retry provisioning steps
-- Transition to `Error` if provisioning fails
-
-#### Error State Recovery
-- Attempt transition to `Available` if host is healthy
-- Retry `Enrolling` if connection issues resolved
-
-### Configuration
-
-Recovery behavior and reconciliation safety can be configured via command-line flags or environment variables. Flags take precedence; the flags accept values from env defaults shown below.
-
-- Flags:
-  - `--reconcile-timeout` (default `2m`, env `RECONCILE_TIMEOUT`): Maximum reconciliation time per `PhysicalHost` reconcile loop.
-  - `--stuck-state-timeout` (default `15m`, env `STUCK_STATE_TIMEOUT`): Time before considering a host stuck in a transitional state.
-  - `--max-retries` (default `3`, env `MAX_RETRIES`): Maximum retries for guarded state transitions.
-
-- Example deployment arguments and env (see `config/manager/manager.yaml`):
-  ```yaml
-  args:
-    - --reconcile-timeout=$(RECONCILE_TIMEOUT)
-    - --stuck-state-timeout=$(STUCK_STATE_TIMEOUT)
-    - --max-retries=$(MAX_RETRIES)
-  env:
-    - name: RECONCILE_TIMEOUT
-      value: "2m"
-    - name: STUCK_STATE_TIMEOUT
-      value: "15m"
-    - name: MAX_RETRIES
-      value: "3"
-  ```
-
-## Troubleshooting
-
-### Common Issues
-
-#### Host Stuck in Enrolling State
-
-**Symptoms:**
-- Host remains in `Enrolling` state for > 15 minutes
-- No progress in Redfish connection
-
-**Diagnosis:**
 ```bash
-# Check host status
-kubectl get physicalhost <host-name> -o yaml
-
-# Check events
-kubectl describe physicalhost <host-name>
-
-# Check controller logs
-kubectl logs -n beskar7-system deployment/beskar7-controller-manager
+kubectl describe physicalhost <name>
 ```
 
-**Resolution:**
-1. Verify Redfish credentials in secret
-2. Check network connectivity to BMC
-3. Validate BMC address format
-4. Check for InsecureSkipVerify setting if using self-signed certificates
+Look at the `RedfishConnectionReady` condition reason — it is one of `MissingCredentials`, `SecretNotFound`, `MissingSecretData`, `RedfishConnectionFailed`, or `RedfishQueryFailed`. Fix the credentials Secret or the BMC address; the next reconcile transitions to `Available`.
 
-#### Host Stuck in Provisioning State
+### Stuck in `Inspecting`
 
-**Symptoms:**
-- Host remains in `Provisioning` state for > 15 minutes
-- Boot configuration appears incomplete
+The host booted but the inspection image never POSTed a report. Check:
 
-**Diagnosis:**
 ```bash
-# Check provisioning status
-kubectl get physicalhost <host-name> -o jsonpath='{.status}'
-
-# Check associated machine
-kubectl get beskar7machine <machine-name> -o yaml
+kubectl get physicalhost <name> -o jsonpath='{.status.inspectionPhase}'
+kubectl get physicalhost <name> -o jsonpath='{.status.inspectionTimestamp}'
 ```
 
-**Resolution:**
-1. Verify boot ISO URL is accessible
-2. Check host power state via BMC
-3. Validate boot configuration in BMC
-4. Check for hardware compatibility issues
+If `inspectionTimestamp` is more than 10 minutes ago, the Beskar7Machine controller will mark `InspectionTimedOut` (terminal) and write `inspection-request: timeout`, which moves the host to `Error`. To recover, fix the underlying iPXE / inspection-image / network issue, then delete-and-recreate the `Beskar7Machine` (which deletes the BMC token Secret, clears `ConsumerRef`, and lets the host return to `Available`).
 
-#### State Consistency Errors
+### Stuck in `Error`
 
-**Symptoms:**
-- Events showing "StateInconsistent"
-- Frequent state transitions
+`Status.ErrorMessage` is the source of truth. Common cases:
 
-**Diagnosis:**
+- `redfishConnection.insecureSkipVerify=true is mutually exclusive with caBundleSecretRef`: edit the spec — pick one. The reconciler resumes once the spec is valid.
+- `failed to get credentials secret`: the named Secret does not exist or is missing `username`/`password`. Create or fix it.
+- `Inspection timed out`: see above.
+
+### Force release
+
+If the BMC is permanently unreachable and you need to delete the consuming Beskar7Machine without waiting for the Redfish power-off / boot-clear, set the force-release annotation on the Beskar7Machine before deleting it:
+
 ```bash
-# Check for inconsistent fields
-kubectl get physicalhost <host-name> -o yaml | grep -E "(consumerRef|bootIsoSource|state)"
+kubectl annotate beskar7machine <name> \
+  infrastructure.cluster.x-k8s.io/force-release=true
+kubectl delete beskar7machine <name>
 ```
 
-**Resolution:**
-1. Ensure `ConsumerRef` alignment with state
-2. Verify `BootISOSource` is set only when needed
-3. Check for manual modifications to spec fields
+The Beskar7Machine controller skips the Redfish cleanup, clears `ConsumerRef`, and removes the finalizer. The host returns to `Available`.
 
-### Manual Recovery
+### Last-resort finalizer removal
 
-If automatic recovery fails, manual intervention may be required:
+If a finalizer is genuinely stuck (and only after exhausting the recovery paths above), you can remove it manually. This is destructive — it leaves Redfish state untouched.
 
-#### Force State Reset
 ```bash
-# Clear consumer reference to release host
-kubectl patch physicalhost <host-name> --type='merge' -p='{"spec":{"consumerRef":null}}'
-
-# Clear boot ISO source  
-kubectl patch physicalhost <host-name> --type='merge' -p='{"spec":{"bootIsoSource":null}}'
+kubectl patch physicalhost <name> --type=merge -p '{"metadata":{"finalizers":[]}}'
 ```
 
-#### Reset to Available State
-The controller will automatically transition to `Available` when spec fields are cleared.
+## Observability
 
-#### Emergency Cleanup
-```bash
-# Remove finalizer to force deletion (USE WITH CAUTION)
-kubectl patch physicalhost <host-name> --type='merge' -p='{"metadata":{"finalizers":[]}}'
-```
+### Conditions
 
-## Monitoring and Observability
+`kubectl describe physicalhost <name>` shows the conditions list. Key types:
 
-### Metrics
-
-The state machine exposes metrics for monitoring:
-
-- `beskar7_physicalhost_state_transitions_total`: Total state transitions
-- `beskar7_physicalhost_stuck_states_total`: Number of stuck state detections
-- `beskar7_physicalhost_recovery_attempts_total`: Recovery attempts
-- `beskar7_physicalhost_state_duration_seconds`: Time spent in each state
+- `RedfishConnectionReady` — BMC connectivity.
+- `HostAvailable` — host has no consumer.
+- `HostInspected` — inspection report has been persisted.
 
 ### Events
 
-State changes generate Kubernetes events:
-
 ```bash
-# View state-related events
 kubectl get events --field-selector involvedObject.kind=PhysicalHost
 ```
 
-### Logging
+The controller emits events for major transitions and for warnings like deleting a still-claimed host.
 
-State machine operations are logged with structured logging:
+### Metrics
 
-```json
-{
-  "level": "info",
-  "msg": "State transition validated",
-  "physicalhost": "default/host-1",
-  "from": "Available", 
-  "to": "Claimed",
-  "reason": "ConsumerAssigned"
-}
-```
+See [Metrics](metrics.md) for the Prometheus surface. The relevant metric for state observation is `beskar7_controller_physicalhost_states_total{state=...}`.
 
-## Best Practices
+## See also
 
-### For Operations Teams
-
-1. **Monitor State Metrics**: Set up alerts for stuck states and failed recoveries
-2. **Regular Health Checks**: Monitor hosts in transitional states
-3. **Event Monitoring**: Set up log aggregation for state transition events
-4. **Backup Recovery**: Document manual recovery procedures
-
-### For Developers
-
-1. **State Validation**: Always use the state machine for transitions
-2. **Error Handling**: Implement proper error transitions
-3. **Testing**: Test state transitions in development environments
-4. **Documentation**: Document any custom state logic
-
-### For End Users
-
-1. **Avoid Manual Edits**: Don't manually edit PhysicalHost status fields
-2. **Use Proper Workflow**: Follow claiming -> provisioning -> release workflow  
-3. **Monitor Events**: Check events if hosts appear stuck
-4. **Report Issues**: Report persistent state issues to operations team
-
-## State Machine API
-
-### Using State Machine in Controllers
-
-```go
-// Initialize state machine
-stateMachine := statemachine.NewPhysicalHostStateMachine(logger)
-stateGuard := statemachine.NewStateTransitionGuard(client, logger)
-
-// Validate transition
-if err := stateMachine.ValidateTransition(host, newState); err != nil {
-    return fmt.Errorf("invalid transition: %w", err)
-}
-
-// Safe transition with retries
-err := stateGuard.SafeStateTransition(ctx, host, stateMachine, newState, reason, maxRetries)
-```
-
-### State Consistency Validation
-
-```go
-// Validate current state consistency
-if err := stateMachine.ValidateStateConsistency(host); err != nil {
-    logger.Error(err, "State consistency validation failed")
-    // Handle inconsistency...
-}
-```
-
-## Security Considerations
-
-- **RBAC**: State transitions respect Kubernetes RBAC policies
-- **Validation**: All transitions are validated before execution
-- **Audit Trail**: State changes are logged and recorded as events
-- **Race Protection**: Optimistic locking prevents concurrent modification issues
-
-## Version Compatibility
-
-This state management system is compatible with:
-- Kubernetes 1.25+
-- Cluster API v1.5+
-- Beskar7 v1.0+
-
-State machine behavior is backward compatible, but new validation rules may reject previously invalid configurations. 
+- [PhysicalHost](physicalhost.md)
+- [Beskar7Machine](beskar7machine.md)
+- [Architecture](architecture.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,11 +52,13 @@ kubectl rollout restart deployment/beskar7-controller-manager -n beskar7-system
 
 **Symptom:**
 ```
-failed calling webhook "mutation.physicalhost.infrastructure.cluster.x-k8s.io"
+failed calling webhook "validation.beskar7cluster.infrastructure.cluster.x-k8s.io"
 x509: certificate signed by unknown authority
 ```
 
-**Cause:** cert-manager not installed or not ready
+There is exactly one webhook in v0.4: the Beskar7Cluster validating webhook (`api/v1beta1/webhooks/beskar7cluster_webhook.go`). If your error mentions `physicalhost`, `beskar7machine`, or `beskar7machinetemplate` webhooks, those are stale `ValidatingWebhookConfiguration`/`MutatingWebhookConfiguration` objects left over from a v0.3 install — see step 3 below.
+
+**Cause:** cert-manager not installed or not ready, or webhook serving cert not issued.
 
 **Solution:**
 ```bash
@@ -66,15 +68,36 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 # Wait for it to be ready
 kubectl wait --for=condition=Available --timeout=300s deployment/cert-manager -n cert-manager
 
+# Verify the chart's Certificate is Ready
+kubectl get certificate -n beskar7-system
+
 # Restart Beskar7
 kubectl rollout restart deployment/beskar7-controller-manager -n beskar7-system
 
-# Verify webhook is working
-kubectl get validatingwebhookconfigurations
-kubectl get mutatingwebhookconfigurations
+# Verify the only expected webhook is registered
+kubectl get validatingwebhookconfigurations -l app.kubernetes.io/name=beskar7
 ```
 
-### 3. PhysicalHost Stuck in "Enrolling"
+### 3. Stale v0.3 webhooks blocking admission
+
+**Symptom:** `kubectl apply` of any resource returns `failed calling webhook "mutation.physicalhost..."` or similar.
+
+**Cause:** v0.4 removed the PhysicalHost defaulting/validating webhooks. If you upgraded from v0.3.x, the `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` objects can survive. With `failurePolicy: Fail`, the apiserver tries to call a path that no longer exists and rejects the request.
+
+**Diagnosis:**
+```bash
+kubectl get validatingwebhookconfigurations | grep -i physicalhost
+kubectl get mutatingwebhookconfigurations | grep -i physicalhost
+```
+
+**Solution:**
+```bash
+# Delete any orphaned webhook configs that reference physicalhost / beskar7machine / beskar7machinetemplate paths
+kubectl delete validatingwebhookconfigurations <name>
+kubectl delete mutatingwebhookconfigurations <name>
+```
+
+### 4. PhysicalHost Stuck in "Enrolling"
 
 **Symptom:** Host never transitions to Available
 
@@ -120,7 +143,7 @@ kubectl get secret <secret-name> -o jsonpath='{.data.password}' | base64 -d
 - HPE iLO: Network -> iLO RESTful API -> Enable
 - Supermicro: Configuration -> Redfish API -> Enable
 
-### 4. Inspection Phase Stuck in "Pending" or "Booting"
+### 5. Inspection Phase Stuck in "Pending" or "Booting"
 
 **Symptom:** InspectionPhase never progresses to "Complete"
 
@@ -173,7 +196,7 @@ kubectl get beskar7machine <name> -o jsonpath='{.status.phase}'
 - Check firewall rules
 - Monitor server serial console for boot errors
 
-### 5. Inspection Times Out
+### 6. Inspection Times Out
 
 **Symptom:** InspectionPhase changes to "Timeout" after 10 minutes
 
@@ -203,7 +226,7 @@ sudo tail -f /var/log/nginx/boot-access.log
 - Verify inspection image is working
 - Increase timeout if hardware is slow
 
-### 6. Hardware Validation Failed
+### 7. Hardware Validation Failed
 
 **Symptom:** Machine stuck with validation error
 
@@ -229,7 +252,7 @@ spec:
 
 Option 2: Use different hardware that meets requirements
 
-### 7. Power Operations Fail
+### 8. Power Operations Fail
 
 **Symptom:** Can't power on/off server
 
@@ -266,7 +289,7 @@ kubectl logs -n beskar7-system deployment/beskar7-controller-manager | grep -i p
 - Check physical power button isn't locked
 - Verify power supplies are connected
 
-### 8. Machine Never Becomes Ready
+### 9. Machine Never Becomes Ready
 
 **Symptom:** Beskar7Machine stays in "Provisioning" or "Inspecting" phase
 
@@ -291,6 +314,45 @@ kubectl describe physicalhost <name>
 ```
 
 **Solution:** Depends on which step failed (see above sections)
+
+### 10. Inspection or bootstrap callback returns 401 Unauthorized
+
+**Symptom:** The inspector logs `401` from `https://<manager>:8082/api/v1/inspection/<ns>/<host>`, or the host fails to fetch bootstrap data.
+
+The callback endpoint authenticates every request via per-host bearer tokens. Failures collapse to an opaque `401` body — the verifier's specific reason is logged on the manager at V(1).
+
+**Diagnosis:**
+```bash
+# Tail manager logs for verifier output. Add --zap-devel=true to manager args
+# temporarily to surface V(1) lines.
+kubectl logs -n beskar7-system deployment/beskar7-controller-manager -f | grep -i bearer
+```
+
+**Common causes:**
+
+| V(1) message | Cause | Fix |
+|---|---|---|
+| `no bootstrap token issued for host ...` | The Beskar7Machine reconciler has not minted a token yet. | Wait, or check `kubectl describe beskar7machine <name>` for the current phase. |
+| `bootstrap token expired for host ...` | More than 30 minutes elapsed since the token was minted (`auth.TokenLifetime`). | Delete the per-host Secret `<host>-bootstrap-token`; the controller mints a fresh one and re-renders the cmdline on next reconcile. The booted host must re-PXE to pick up the new plaintext. |
+| `bootstrap token mismatch for host ...` | Plaintext on the wire does not hash to `Status.Bootstrap.TokenHash`. | Stale iPXE cmdline. Compare the token in the kernel cmdline against `kubectl get secret <host>-bootstrap-token -o jsonpath='{.data.plaintext-token}' \| base64 -d`. Re-PXE if they diverge. |
+
+Clock skew (> 30 min) between the manager pod and the BMC-managed host can also cause `expired` results — verify NTP on both sides.
+
+### 11. PhysicalHost in Error: `InsecureCABundleConflict` or `CABundleFetchFailed`
+
+**Symptom:**
+```bash
+kubectl get physicalhost <name> -o jsonpath='{.status.errorMessage}'
+```
+returns either `redfishConnection.insecureSkipVerify=true is mutually exclusive with caBundleSecretRef` or `CA bundle secret ... not found / has no usable ca.crt or tls.crt data key`.
+
+**`InsecureCABundleConflict`:** the spec has both `insecureSkipVerify: true` and `caBundleSecretRef` set. Pick one. See [Security Configuration](security/configuration.md#bmc-tls).
+
+**`CABundleFetchFailed`:** the named Secret does not exist in the host's namespace, or the data is missing. The expected data keys are `ca.crt` (preferred) or `tls.crt`. Check the Secret:
+```bash
+kubectl get secret <ca-bundle-secret> -n <namespace> -o yaml
+```
+Populate `data.ca.crt` (base64 PEM) and re-apply.
 
 ## Debugging Tools
 
@@ -435,17 +497,9 @@ kubectl get beskar7machine -o custom-columns=NAME:.metadata.name,PHASE:.status.p
 
 ### Slow Reconciliation
 
-**Symptom:** Resources take long time to update
+**Symptom:** Resources take long time to update.
 
-**Solution:**
-```bash
-# Increase worker count
-kubectl edit deployment -n beskar7-system beskar7-controller-manager
-
-# Add to container args:
-- --max-concurrent-reconciles-physicalhost=5  # Default: 1
-- --max-concurrent-reconciles-beskar7machine=5
-```
+There is no per-controller `--max-concurrent-reconciles-*` flag in v0.4. The reconcilers use controller-runtime's default (`MaxConcurrentReconciles = 1`). If you genuinely need to raise concurrency, the change is in code — `controllers/<kind>_controller.go:SetupWithManager` — not configuration. Open an issue with your scaling profile if the default is a real constraint.
 
 ### High CPU/Memory Usage
 

--- a/examples/complete-cluster.md
+++ b/examples/complete-cluster.md
@@ -1,85 +1,43 @@
 # Complete Cluster Deployment Example
 
-This example demonstrates a complete Kubernetes cluster deployment using Beskar7 with bare-metal machines managed via Redfish API.
-
-## Overview
-
-This example creates a fully functional cluster with:
-- **1 Control Plane Node** - Running Kubernetes control plane components
-- **2 Worker Nodes** - Running workload pods
-- **Kairos OS** - Immutable Linux distribution optimized for Kubernetes
-- **Cluster API Integration** - Full integration with CAPI resources
-
-## Architecture
-
-```
-
-                    Beskar7 Controller                       
-              (Manages PhysicalHosts & Machines)             
-
-                            
-                
-                                      
-       v      v
-        PhysicalHost         PhysicalHost   
-        control-plane          worker-01    
-        (172.16.56.101)      (172.16.56.102)
-             
-                           
-                   v
-                    PhysicalHost   
-                      worker-02    
-                    (172.16.56.103)
-                   
-```
+This walkthrough deploys a 1-control-plane + 2-worker Kubernetes cluster on bare metal using Beskar7 v0.4.0-alpha. The accompanying YAML is [`complete-cluster.yaml`](complete-cluster.yaml).
 
 ## Prerequisites
 
-### 1. Beskar7 Installed
+1. **Beskar7 controller installed and Ready.** Either Helm (`helm install beskar7 beskar7/beskar7 --namespace beskar7-system --create-namespace`) or release manifests. Verify:
+   ```bash
+   kubectl get pods -n beskar7-system
+   ```
+2. **Cluster API core + KubeadmControlPlane + KubeadmBootstrap providers.**
+   ```bash
+   clusterctl init
+   ```
+3. **cert-manager.** See [Quick Start](../docs/quick-start.md#prerequisites).
+4. **iPXE infrastructure.** DHCP + HTTP boot server reachable from the bare-metal nodes' management network. See [iPXE Setup](../docs/ipxe-setup.md).
+5. **The beskar7-inspector image and target OS image hosted on the boot server.**
+6. **Three bare-metal servers with Redfish-compatible BMCs**, with credentials and IP addresses for each BMC.
 
-```bash
-# Install Beskar7
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.3.0/beskar7-manifests-v0.3.0.yaml
+## What the manifest deploys
 
-# Verify installation
-kubectl get pods -n beskar7-system
-```
+| Object | Count | Purpose |
+|---|---|---|
+| `Secret/bmc-credentials` | 1 | BMC username + password. |
+| `PhysicalHost` | 3 | One per bare-metal server. |
+| `Beskar7Cluster` | 1 | CAPI infra-cluster; tracks control-plane endpoint and failure domains. |
+| `Cluster` (CAPI) | 1 | The CAPI Cluster that owns Beskar7Cluster. |
+| `Beskar7MachineTemplate` (control plane) | 1 | Schema for the control-plane Beskar7Machines. |
+| `KubeadmControlPlane` | 1 | Drives `replicas: 1` control-plane Machine. |
+| `Beskar7MachineTemplate` (workers) | 1 | Schema for the worker Beskar7Machines. |
+| `MachineDeployment` | 1 | Drives `replicas: 2` worker Machines. |
+| `KubeadmConfigTemplate` | 1 | Worker bootstrap config (kubeadm join). |
 
-### 2. Cluster API Core Components
+Each `Beskar7Machine` claims a `PhysicalHost`, runs the iPXE inspection workflow, validates hardware against `hardwareRequirements`, then kexecs into the target OS.
 
-```bash
-# Install Cluster API
-clusterctl init
+## Configuration steps
 
-# Verify CAPI is ready
-kubectl get pods -n capi-system
-kubectl get pods -n capi-kubeadm-bootstrap-system
-kubectl get pods -n capi-kubeadm-control-plane-system
-```
+### 1. Update BMC credentials
 
-### 3. cert-manager
-
-```bash
-# Install cert-manager
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
-
-# Verify cert-manager is ready
-kubectl wait --for=condition=Available --timeout=300s deployment/cert-manager -n cert-manager
-```
-
-### 4. Physical Infrastructure
-
-You need:
-- **3 bare-metal servers** with Redfish-compatible BMC
-- **Network connectivity** from Kubernetes cluster to BMC IPs
-- **BMC credentials** (username/password)
-- **Web server** hosting Kairos configuration files (or use PreBakedISO mode)
-
-## Configuration Steps
-
-### Step 1: Update BMC Credentials
-
-Edit the `bmc-credentials` Secret in the manifest:
+Edit the Secret:
 
 ```yaml
 apiVersion: v1
@@ -89,355 +47,145 @@ metadata:
   namespace: default
 type: Opaque
 stringData:
-  username: "admin"          # Your BMC username
-  password: "your-password"  # Your BMC password
+  username: "admin"
+  password: "your-password"
 ```
 
-### Step 2: Update BMC IP Addresses
+### 2. Update BMC IP addresses
 
-Update the `redfishConnection.address` in each `PhysicalHost`:
+Update `spec.redfishConnection.address` on each `PhysicalHost`:
 
 ```yaml
 spec:
   redfishConnection:
-    address: "https://172.16.56.101"  # Replace with actual BMC IP
+    address: "https://172.16.56.101"   # actual BMC IP
     credentialsSecretRef: "bmc-credentials"
-    insecureSkipVerify: true
+    insecureSkipVerify: true            # set to false in production
 ```
 
-### Step 3: Update Control Plane Endpoint
+For TLS-verified BMC connections in production, see [Security Configuration](../docs/security/configuration.md) — provide a `caBundleSecretRef` and leave `insecureSkipVerify: false`.
 
-Update the `controlPlaneEndpoint` in `Beskar7Cluster`:
+### 3. Update the control-plane endpoint
+
+Update `Beskar7Cluster.spec.controlPlaneEndpoint.host`:
 
 ```yaml
 spec:
   controlPlaneEndpoint:
-    host: "172.16.56.10"  # Your VIP or load balancer IP
+    host: "172.16.56.10"  # VIP / load balancer
     port: 6443
 ```
 
-This can be:
-- A static IP on the control plane node
-- A virtual IP managed by keepalived/kube-vip
-- A load balancer IP
+This must be a stable address that survives a control-plane node move — typically a virtual IP managed by `kube-vip`/`keepalived`, or an external load balancer.
 
-### Step 4: Configure Kairos Config URLs
+### 4. Update image URLs
 
-Update the `configURL` in `Beskar7Machine` and `Beskar7MachineTemplate` resources:
+Update `inspectionImageURL`, `targetImageURL`, and `configurationURL` on the two `Beskar7MachineTemplate` objects. Each must match `^https?://.*` and be reachable from the bare-metal nodes' boot network. Examples:
 
 ```yaml
-spec:
-  provisioningMode: "RemoteConfig"
-  configURL: "https://your-server.com/config/control-plane-config.yaml"
+inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+configurationURL:   "http://boot-server.local/configs/control-plane.yaml"
 ```
 
-**Alternative**: Use `PreBakedISO` mode:
+For details on how the kernel cmdline is constructed from these URLs, see [iPXE Setup: kernel cmdline](../docs/ipxe-setup.md).
+
+### 5. Adjust hardware requirements
+
+Each template carries a `hardwareRequirements` block. The inspection workflow validates the report against these — if any minimum is violated, the Beskar7Machine fails terminally with `HardwareRequirementsNotMet`. Tune them to match your actual hardware:
 
 ```yaml
-spec:
-  provisioningMode: "PreBakedISO"
-  imageURL: "https://your-server.com/custom-images/control-plane.iso"
+hardwareRequirements:
+  minCPUCores: 4    # summed across all CPUs in the report
+  minMemoryGB: 16   # summed across all DIMMs (decimal GB; "16GB" or "16GiB" both accepted)
+  minDiskGB:   100  # summed across all disks
 ```
 
-## Kairos Configuration Files
-
-### Control Plane Configuration
-
-Create `control-plane-config.yaml`:
-
-```yaml
-#cloud-config
-
-hostname: control-plane-{{ trunc 4 .MachineID }}
-
-stages:
-  rootfs:
-    - name: "Setup SSH"
-      authorized_keys:
-        - "ssh-rsa AAAA... your-ssh-key"
-
-  initramfs:
-    - name: "Setup networking"
-      commands:
-        - |
-          cat > /etc/systemd/network/20-wired.network <<EOF
-          [Match]
-          Name=eth*
-
-          [Network]
-          DHCP=yes
-          EOF
-
-  boot:
-    - name: "Install Kubernetes"
-      commands:
-        - kubeadm init --config /etc/kubernetes/kubeadm-config.yaml
-```
-
-### Worker Configuration
-
-Create `worker-config.yaml`:
-
-```yaml
-#cloud-config
-
-hostname: worker-{{ trunc 4 .MachineID }}
-
-stages:
-  rootfs:
-    - name: "Setup SSH"
-      authorized_keys:
-        - "ssh-rsa AAAA... your-ssh-key"
-
-  initramfs:
-    - name: "Setup networking"
-      commands:
-        - |
-          cat > /etc/systemd/network/20-wired.network <<EOF
-          [Match]
-          Name=eth*
-
-          [Network]
-          DHCP=yes
-          EOF
-
-  boot:
-    - name: "Join Kubernetes cluster"
-      commands:
-        - kubeadm join {{ .ControlPlaneEndpoint }} --token {{ .Token }} --discovery-token-ca-cert-hash {{ .CACertHash }}
-```
-
-## Deployment
-
-### Deploy the Complete Cluster
+## Deploy
 
 ```bash
-# Apply the complete manifest
 kubectl apply -f examples/complete-cluster.yaml
-
-# Watch the deployment progress
-watch kubectl get physicalhost,beskar7machine,beskar7cluster,cluster
 ```
 
-### Monitor Progress
+Watch progress:
 
 ```bash
-# Check PhysicalHost status
-kubectl get physicalhost -w
-
-# Expected output:
-# NAME                STATE       POWER   BOOT
-# control-plane-01    Available   On      ISO
-# worker-01           Available   On      ISO
-# worker-02           Available   On      ISO
-
-# Check Beskar7Machine status
-kubectl get beskar7machine -w
-
-# Check cluster status
-kubectl get cluster my-cluster -o yaml
+kubectl get physicalhost,beskar7machine,beskar7cluster,cluster -n default -w
 ```
 
-### Verify Cluster Creation
+Expected sequence per host:
+
+```
+NAME             STATE         READY
+control-plane-01 Available     true       # BMC reachable
+control-plane-01 InUse         true       # Beskar7Machine claimed it
+control-plane-01 Inspecting    true       # iPXE booted the inspection image
+control-plane-01 Ready         true       # report validated, ready for kexec
+```
+
+## Verify the cluster
+
+Once the control-plane node reports `Ready` and joined as a Kubernetes node, fetch its kubeconfig and check status:
 
 ```bash
-# Get the kubeconfig for the new cluster
-clusterctl get kubeconfig my-cluster > my-cluster.kubeconfig
-
-# Check nodes in the new cluster
+clusterctl get kubeconfig my-cluster -n default > my-cluster.kubeconfig
 kubectl --kubeconfig=my-cluster.kubeconfig get nodes
-
-# Expected output:
-# NAME                        STATUS   ROLES           AGE   VERSION
-# my-cluster-control-plane-0  Ready    control-plane   10m   v1.31.0
-# my-cluster-workers-abc123   Ready    <none>          8m    v1.31.0
-# my-cluster-workers-def456   Ready    <none>          8m    v1.31.0
 ```
 
-## Customization Options
+## Scaling
 
-### Scaling Workers
-
-To add more worker nodes:
+### More workers
 
 ```bash
-# Edit the MachineDeployment
-kubectl edit machinedeployment my-cluster-workers
-
-# Change spec.replicas to desired count
-spec:
-  replicas: 5  # Scale to 5 workers
+kubectl scale machinedeployment my-cluster-workers --replicas=5 -n default
 ```
 
-### High Availability Control Plane
+The `MachineDeployment` mints additional `Beskar7Machine` objects. Each claims an `Available` `PhysicalHost`. If no host is `Available`, the new machines stay in `WaitingForPhysicalHost` until one is freed or registered.
 
-To create an HA control plane with 3 nodes:
+### HA control plane
 
-```yaml
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-kind: KubeadmControlPlane
-metadata:
-  name: my-cluster-control-plane
-spec:
-  replicas: 3  # Change from 1 to 3
-```
-
-Make sure you have 3 PhysicalHosts labeled for control-plane role.
-
-### Custom Kubernetes Version
-
-```yaml
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-kind: KubeadmControlPlane
-spec:
-  version: v1.30.0  # Change Kubernetes version
-```
-
-### Different OS Family
-
-Replace `kairos` with other supported OS families:
+Edit `KubeadmControlPlane.spec.replicas`:
 
 ```yaml
 spec:
-  osFamily: "flatcar"
-  imageURL: "https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_iso_image.iso"
+  replicas: 3
 ```
 
-Supported OS families:
-- `kairos` - Kairos (recommended)
-- `flatcar` - Flatcar Container Linux
-- `LeapMicro` - openSUSE Leap Micro
-
-## Troubleshooting
-
-### PhysicalHost Not Becoming Available
-
-```bash
-# Check PhysicalHost status
-kubectl describe physicalhost control-plane-01
-
-# Check controller logs
-kubectl logs -n beskar7-system deployment/controller-manager -c manager -f
-```
-
-Common issues:
-- BMC credentials incorrect
-- BMC not reachable from cluster
-- Redfish API not enabled on BMC
-
-### Machine Not Provisioning
-
-```bash
-# Check Beskar7Machine status
-kubectl describe beskar7machine my-cluster-control-plane-0
-
-# Check events
-kubectl get events --sort-by='.lastTimestamp'
-```
-
-Common issues:
-- No available PhysicalHost with matching labels
-- ISO URL not accessible from server
-- Config URL not accessible (RemoteConfig mode)
-
-### Cluster Not Becoming Ready
-
-```bash
-# Check cluster status
-kubectl describe cluster my-cluster
-
-# Check control plane status
-kubectl describe kubeadmcontrolplane my-cluster-control-plane
-```
-
-Common issues:
-- Control plane endpoint not reachable
-- kubeadm init/join failures
-- Network plugin not installed
+Make sure you have at least three `PhysicalHost` objects available; a control-plane VIP (`172.16.56.10` in this example) that fronts the API server; and `certSANs` on `kubeadmConfigSpec.clusterConfiguration.apiServer` covering all control-plane addresses.
 
 ## Cleanup
 
-To delete the cluster and all resources:
+```bash
+kubectl delete cluster my-cluster -n default
+kubectl wait --for=delete cluster/my-cluster -n default --timeout=600s
+```
+
+CAPI walks the owner chain: deleting `Cluster` deletes `KubeadmControlPlane`, `MachineDeployment`, `Machine`, and `Beskar7Machine`. Each Beskar7Machine deletion runs the BMC release flow (best-effort `ClearBootSourceOverride` + `SetPowerState(Off)` graceful) before clearing `ConsumerRef` on the host. The `PhysicalHost` then transitions back to `Available`.
+
+If a BMC is unreachable and a Beskar7Machine deletion is stuck, set the force-release annotation before deleting:
 
 ```bash
-# Delete the cluster (this will also delete machines and infrastructure)
-kubectl delete cluster my-cluster
-
-# Wait for cleanup to complete
-kubectl wait --for=delete cluster/my-cluster --timeout=600s
-
-# PhysicalHosts will be released and become Available again
-kubectl get physicalhost
-
-# Delete the secret
-kubectl delete secret bmc-credentials
+kubectl annotate beskar7machine <name> \
+  -n default \
+  infrastructure.cluster.x-k8s.io/force-release=true
 ```
 
-## Advanced Scenarios
+## Troubleshooting
 
-### Using PreBakedISO Mode
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| `PhysicalHost` stuck in `Enrolling` | BMC unreachable or wrong credentials. | `kubectl describe physicalhost <name>` — check `RedfishConnectionReady` reason. |
+| `Beskar7Machine` stuck in `WaitingForPhysicalHost` | No `Available` host with matching namespace. | `kubectl get physicalhost`. Register more hosts or release one. |
+| `PhysicalHost` stuck in `Inspecting` | iPXE not delivering the inspection image, or the inspector cannot reach the manager's callback endpoint on `:8082`. | Server serial console; `kubectl logs -n beskar7-system deployment/beskar7-controller-manager`. |
+| `FailureReason: HardwareRequirementsNotMet` | Inspection report below the configured minimums. | `kubectl get physicalhost <name> -o jsonpath='{.status.inspectionReport}' \| jq` and compare with `hardwareRequirements`. |
+| `FailureReason: BootstrapDataUnavailable` | The Secret named by `Machine.Spec.Bootstrap.DataSecretName` does not exist. | Wait for the bootstrap provider to reconcile, or check the `KubeadmConfig` for the missing config. |
 
-For faster provisioning with pre-configured ISOs:
+See [Troubleshooting](../docs/troubleshooting.md) for deeper coverage.
 
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7Machine
-spec:
-  osFamily: "kairos"
-  provisioningMode: "PreBakedISO"
-  imageURL: "https://your-server.com/images/control-plane-node.iso"
-  # configURL not needed in PreBakedISO mode
-```
+## See also
 
-### Using Different Boot Modes
-
-```yaml
-spec:
-  bootMode: "Legacy"  # For Legacy BIOS boot
-  # or
-  bootMode: "UEFI"    # For UEFI boot (default)
-```
-
-### Network Segmentation
-
-To use different networks for control plane and workers:
-
-```yaml
-# Control plane template
-spec:
-  template:
-    spec:
-      networkConfig:
-        interfaces:
-          - name: eth0
-            addresses:
-              - 172.16.56.10/24
-
-# Worker template
-spec:
-  template:
-    spec:
-      networkConfig:
-        interfaces:
-          - name: eth0
-            addresses:
-              - 172.16.57.10/24
-```
-
-## Next Steps
-
-After your cluster is running:
-
-1. **Install CNI**: Deploy a network plugin (Calico, Cilium, etc.)
-2. **Install CSI**: Deploy storage drivers for persistent volumes
-3. **Install Ingress**: Deploy ingress controller for external access
-4. **Deploy Workloads**: Start deploying your applications
-
-## See Also
-
-- [PhysicalHost Documentation](../docs/physicalhost.md)
-- [Beskar7Machine Documentation](../docs/beskar7machine.md)
-- [Beskar7Cluster Documentation](../docs/beskar7cluster.md)
-- [Troubleshooting Guide](../docs/troubleshooting.md)
-- [Vendor-Specific Support](../docs/vendor-specific-support.md)
-
+- [PhysicalHost](../docs/physicalhost.md)
+- [Beskar7Machine](../docs/beskar7machine.md)
+- [State Management](../docs/state-management.md)
+- [iPXE Setup](../docs/ipxe-setup.md)
+- [Security Configuration](../docs/security/configuration.md)

--- a/examples/complete-cluster.yaml
+++ b/examples/complete-cluster.yaml
@@ -1,18 +1,20 @@
 # Complete Beskar7 Cluster Example
-# This manifest contains all resources needed to deploy a functional Kubernetes cluster
-# using Beskar7 with bare-metal machines via Redfish.
+# Deploys a 1 control-plane + 2 worker cluster using Beskar7 v0.4.0-alpha.
 #
 # Prerequisites:
-# 1. Beskar7 controller is installed and running
-# 2. cert-manager is installed
-# 3. Cluster API core components are installed
-# 4. BMC credentials secret exists
+#   1. Beskar7 controller is installed (Helm or release manifests).
+#   2. cert-manager is installed and Ready.
+#   3. Cluster API core + KubeadmControlPlane + KubeadmBootstrap providers are installed.
+#   4. iPXE infrastructure is set up (see docs/ipxe-setup.md).
+#   5. The beskar7-inspector image and target OS image are reachable from the bare-metal nodes.
 #
 # Usage:
 #   kubectl apply -f complete-cluster.yaml
+#
+# Replace the BMC IPs, image URLs, and credentials with your own.
 
 ---
-# Secret containing BMC credentials for Redfish API access
+# Step 1: BMC credentials. Must contain "username" and "password" data keys.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,58 +23,54 @@ metadata:
 type: Opaque
 stringData:
   username: "admin"
-  password: "password"  # Replace with your actual BMC password
+  password: "changeme"
 
 ---
-# PhysicalHost - Represents a bare-metal server for the control plane
+# Step 2: PhysicalHost objects, one per server. The topology label is consumed
+# by Beskar7Cluster.Status.FailureDomains.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
   name: control-plane-01
   namespace: default
   labels:
-    cluster.x-k8s.io/cluster-name: "my-cluster"
-    cluster.x-k8s.io/role: "control-plane"
+    topology.kubernetes.io/zone: rack-1
 spec:
   redfishConnection:
-    address: "https://172.16.56.101"  # Replace with your BMC IP
+    address: "https://172.16.56.101"
     credentialsSecretRef: "bmc-credentials"
-    insecureSkipVerify: true  # Set to false in production with valid certs
+    insecureSkipVerify: true   # Set to false in production. See docs/security/configuration.md for caBundleSecretRef.
 
 ---
-# PhysicalHost - Represents a bare-metal server for a worker node
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
   name: worker-01
   namespace: default
   labels:
-    cluster.x-k8s.io/cluster-name: "my-cluster"
-    cluster.x-k8s.io/role: "worker"
+    topology.kubernetes.io/zone: rack-2
 spec:
   redfishConnection:
-    address: "https://172.16.56.102"  # Replace with your BMC IP
+    address: "https://172.16.56.102"
     credentialsSecretRef: "bmc-credentials"
     insecureSkipVerify: true
 
 ---
-# PhysicalHost - Additional worker node
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
   name: worker-02
   namespace: default
   labels:
-    cluster.x-k8s.io/cluster-name: "my-cluster"
-    cluster.x-k8s.io/role: "worker"
+    topology.kubernetes.io/zone: rack-3
 spec:
   redfishConnection:
-    address: "https://172.16.56.103"  # Replace with your BMC IP
+    address: "https://172.16.56.103"
     credentialsSecretRef: "bmc-credentials"
     insecureSkipVerify: true
 
 ---
-# Beskar7Cluster - Infrastructure cluster resource
+# Step 3: Beskar7Cluster — the CAPI infra-cluster.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Beskar7Cluster
 metadata:
@@ -80,11 +78,11 @@ metadata:
   namespace: default
 spec:
   controlPlaneEndpoint:
-    host: "172.16.56.10"  # Replace with your control plane VIP or load balancer IP
+    host: "172.16.56.10"   # VIP / load balancer for the control-plane API
     port: 6443
 
 ---
-# Cluster - Core Cluster API resource
+# Step 4: CAPI Cluster, owning the Beskar7Cluster.
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
@@ -93,11 +91,9 @@ metadata:
 spec:
   clusterNetwork:
     pods:
-      cidrBlocks:
-        - "10.244.0.0/16"
+      cidrBlocks: ["10.244.0.0/16"]
     services:
-      cidrBlocks:
-        - "10.96.0.0/12"
+      cidrBlocks: ["10.96.0.0/12"]
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Beskar7Cluster
@@ -108,7 +104,8 @@ spec:
     name: my-cluster-control-plane
 
 ---
-# Beskar7MachineTemplate - Template for control plane machines
+# Step 5: Beskar7MachineTemplate for the control plane. CAPI clones the
+# template's spec into one Beskar7Machine per replica.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Beskar7MachineTemplate
 metadata:
@@ -117,15 +114,16 @@ metadata:
 spec:
   template:
     spec:
-      osFamily: "kairos"
-      imageURL: "https://github.com/kairos-io/kairos/releases/download/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-      provisioningMode: "RemoteConfig"
-      configURL: "https://your-server.com/config/control-plane-config.yaml"
-      # Optional: Customize boot order, BIOS settings, etc.
-      bootMode: "UEFI"
+      inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+      targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+      configurationURL:   "http://boot-server.local/configs/control-plane.yaml"
+      hardwareRequirements:
+        minCPUCores: 4
+        minMemoryGB: 16
+        minDiskGB:   100
 
 ---
-# KubeadmControlPlane - Control plane configuration
+# Step 6: KubeadmControlPlane drives 1 control-plane Machine.
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
@@ -141,47 +139,20 @@ spec:
       name: my-cluster-control-plane
   kubeadmConfigSpec:
     clusterConfiguration:
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       apiServer:
         certSANs:
           - localhost
           - 127.0.0.1
-          - 0.0.0.0
-          - "172.16.56.10"  # Control plane endpoint
+          - "172.16.56.10"
     initConfiguration:
       nodeRegistration:
         criSocket: /run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
     joinConfiguration:
       nodeRegistration:
         criSocket: /run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 
 ---
-# Beskar7Machine - Control plane machine
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Beskar7Machine
-metadata:
-  name: my-cluster-control-plane-0
-  namespace: default
-  labels:
-    cluster.x-k8s.io/cluster-name: "my-cluster"
-    cluster.x-k8s.io/control-plane: "true"
-spec:
-  osFamily: "kairos"
-  imageURL: "https://github.com/kairos-io/kairos/releases/download/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-  provisioningMode: "RemoteConfig"
-  configURL: "https://your-server.com/config/control-plane-config.yaml"
-  bootMode: "UEFI"
-  # The controller will automatically select an available PhysicalHost
-  # based on cluster labels and availability
-
----
-# Beskar7MachineTemplate - Template for worker machines
+# Step 7: Beskar7MachineTemplate for the workers.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Beskar7MachineTemplate
 metadata:
@@ -190,14 +161,16 @@ metadata:
 spec:
   template:
     spec:
-      osFamily: "kairos"
-      imageURL: "https://github.com/kairos-io/kairos/releases/download/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-      provisioningMode: "RemoteConfig"
-      configURL: "https://your-server.com/config/worker-config.yaml"
-      bootMode: "UEFI"
+      inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+      targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+      configurationURL:   "http://boot-server.local/configs/worker.yaml"
+      hardwareRequirements:
+        minCPUCores: 4
+        minMemoryGB: 8
+        minDiskGB:   50
 
 ---
-# MachineDeployment - Worker machines deployment
+# Step 8: MachineDeployment scales workers using the worker template.
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
@@ -229,7 +202,7 @@ spec:
         name: my-cluster-workers
 
 ---
-# KubeadmConfigTemplate - Worker bootstrap configuration
+# Step 9: KubeadmConfigTemplate for the workers.
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
@@ -241,6 +214,3 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /run/containerd/containerd.sock
-          kubeletExtraArgs:
-            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-

--- a/examples/minimal-test-cluster.yaml
+++ b/examples/minimal-test-cluster.yaml
@@ -1,16 +1,22 @@
 # Minimal Test Cluster Example
-# This is a simplified version for quick testing with a single node.
-# Perfect for development and testing Beskar7 functionality.
+#
+# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha
+# inspection workflow. NOT a working cluster — bring this up first to verify the
+# inspection round-trip, then graduate to examples/complete-cluster.yaml.
 #
 # Prerequisites:
-# 1. Beskar7 controller installed
-# 2. At least one bare-metal server with Redfish BMC
+#   1. Beskar7 controller installed and Ready.
+#   2. cert-manager installed.
+#   3. iPXE infrastructure reachable (see docs/ipxe-setup.md).
+#   4. At least one bare-metal server with Redfish.
 #
 # Usage:
 #   kubectl apply -f minimal-test-cluster.yaml
+#   kubectl get physicalhost -w
+#   kubectl get beskar7machine -w
 
 ---
-# BMC credentials
+# BMC credentials.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,10 +25,10 @@ metadata:
 type: Opaque
 stringData:
   username: "admin"
-  password: "password"  # Change this!
+  password: "changeme"
 
 ---
-# Single PhysicalHost for testing
+# Single PhysicalHost.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
@@ -30,12 +36,12 @@ metadata:
   namespace: default
 spec:
   redfishConnection:
-    address: "https://172.16.56.43"  # Replace with your BMC IP
+    address: "https://172.16.56.43"
     credentialsSecretRef: "test-bmc-credentials"
-    insecureSkipVerify: true
+    insecureSkipVerify: true   # Test env only — see docs/security/configuration.md.
 
 ---
-# Simple Beskar7Cluster
+# Beskar7Cluster (placeholder; not paired with a CAPI Cluster in this minimal test).
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Beskar7Cluster
 metadata:
@@ -43,22 +49,21 @@ metadata:
   namespace: default
 spec:
   controlPlaneEndpoint:
-    host: "172.16.56.43"  # Replace with your server IP
+    host: "172.16.56.43"
     port: 6443
 
 ---
-# Beskar7Machine that will use the PhysicalHost
+# Single Beskar7Machine. Without an owning CAPI Machine, this won't progress
+# past the bootstrap-data check — useful for confirming the controller picks
+# up your spec but not for completing provisioning.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Beskar7Machine
 metadata:
   name: test-machine-01
   namespace: default
   labels:
-    cluster.x-k8s.io/cluster-name: "test-cluster"
+    cluster.x-k8s.io/cluster-name: test-cluster
 spec:
-  osFamily: "kairos"
-  imageURL: "https://github.com/kairos-io/kairos/releases/download/v2.8.1/kairos-alpine-v2.8.1-amd64.iso"
-  provisioningMode: "RemoteConfig"
-  configURL: "https://your-server.com/config/test-config.yaml"
-  bootMode: "UEFI"
-
+  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
+  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  configurationURL:   "http://boot-server.local/configs/test.yaml"

--- a/examples/security/README.md
+++ b/examples/security/README.md
@@ -1,249 +1,63 @@
-# Beskar7 Security Configuration Examples
+# Beskar7 Security Examples
 
-This directory contains security configuration examples for different deployment environments and security profiles.
+Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
 
-## Available Examples
+## What's actually enforced
 
-### Production Configuration (`production.yaml`)
+| Control | Enforced by |
+|---|---|
+| BMC TLS verification with optional custom CA bundle | `PhysicalHost.spec.redfishConnection.{insecureSkipVerify, caBundleSecretRef}` (`controllers/redfish_tls.go`) |
+| BMC credentials in a Secret | `PhysicalHost.spec.redfishConnection.credentialsSecretRef` |
+| Per-host bearer token on `:8082` (inspection POST + bootstrap GET) | `internal/auth/token.go` + `controllers/inspection_handler.go` |
+| Per-namespace Secret/ConfigMap RBAC scope | `config/rbac/role.yaml` (`SEC-2 / D-007`) |
+| Pod security context | `config/manager/manager.yaml` and `charts/beskar7/templates/deployment.yaml` |
+| NetworkPolicy on `:8082`, `:8443`, `:9443` | `charts/beskar7/templates/networkpolicy.yaml` |
+| Authenticated metrics on `:8443` | `cmd/manager/main.go` (`--secure-metrics`) |
+| Distroless, digest-pinned base image | `Dockerfile` |
 
-A comprehensive production-ready security configuration with:
+For details, see [`docs/security/README.md`](../../docs/security/README.md) and [`docs/security/configuration.md`](../../docs/security/configuration.md).
 
-- **Strict TLS enforcement** with certificate validation
-- **Minimal RBAC permissions** following principle of least privilege
-- **Strong password policies** and credential rotation
-- **Network policies** with default deny and selective allow rules
-- **Container security hardening** with read-only filesystems and dropped capabilities
-- **Comprehensive monitoring** with frequent security scans and alerting
-- **Compliance features** for CIS Kubernetes, NIST, and SOC 2
-- **High availability** configuration with pod anti-affinity
+## Examples
 
-Use this configuration for production environments where security is paramount.
+### `production.yaml`
+
+A production-style configuration:
+
+- BMC credentials in a Secret in the host namespace.
+- A cert-manager-issued CA bundle Secret (`bmc-ca-bundle`) referenced via `caBundleSecretRef`.
+- `insecureSkipVerify: false`.
+- A NetworkPolicy that narrows the chart's default egress to a known BMC subnet.
+- Helm values for a production install (commented at the bottom of the YAML).
 
 ```bash
+# Adjust the BMC address, password, CA issuer, and BMC subnet for your environment.
 kubectl apply -f production.yaml
 ```
 
-### Development Configuration (`development.yaml`)
+### `development.yaml`
 
-A development-friendly configuration with relaxed security settings:
-
-- **Relaxed TLS validation** allowing self-signed certificates
-- **Broader RBAC permissions** for easier development and debugging
-- **Relaxed password policies** with shorter, simpler passwords
-- **Minimal network restrictions** allowing more communication
-- **Debug-friendly container settings** with root access and writable filesystems
-- **Less frequent monitoring** to reduce noise during development
-- **Enhanced logging** for troubleshooting
-
-Use this configuration for development and testing environments.
+A lab configuration with `insecureSkipVerify: true` for self-signed BMC certs. Includes recommended Helm values for a development install (webhook disabled, verbose logging via `--zap-devel=true`).
 
 ```bash
 kubectl apply -f development.yaml
 ```
 
-## Configuration Comparison
+## Verifying
 
-| Feature | Production | Development |
-|---------|------------|-------------|
-| TLS Validation | Strict | Relaxed |
-| Password Policy | Strong (16+ chars) | Simple (8+ chars) |
-| RBAC Permissions | Minimal | Broad |
-| Container Security | Hardened | Debug-friendly |
-| Monitoring Frequency | 30 minutes | 4 hours |
-| Network Policies | Restrictive | Permissive |
-| Resource Limits | Enforced | Optional |
-| Audit Logging | Enabled | Disabled |
-
-## Using These Examples
-
-### Production Deployment
-
-1. **Review the configuration** to ensure it meets your security requirements
-2. **Update CA certificates** if using custom certificate authorities
-3. **Customize resource limits** based on your cluster capacity
-4. **Configure monitoring** to integrate with your alerting system
-5. **Apply the configuration**:
+After applying:
 
 ```bash
-# Apply production security configuration
-kubectl apply -f examples/security/production.yaml
+# Are the PhysicalHosts reaching the BMC?
+kubectl get physicalhost -A
+kubectl describe physicalhost <name> -n <namespace> | grep -A3 RedfishConnectionReady
 
-# Verify deployment
-kubectl get deployment controller-manager -n beskar7-system
-kubectl get events -n beskar7-system
+# Is the manager seeing the bearer-token traffic?
+kubectl logs -n beskar7-system deployment/beskar7-controller-manager | grep -i bearer
 ```
 
-### Development Deployment
+## See also
 
-1. **Apply the development configuration**:
-
-```bash
-# Apply development security configuration
-kubectl apply -f examples/security/development.yaml
-
-# Enable debug logging
-kubectl patch deployment controller-manager -n beskar7-system \
-  --patch '{"spec":{"template":{"spec":{"containers":[{"name":"manager","args":["--leader-elect=false","--v=2"]}]}}}}'
-```
-
-2. **Create test resources**:
-
-```bash
-# Create development PhysicalHost
-kubectl apply -f - <<EOF
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: PhysicalHost
-metadata:
-  name: dev-test-server
-spec:
-  redfishConnection:
-    address: "https://192.168.1.100"
-    credentialsSecretRef:
-      name: dev-bmc-credentials
-    insecureSkipVerify: true
-EOF
-```
-
-## Security Validation
-
-### Check Security Status
-
-```bash
-# Check security events
-kubectl get events -n beskar7-system --field-selector type=Warning
-
-# View security policy
-kubectl get configmap beskar7-security-policy -n beskar7-system -o yaml
-
-# Check RBAC permissions
-kubectl auth can-i --list --as=system:serviceaccount:beskar7-system:controller-manager
-```
-
-### Validate TLS Configuration
-
-```bash
-# Test certificate validation
-openssl s_client -connect your-bmc.example.com:443 -verify_return_error
-
-# Check PhysicalHost TLS settings
-kubectl get physicalhost -o yaml | grep -A5 redfishConnection
-```
-
-### Monitor Security Metrics
-
-```bash
-# View security metrics
-kubectl port-forward -n beskar7-system deployment/controller-manager 8080:8080
-curl http://localhost:8080/metrics | grep beskar7_security
-```
-
-## Customization
-
-### Environment-Specific Customization
-
-Create your own configuration by copying and modifying one of the examples:
-
-```bash
-# Copy production config for customization
-cp production.yaml my-environment.yaml
-
-# Edit security policy
-vim my-environment.yaml
-```
-
-### Common Customizations
-
-#### Custom CA Certificate
-
-```yaml
-# Add your organization's CA certificate
-apiVersion: v1
-kind: Secret
-metadata:
-  name: corporate-ca-cert
-  namespace: beskar7-system
-data:
-  ca.crt: <base64-encoded-ca-certificate>
-```
-
-#### Adjusted Password Policy
-
-```yaml
-# Customize password requirements
-security:
-  credentials:
-    password_policy:
-      min_length: 20              # Longer passwords
-      require_special_chars: true
-      prohibited_patterns:        # Block specific patterns
-        - "company"
-        - "beskar"
-```
-
-#### Custom Network Policies
-
-```yaml
-# Allow specific BMC subnets
-egress:
-- to:
-  - ipBlock:
-      cidr: 10.100.0.0/16  # BMC network
-  ports:
-  - protocol: TCP
-    port: 443
-```
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Certificate validation failures**: Check CA certificates and hostname verification
-2. **RBAC permission denied**: Verify ClusterRole permissions match requirements
-3. **Network connectivity issues**: Review network policies and firewall rules
-4. **Resource limit violations**: Adjust resource limits based on actual usage
-
-### Debug Commands
-
-```bash
-# Check controller logs
-kubectl logs deployment/controller-manager -n beskar7-system --tail=100
-
-# Test webhook validation
-kubectl create -f test-physicalhost.yaml --dry-run=server
-
-# Verify security monitoring
-kubectl get events -n beskar7-system | grep security
-```
-
-## Migration Between Configurations
-
-### From Development to Production
-
-1. **Test in staging** with production configuration
-2. **Update secrets** with strong passwords
-3. **Configure certificates** for production BMCs
-4. **Apply production configuration** during maintenance window
-5. **Monitor for issues** and validate functionality
-
-### From Production to Development
-
-1. **Create development namespace** to avoid conflicts
-2. **Apply development configuration** in separate namespace
-3. **Update PhysicalHost resources** to point to development BMCs
-4. **Use development credentials** with relaxed policies
-
-## Security Best Practices
-
-1. **Start with production configuration** and relax only as needed
-2. **Use separate configurations** for different environments
-3. **Regularly rotate credentials** according to your security policy
-4. **Monitor security events** and respond to alerts promptly
-5. **Keep configurations in version control** with proper access controls
-6. **Test configuration changes** in non-production environments first
-
-## Additional Resources
-
-- [Security Documentation](../../docs/security/README.md)
-- [Configuration Guide](../../docs/security/configuration.md)
-- [Troubleshooting Guide](../../docs/security/troubleshooting.md)
-- [Best Practices](../../docs/security/README.md#best-practices) 
+- [Security overview](../../docs/security/README.md)
+- [Security configuration](../../docs/security/configuration.md)
+- [RBAC hardening](../../docs/security/rbac-hardening.md)
+- [Security troubleshooting](../../docs/security/troubleshooting.md)

--- a/examples/security/development.yaml
+++ b/examples/security/development.yaml
@@ -1,331 +1,56 @@
-# Development Security Configuration for Beskar7
-# This example demonstrates a development-friendly configuration with relaxed security settings
+# Development-style security configuration for Beskar7 v0.4.0-alpha.
+#
+# Loosens TLS verification for self-signed BMC certs typical in lab setups.
+# Do NOT use this configuration in production.
+#
+# See docs/security/configuration.md for the production equivalent.
 
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Namespace
 metadata:
-  name: beskar7-security-policy
-  namespace: beskar7-system
-data:
-  policy.yaml: |
-    # Development Security Policy - Relaxed settings for development
-    security:
-      # Relaxed TLS for development environments
-      tls:
-        enforce_certificate_validation: false  # Allow self-signed certs
-        allow_insecure_skip_verify: true       # Allow skipping verification
-        min_tls_version: "1.0"                # More permissive TLS version
-        expiry_warning_days: 7                 # Shorter warning period
-        expiry_critical_days: 1                # Shorter critical period
-        trusted_cas:
-          - system
-        require_hostname_verification: false   # Allow hostname mismatches
-        require_valid_certificate_chain: false # Allow invalid chains
-        
-      # Relaxed RBAC for development
-      rbac:
-        enforce_least_privilege: false  # Allow broader permissions for development
-        prohibited_permissions: []      # No prohibited permissions in dev
-        
-      # Relaxed credential requirements
-      credentials:
-        password_policy:
-          min_length: 8                        # Shorter passwords OK
-          require_uppercase: false             # Not required in dev
-          require_lowercase: false             # Not required in dev
-          require_numbers: false               # Not required in dev
-          require_special_chars: false         # Not required in dev
-          prohibited_common_passwords: false   # Allow common passwords in dev
-        rotation_policy:
-          max_age_days: 365                    # Longer rotation period
-          warning_age_days: 300                # Longer warning period
-          force_rotation_age_days: 999         # Very long force rotation
-        storage_policy:
-          require_encryption_at_rest: false    # Not required in dev
-          require_kubernetes_secrets: false    # Allow other storage methods
-          prohibit_plaintext_storage: false    # Allow plaintext for dev
-          
-      # Network security - more permissive
-      network:
-        default_tls: false                     # Allow HTTP for development
-        prohibited_protocols: []               # No prohibited protocols
-        bmc_encryption: false                  # Not required in dev
-        require_network_policies: false       # Optional network policies
-        
-      # Container security - relaxed
-      container:
-        security_context:
-          run_as_non_root: false               # Allow root for debugging
-          read_only_root_filesystem: false     # Allow writable filesystem
-          allow_privilege_escalation: true     # Allow for debugging
-          drop_all_capabilities: false         # Keep capabilities for debugging
-          seccomp_profile: unconfined          # More permissive seccomp
-        resource_limits:
-          enforce_resource_limits: false       # No resource limits enforcement
-          
-      # Development monitoring - less frequent
-      monitoring:
-        security_monitoring:
-          enabled: true                        # Still monitor, but relaxed
-          scan_interval: "4h"                  # Less frequent scans
-          alert_on_critical: true              # Only critical alerts
-          alert_on_high: false                 # Skip high severity alerts
-          alert_on_medium: false               # Skip medium severity alerts
-        audit_logging:
-          enabled: false                       # Disable audit logging in dev
-        metrics:
-          expose_security_metrics: true        # Still expose metrics
-          alert_on_policy_violations: false    # Don't alert on violations
-          alert_on_certificate_expiry: false   # Don't alert on expiry
-          alert_on_credential_age: false       # Don't alert on old credentials
-          
-      # Development exceptions
-      exceptions:
-        development:
-          allow_insecure_skip_verify: true
-          allow_self_signed_certificates: true
-          allow_http_communication: true
-          allow_weak_passwords: true
-          allow_test_credentials: true
-          relaxed_rbac_validation: true
-          extended_credential_rotation: true
+  name: beskar7-dev
 
 ---
-# Development PhysicalHost Example with relaxed security
+# Throwaway BMC credentials for a lab. Generate a real password externally.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-credentials
+  namespace: beskar7-dev
+type: Opaque
+stringData:
+  username: "admin"
+  password: "changeme"
+
+---
+# Lab PhysicalHost: skip TLS verification because the BMC has a self-signed
+# cert. NEVER do this in production — use caBundleSecretRef instead.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
   name: dev-server-01
-  namespace: default
-  annotations:
-    # Mark as development environment
-    beskar7.io/environment: "development"
-    beskar7.io/security-profile: "relaxed"
+  namespace: beskar7-dev
 spec:
   redfishConnection:
-    address: "https://dev-bmc-01.local"
-    credentialsSecretRef:
-      name: dev-bmc-credentials
-    # Skip certificate verification for development
-    insecureSkipVerify: true
-  
-  # Development hardware specs
-  serverSpecs:
-    manufacturer: "Generic"
-    model: "Development Server"
-    cpu: "Intel Core i5"
-    memory: "32GB"
-    storage: "500GB SSD"
+    address: "https://192.168.1.100"
+    credentialsSecretRef: "bmc-credentials"
+    insecureSkipVerify: true       # Development only — accepts any BMC cert.
 
 ---
-# Development BMC Credentials (simple password)
-apiVersion: v1
-kind: Secret
-metadata:
-  name: dev-bmc-credentials
-  namespace: default
-  annotations:
-    # Mark as development credentials
-    beskar7.io/environment: "development"
-    beskar7.io/credential-type: "development"
-type: Opaque
-data:
-  username: YWRtaW4=    # admin
-  password: cGFzc3dvcmQ=  # password (simple for development)
-
----
-# Minimal Network Policy for Development (optional)
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: beskar7-development-policy
-  namespace: beskar7-system
-spec:
-  podSelector:
-    matchLabels:
-      control-plane: beskar7-controller-manager
-  policyTypes:
-  - Egress
-  
-  egress:
-  # Allow all egress for development
-  - to: []
-
----
-# Development Deployment with Relaxed Security
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: beskar7-controller-manager
-  namespace: beskar7-system
-  labels:
-    control-plane: beskar7-controller-manager
-spec:
-  selector:
-    matchLabels:
-      control-plane: beskar7-controller-manager
-  replicas: 1  # Single replica for development
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: manager
-      labels:
-        control-plane: beskar7-controller-manager
-    spec:
-      # Relaxed security context for development
-      securityContext:
-        runAsNonRoot: false  # Allow root for debugging
-        runAsUser: 0         # Run as root for development
-        fsGroup: 0
-      
-      volumes:
-      - name: webhook-server-cert
-        secret:
-          secretName: beskar7-webhook-server-cert
-      - name: tmp
-        emptyDir: {}
-      
-      containers:
-      - name: manager
-        command:
-        - /manager
-        args:
-        - --leader-elect=false                    # Disable leader election for single replica
-        - --enable-security-monitoring=true      # Keep monitoring but relaxed
-        - --security-scan-interval=4h            # Less frequent scans
-        - --metrics-bind-address=:8080
-        - --health-probe-bind-address=:8081
-        - --v=2                                  # Verbose logging for development
-        image: ghcr.io/projectbeskar/beskar7/beskar7:${VERSION}
-        imagePullPolicy: IfNotPresent            # Use cached images in dev
-        
-        # Relaxed security context for debugging
-        securityContext:
-          allowPrivilegeEscalation: true         # Allow for debugging
-          readOnlyRootFilesystem: false          # Allow writing for debugging
-          runAsNonRoot: false                    # Allow root for debugging
-          runAsUser: 0                           # Run as root
-          capabilities:
-            add: ["SYS_PTRACE"]                  # Add debugging capabilities
-        
-        # Development environment variables
-        env:
-        - name: BESKAR7_ENVIRONMENT
-          value: "development"
-        - name: BESKAR7_SECURITY_STRICT
-          value: "false"
-        - name: BESKAR7_DEBUG
-          value: "true"
-        - name: BESKAR7_LOG_LEVEL
-          value: "debug"
-        
-        volumeMounts:
-        - name: webhook-server-cert
-          mountPath: /tmp/k8s-webhook-server/serving-certs
-          readOnly: true
-        - name: tmp
-          mountPath: /tmp
-        
-        ports:
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
-        - containerPort: 8081
-          name: healthz
-          protocol: TCP
-        - containerPort: 9443
-          name: webhook
-          protocol: TCP
-        
-        # Relaxed health checks for development
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 30
-          timeoutSeconds: 5
-          failureThreshold: 5
-        
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
-        
-        # Generous resource limits for development
-        resources:
-          limits:
-            cpu: 2000m          # More CPU for development
-            memory: 2Gi         # More memory for development
-            ephemeral-storage: 5Gi
-          requests:
-            cpu: 100m           # Low requests for resource efficiency
-            memory: 128Mi
-            ephemeral-storage: 100Mi
-      
-      serviceAccountName: controller-manager
-      terminationGracePeriodSeconds: 10  # Shorter grace period for development
-      automountServiceAccountToken: true
-      enableServiceLinks: true           # Enable service links for development
-      hostNetwork: false
-      hostPID: false
-      hostIPC: false
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-
----
-# Development-specific RBAC with broader permissions
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: manager-role-dev
-rules:
-# All our CRDs
-- apiGroups: ["infrastructure.cluster.x-k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-
-# Cluster API resources
-- apiGroups: ["cluster.x-k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-
-# Core resources for development
-- apiGroups: [""]
-  resources: ["secrets", "configmaps", "events", "pods", "services"]
-  verbs: ["*"]
-
-# Additional permissions for development debugging
-- apiGroups: ["apps"]
-  resources: ["deployments", "replicasets"]
-  verbs: ["get", "list", "watch"]
-
-# Webhook permissions
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-  verbs: ["get", "list", "watch", "create", "update", "patch"]
-
-# Leader election for development
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-
----
-# Development Service Account with broader permissions
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: manager-rolebinding-dev
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: manager-role-dev  # Use development role
-subjects:
-- kind: ServiceAccount
-  name: beskar7-controller-manager
-  namespace: beskar7-system 
+# Helm values for a development install. Apply with:
+#   helm install beskar7 beskar7/beskar7 -n beskar7-system --create-namespace -f values-dev.yaml
+#
+# values-dev.yaml:
+#
+#   webhook:
+#     enabled: false              # skip the Beskar7Cluster webhook in dev
+#   certManager:
+#     enabled: true               # callback endpoint still needs serving certs
+#   bootstrap:
+#     urlBase: "https://beskar7-controller-manager.beskar7-system.svc:8082"
+#   controllerManager:
+#     # Verbose logging via the controller-runtime zap dev encoder. Adds stack
+#     # traces from Warn and a console (not JSON) encoder.
+#     extraArgs:
+#       - --zap-devel=true

--- a/examples/security/production.yaml
+++ b/examples/security/production.yaml
@@ -1,455 +1,130 @@
-# Production Security Configuration for Beskar7
-# This example demonstrates a secure production deployment
+# Production-style security configuration for Beskar7 v0.4.0-alpha.
+#
+# This file demonstrates the enforced security knobs only — the
+# beskar7-security-policy ConfigMap and the various "security framework"
+# settings advertised in earlier docs were never implemented and have been
+# removed. The real controls today are:
+#
+#   1. PhysicalHost.spec.redfishConnection.caBundleSecretRef for verified BMC TLS
+#   2. PhysicalHost.spec.redfishConnection.insecureSkipVerify=false
+#   3. Strong BMC credentials in a Secret (operator-managed; no in-controller policy)
+#   4. NetworkPolicy gating manager ingress
+#   5. cert-manager-issued certs for the webhook + callback endpoint
+#
+# See docs/security/README.md and docs/security/configuration.md.
 
 ---
+# A namespace for production hosts. The chart's NetworkPolicy and the
+# controllers' RBAC are cluster-scoped, but Secrets live where the hosts live.
 apiVersion: v1
-kind: ConfigMap
+kind: Namespace
 metadata:
-  name: beskar7-security-policy
-  namespace: beskar7-system
-data:
-  policy.yaml: |
-    # Production Security Policy
-    security:
-      # Strict TLS enforcement for production
-      tls:
-        enforce_certificate_validation: true
-        allow_insecure_skip_verify: false
-        min_tls_version: "1.2"
-        expiry_warning_days: 30
-        expiry_critical_days: 7
-        trusted_cas:
-          - system
-          - production-ca-cert  # Custom production CA
-        require_hostname_verification: true
-        require_valid_certificate_chain: true
-        
-      # Strict RBAC enforcement
-      rbac:
-        enforce_least_privilege: true
-        prohibited_permissions:
-          - apiGroups: ["*"]
-            resources: ["*"]
-            verbs: ["*"]
-          - apiGroups: ["rbac.authorization.k8s.io"]
-            resources: ["*"]
-            verbs: ["*"]
-          - verbs: ["impersonate"]
-        
-      # Strong credential requirements
-      credentials:
-        password_policy:
-          min_length: 16
-          require_uppercase: true
-          require_lowercase: true
-          require_numbers: true
-          require_special_chars: true
-          prohibited_common_passwords: true
-        rotation_policy:
-          max_age_days: 90
-          warning_age_days: 60
-          force_rotation_age_days: 365
-        storage_policy:
-          require_encryption_at_rest: true
-          require_kubernetes_secrets: true
-          prohibit_plaintext_storage: true
-          
-      # Network security
-      network:
-        default_tls: true
-        prohibited_protocols:
-          - http
-          - telnet
-          - ftp
-          - snmp
-        bmc_encryption: true
-        require_network_policies: true
-        
-      # Container security hardening
-      container:
-        security_context:
-          run_as_non_root: true
-          read_only_root_filesystem: true
-          allow_privilege_escalation: false
-          drop_all_capabilities: true
-          seccomp_profile: runtime/default
-        resource_limits:
-          enforce_resource_limits: true
-          default_cpu_limit: "500m"
-          default_memory_limit: "512Mi"
-          
-      # Comprehensive monitoring
-      monitoring:
-        security_monitoring:
-          enabled: true
-          scan_interval: "30m"  # Frequent scans for production
-          alert_on_critical: true
-          alert_on_high: true
-          alert_on_medium: true
-        audit_logging:
-          enabled: true
-          log_failed_authentications: true
-          log_privilege_escalations: true
-          log_secret_access: true
-          log_rbac_changes: true
-        metrics:
-          expose_security_metrics: true
-          alert_on_policy_violations: true
-          alert_on_certificate_expiry: true
-          alert_on_credential_age: true
-          
-      # Compliance requirements
-      compliance:
-        standards:
-          cis_kubernetes: true
-          nist_cybersecurity: true
-          soc2: true
-        validation:
-          periodic_security_scans: true
-          vulnerability_assessments: true
-          compliance_reporting: true
+  name: beskar7-prod
 
 ---
-# Production CA Certificate Secret
+# BMC credentials Secret. Generate the password externally; Beskar7 does not
+# enforce any strength policy itself.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: production-ca-cert
-  namespace: beskar7-system
+  name: bmc-credentials
+  namespace: beskar7-prod
 type: Opaque
 data:
-  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t  # Base64 encoded production CA
+  username: YWRtaW4=                       # "admin"
+  password: <base64 of openssl rand -base64 32>
 
 ---
-# Secure PhysicalHost Example
+# CA bundle for the BMC fleet, issued by cert-manager. The Beskar7 controller
+# reads data["ca.crt"] (preferred) or data["tls.crt"] (fallback).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: bmc-ca-bundle
+  namespace: beskar7-prod
+spec:
+  secretName: bmc-ca-bundle
+  isCA: true
+  commonName: "BMC Issuing CA"
+  duration: 8760h        # 1 year
+  renewBefore: 720h      # rotate 30 days before expiry
+  issuerRef:
+    name: my-root-issuer
+    kind: ClusterIssuer
+
+---
+# PhysicalHost using strict TLS verification against the bundle above.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PhysicalHost
 metadata:
   name: prod-server-01
-  namespace: default
+  namespace: beskar7-prod
 spec:
   redfishConnection:
-    address: "https://prod-bmc-01.internal.company.com"
-    credentialsSecretRef:
-      name: prod-bmc-credentials
-    # Use custom CA for internal certificates
-    caCertificateSecretRef:
-      name: production-ca-cert
-    # Never skip verification in production
-    insecureSkipVerify: false
-  
-  # Hardware specifications
-  serverSpecs:
-    manufacturer: "Dell"
-    model: "PowerEdge R750"
-    cpu: "Intel Xeon Gold 6338"
-    memory: "256GB"
-    storage: "2x 960GB NVMe SSD"
+    address: "https://bmc.prod.example.com"
+    credentialsSecretRef: "bmc-credentials"
+    insecureSkipVerify: false              # mutually exclusive with caBundleSecretRef
+    caBundleSecretRef:
+      name: bmc-ca-bundle
 
 ---
-# Production BMC Credentials (with strong password)
-apiVersion: v1
-kind: Secret
-metadata:
-  name: prod-bmc-credentials
-  namespace: default
-  annotations:
-    # Track credential creation for rotation
-    beskar7.io/credential-created: "2024-01-15"
-    beskar7.io/credential-owner: "infrastructure-team"
-    beskar7.io/rotation-schedule: "quarterly"
-type: Opaque
-data:
-  username: cm9vdA==  # root
-  password: UGFzc3dvcmQxMjM0NSE=  # Strong password (example)
-
----
-# Network Policies for Production
+# Tighten the chart's NetworkPolicy egress to a known BMC subnet. Apply this
+# AFTER the chart's default NetworkPolicy (overlays it).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: beskar7-production-policy
+  name: beskar7-bmc-egress
   namespace: beskar7-system
 spec:
   podSelector:
     matchLabels:
-      control-plane: beskar7-controller-manager
+      app.kubernetes.io/name: beskar7
   policyTypes:
-  - Ingress
-  - Egress
-  
-  ingress:
-  # Webhook traffic from API server only
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          name: kube-system
-      podSelector:
-        matchLabels:
-          component: kube-apiserver
-    ports:
-    - protocol: TCP
-      port: 9443
-  
-  # Metrics from monitoring namespace only
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          name: monitoring
-    ports:
-    - protocol: TCP
-      port: 8080
-  
+    - Egress
   egress:
-  # DNS resolution
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-    ports:
-    - protocol: UDP
-      port: 53
-  
-  # Kubernetes API server
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          name: kube-system
-    ports:
-    - protocol: TCP
-      port: 443
-  
-  # BMC communication to internal network only
-  - to:
-    - namespaceSelector: {}
-    ports:
-    - protocol: TCP
-      port: 443
-    - protocol: TCP
-      port: 8443
+    # DNS
+    - ports:
+        - protocol: UDP
+          port: 53
+    # kube-apiserver
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+    # BMC subnet only — replace the CIDR with your actual management network.
+    - to:
+        - ipBlock:
+            cidr: 10.100.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443           # standard Redfish HTTPS
+        - protocol: TCP
+          port: 5000          # Supermicro X10/X11 alternate
 
 ---
-# Production Deployment with Enhanced Security
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: beskar7-controller-manager
-  namespace: beskar7-system
-  labels:
-    control-plane: beskar7-controller-manager
-spec:
-  selector:
-    matchLabels:
-      control-plane: beskar7-controller-manager
-  replicas: 2  # HA deployment for production
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: manager
-      labels:
-        control-plane: beskar7-controller-manager
-    spec:
-      # Enhanced security context
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
-        seccompProfile:
-          type: RuntimeDefault
-        sysctls: []
-      
-      # Additional security volumes
-      volumes:
-      - name: webhook-server-cert
-        secret:
-          secretName: beskar7-webhook-server-cert
-          defaultMode: 0400
-      - name: tmp
-        emptyDir:
-          sizeLimit: 100Mi
-      - name: ca-certificates
-        secret:
-          secretName: production-ca-cert
-          defaultMode: 0444
-      
-      containers:
-      - name: manager
-        command:
-        - /manager
-        args:
-        - --leader-elect
-        - --enable-security-monitoring=true
-        - --security-scan-interval=30m
-        - --metrics-bind-address=:8080
-        - --health-probe-bind-address=:8081
-        image: ghcr.io/projectbeskar/beskar7/beskar7:${VERSION}
-        imagePullPolicy: Always
-        
-        # Maximum security context
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 65532
-          runAsGroup: 65532
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
-        
-        # Production environment variables
-        env:
-        - name: GODEBUG
-          value: "netdns=go"
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: BESKAR7_ENVIRONMENT
-          value: "production"
-        - name: BESKAR7_SECURITY_STRICT
-          value: "true"
-        
-        volumeMounts:
-        - name: webhook-server-cert
-          mountPath: /tmp/k8s-webhook-server/serving-certs
-          readOnly: true
-        - name: tmp
-          mountPath: /tmp
-          readOnly: false
-        - name: ca-certificates
-          mountPath: /etc/ssl/certs/production-ca.crt
-          subPath: ca.crt
-          readOnly: true
-        
-        ports:
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
-        - containerPort: 8081
-          name: healthz
-          protocol: TCP
-        - containerPort: 9443
-          name: webhook
-          protocol: TCP
-        
-        # Enhanced health checks
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 20
-          timeoutSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-        
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-            scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
-        
-        # Production resource limits
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-            ephemeral-storage: 2Gi
-          requests:
-            cpu: 200m
-            memory: 256Mi
-            ephemeral-storage: 100Mi
-      
-      serviceAccountName: controller-manager
-      terminationGracePeriodSeconds: 30
-      automountServiceAccountToken: true
-      enableServiceLinks: false
-      hostNetwork: false
-      hostPID: false
-      hostIPC: false
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      priorityClassName: system-cluster-critical
-      
-      # Production scheduling preferences
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  control-plane: beskar7-controller-manager
-              topologyKey: kubernetes.io/hostname
-      
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-        operator: Exists
-
----
-# Production Service Monitor for Prometheus
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: beskar7-security-metrics
-  namespace: beskar7-system
-spec:
-  selector:
-    matchLabels:
-      control-plane: beskar7-controller-manager
-  endpoints:
-  - port: metrics
-    interval: 30s
-    path: /metrics
-    scheme: http
-
----
-# Production Alert Rules
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: beskar7-security-alerts
-  namespace: beskar7-system
-spec:
-  groups:
-  - name: beskar7-security
-    rules:
-    - alert: Beskar7CriticalSecurityIssue
-      expr: beskar7_security_scan_issues_total{severity="critical"} > 0
-      for: 0m
-      labels:
-        severity: critical
-      annotations:
-        summary: "Critical security issue detected in Beskar7"
-        description: "{{ $value }} critical security issues detected"
-    
-    - alert: Beskar7CertificateExpiring
-      expr: beskar7_tls_certificate_expiry_days < 7
-      for: 0m
-      labels:
-        severity: warning
-      annotations:
-        summary: "TLS certificate expiring soon"
-        description: "Certificate expires in {{ $value }} days"
-    
-    - alert: Beskar7CredentialRotationRequired
-      expr: beskar7_credential_age_days > 90
-      for: 0m
-      labels:
-        severity: warning
-      annotations:
-        summary: "Credential rotation required"
-        description: "Credentials are {{ $value }} days old" 
+# Chart values pinned for production:
+#   bootstrap.urlBase            — match the Service DNS for your release name
+#   webhook.enabled              — turn the Beskar7Cluster validating webhook on
+#   certManager.enabled          — webhook + callback endpoint serving certs
+#
+# Apply with:
+#   helm install beskar7 beskar7/beskar7 -n beskar7-system --create-namespace -f values-prod.yaml
+#
+# values-prod.yaml:
+#
+#   webhook:
+#     enabled: true
+#   certManager:
+#     enabled: true
+#   bootstrap:
+#     urlBase: "https://beskar7-controller-manager.beskar7-system.svc:8082"
+#   controllerManager:
+#     replicaCount: 1                       # leader-elect=true; only one active
+#     resources:
+#       limits:
+#         cpu: "500m"
+#         memory: "512Mi"
+#       requests:
+#         cpu: "100m"
+#         memory: "128Mi"


### PR DESCRIPTION
## Summary

**Phase 9 of the v0.4 stabilization plan.** The Beskar7 v0.3 → v0.4 refactor was functionally complete months ago but the documentation has not been swept since. This PR brings every user-facing file into agreement with the current code.

After this lands, the only remaining v0.4 work is **Phase 10 (test backfill)**.

## Stats

**28 files changed, +1841 / −4692 (net −2851 lines)** — mostly cutting unsubstantiated security-framework claims and v0.3-era removed-feature documentation.

## Critical rewrites (factually wrong; would mislead users)

| File | Change |
|---|---|
| `docs/api-reference.md` | Full rewrite to v1beta1 schema (correct field names; `BootstrapStatus`; `InspectionReport` array-of-structs; `caBundleSecretRef` from PR-3.2; current state strings). |
| `docs/beskar7cluster.md`, `beskar7machine.md`, `beskar7machinetemplate.md`, `physicalhost.md` | Per-CRD reference rewrites. `Beskar7MachineTemplate` corrected: it is a pure schema, no controller, no immutability webhook. |
| `docs/state-management.md` | State machine redrawn around `Available / InUse / Inspecting / Ready / Error` (the v0.3 `Claimed / Provisioning / Provisioned / Deprovisioning` strings are gone). |
| `examples/complete-cluster.yaml`, `minimal-test-cluster.yaml` | Full rewrites using current schema. The CRDs would have rejected the v0.3-shaped versions on apply. |
| `docs/security/*.md` (4 files) | **Cut hard.** Removed all references to the deleted `beskar7-security-policy` ConfigMap, the never-shipped `--enable-security-monitoring` flag, the deleted `internal/security` package, never-audited compliance claims (CIS/NIST/SOC 2/ISO 27001), never-registered security metrics, and the never-shipped `beskar7-security-monitor` CronJob. **Kept and documented** the controls that actually exist: TLS via `insecureSkipVerify` + `caBundleSecretRef` (PR-3.2), bearer-token auth on inspection POST + bootstrap GET (D-004), per-host plaintext Secret (D-006), per-namespace RBAC scoping (PR-7 / D-007), pod securityContext, NetworkPolicy on `:8082`, controller-runtime native metrics auth (PR-11.1). |
| `docs/ipxe-setup.md` | Callback port `:8080` → `:8082` (HTTPS, bearer-auth); documented the kernel cmdline variables (`beskar7.bootstrap-url`, `beskar7.token`) the iPXE script needs. |

## Moderate rewrites

| File | Change |
|---|---|
| `docs/troubleshooting.md` | Removed deleted `mutation.physicalhost...` webhook section; removed reference to undeclared flag; added bearer-token (401) and `caBundleSecretRef` failure-mode sections. |
| `docs/advanced-usage.md` | Replaced removed `RemoteConfig`/`PreBakedISO`/`UefiTargetBootSourceOverride` description with the real bootstrap-data flow + `HardwareRequirements` + `force-release` annotation. |
| `docs/quick-start.md` | Go 1.24 → 1.25; image `v0.2.7` → `v0.4.0-alpha`; added `--bootstrap-url-base` note. |
| `docs/resource-planning.md` | Removed fictional manager flags; corrected to the real flag set. |
| `docs/deployment-best-practices.md` | Metrics references `:8080` → `:8443`; removed fake state metric and fake reconcile flags. |
| `docs/metrics.md` | Endpoint moved to `:8443` with kube-apiserver auth (PR-11.1); state list corrected; scrape config replaced with a working SA-token ServiceMonitor. |
| `docs/architecture.md` | `InspectionReport` example fixed; metrics port 8443; inspection-token section rewritten around D-004; kernel cmdline variables documented. |
| `docs/introduction.md` | Removed "Remote Configuration via kernel parameters or Pre-Baked ISOs" claim; described the actual flow. |
| `README.md` | Removed broken link to `docs/migration-to-projectbeskar.md`. |
| `docs/README.md` | Removed broken links to non-existent `quick-start-vendor-support.md` / `vendor-specific-support.md`; vendor notes inlined. |
| `CHANGELOG.md` | Corrected false constant claims; fixed `InspectionReport` shape description; added `Unreleased` section summarizing PR-0.1 through PR-8.1. |

## Examples

- `examples/security/development.yaml` + `production.yaml`: replaced the `beskar7-security-policy` ConfigMap fiction with working PhysicalHost examples (lab `insecureSkipVerify=true`; production cert-manager-issued CA bundle + strict TLS + NetworkPolicy egress narrowing).
- `examples/security/README.md`, `examples/complete-cluster.md`: slim rewrites.

## Test plan

- [x] All 28 files parse as Markdown / valid YAML
- [x] `grep -rn "imageURL\|osFamily\|provisioningMode\|configURL\b\|bootMode\b" docs/ examples/` → only intentional "v0.3 fields removed" callouts remain
- [x] `grep -rn "Claimed\|Provisioning\|Provisioned\|Deprovisioning" docs/` → all matches are intentional (provisioning-the-verb, `MachineProvisioned` condition, explicit v0.3-strings-are-gone callout)
- [x] `grep -rn "beskar7-security-policy\|--enable-security-monitoring" docs/ examples/` → only intentional "this was never implemented" callouts
- [x] `grep -rn "8080.*metric\|metric.*8080\|8080.*inspection\|inspection.*8080\|callback.*8080\|8080.*callback" docs/` → empty
- [x] `grep -rn "RemoteConfig\|PreBakedISO\|UefiTargetBootSourceOverride" docs/ examples/` → only the intentional `advanced-usage.md` callout
- [x] `grep -rn "go 1.24\|Go 1.24" docs/` → empty
- [x] All four example YAMLs use only v1beta1 fields per the CRDs in `api/v1beta1/`
- [x] `helm template charts/beskar7` unchanged (no chart edits)
- [ ] CI lint / unit / integration jobs pass

## Files deliberately not changed

- `docs/hardware-compatibility.md` and `docs/ci-cd-and-testing.md` — read end-to-end; no v0.3 schema references, no removed-feature drift, no port mismatches.
- `charts/`, `config/`, `.claude/`, `CLAUDE.md` — out of scope.

## Plan progress after this merges

| Phase | Status |
|---|---|
| 0, 1, 2, 3, 4, 5, 6, 8, **9**, 11 | **all done** |
| 7 | partial (D-007 closed; SEC-2 v0.5 finisher tracked) |
| 10 | open — **test backfill (M–L, qa-engineer)** |

Phase 10 is the only remaining v0.4 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)