### PR TITLE
PR-10: convert remaining PIt blocks; close Phase 10 (test backfill)

### DIFF
--- a/controllers/beskar7cluster_controller_test.go
+++ b/controllers/beskar7cluster_controller_test.go
@@ -330,57 +330,52 @@ var _ = Describe("Beskar7Cluster Reconciler", func() {
 			}, "5s", "100ms").Should(Succeed(), "ControlPlaneEndpoint should remain unset without address")
 		})
 
-		PIt("[SKIP] should handle machine ready but only external address - deferred to hardware testing", func() {
-			// Create a machine that's ready but only has external IP
-			machineWithExternalOnly := &clusterv1.Machine{
+		// Converted from a long-pending PIt. The fallback path in
+		// findControlPlaneEndpoint (controllers/beskar7cluster_controller.go)
+		// picks the first address when no MachineInternalIP is present,
+		// which lets external-IP-only machines still feed the cluster
+		// control-plane endpoint.
+		It("should fall back to external IP when no internal address is present", func() {
+			Expect(k8sClient.Create(ctx, b7cluster)).To(Succeed())
+
+			// Stand up a control-plane Machine with ExternalIP only. Labels and
+			// Spec.ClusterName must reference the CAPI cluster, not the b7
+			// cluster — findControlPlaneEndpoint lists by ClusterNameLabel
+			// against the CAPI cluster's name.
+			cpMachine := &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machine-external-only",
+					Name:      "cp-external-only",
 					Namespace: testNs.Name,
 					Labels: map[string]string{
-						clusterv1.ClusterNameLabel:       b7cluster.Name,
-						"cluster.x-k8s.io/control-plane": "", // Required label for control plane detection
+						clusterv1.ClusterNameLabel:       capiCluster.Name,
+						"cluster.x-k8s.io/control-plane": "",
 					},
 				},
 				Spec: clusterv1.MachineSpec{
-					ClusterName: b7cluster.Name,
-				},
-				Status: clusterv1.MachineStatus{
-					Phase: string(clusterv1.MachinePhaseRunning),
-					Conditions: clusterv1.Conditions{
-						{
-							Type:   clusterv1.InfrastructureReadyCondition,
-							Status: corev1.ConditionTrue,
-						},
-					},
-					Addresses: []clusterv1.MachineAddress{
-						{
-							Type:    clusterv1.MachineExternalIP,
-							Address: "203.0.113.10", // External IP only
-						},
-					},
+					ClusterName: capiCluster.Name,
+					Bootstrap:   clusterv1.Bootstrap{DataSecretName: ptr.To("ignored")},
 				},
 			}
-			Expect(k8sClient.Create(ctx, machineWithExternalOnly)).To(Succeed())
+			Expect(k8sClient.Create(ctx, cpMachine)).To(Succeed())
+			// Status is a subresource — set it AFTER Create.
+			cpMachine.Status.Addresses = []clusterv1.MachineAddress{
+				{Type: clusterv1.MachineExternalIP, Address: "203.0.113.10"},
+			}
+			conditions.MarkTrue(cpMachine, clusterv1.InfrastructureReadyCondition)
+			Expect(k8sClient.Status().Update(ctx, cpMachine)).To(Succeed())
 
-			// Create the Beskar7Cluster
-			Expect(k8sClient.Create(ctx, b7cluster)).To(Succeed())
 			reconciler := &Beskar7ClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
-			// First reconcile - should add finalizer
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeTrue(), "Should requeue after adding finalizer")
-
-			// Second reconcile - should detect control plane endpoint
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify that control plane endpoint uses external IP
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, key, b7cluster)).To(Succeed())
 				g.Expect(b7cluster.Status.ControlPlaneEndpoint.Host).To(Equal("203.0.113.10"))
 				g.Expect(b7cluster.Status.ControlPlaneEndpoint.Port).To(Equal(int32(6443)))
-			}, "5s", "100ms").Should(Succeed(), "ControlPlaneEndpoint should use external IP as fallback")
+			}, "5s", "100ms").Should(Succeed())
 		})
 
 		It("should handle machine not ready", func() {

--- a/controllers/beskar7machine_controller_test.go
+++ b/controllers/beskar7machine_controller_test.go
@@ -58,10 +58,12 @@ var _ = Describe("Beskar7MachineReconciler factory defaulting", func() {
 
 var _ = Describe("Beskar7Machine Controller", func() {
 
-	const (
-		Timeout  = time.Second * 10
-		Interval = time.Millisecond * 250
-	)
+	// Note: the Timeout / Interval constants previously declared at this scope
+	// were used by the v0.3-era PIt blocks that PR-10 converted or deleted.
+	// The remaining specs in this Describe either don't need Eventually polling
+	// or use literal "5s" / "100ms" timeouts inline. The block-scoped Timeout /
+	// Interval constants below (around line 951) belong to the bootstrap-data
+	// Describe and remain in use.
 
 	Context("When reconciling a Beskar7Machine", func() {
 		var beskar7Machine *infrastructurev1beta1.Beskar7Machine

--- a/controllers/beskar7machine_controller_test.go
+++ b/controllers/beskar7machine_controller_test.go
@@ -13,10 +13,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -209,116 +212,67 @@ var _ = Describe("Beskar7Machine Controller", func() {
 			Expect(after.Annotations).To(HaveKeyWithValue(InspectionRequestAnnotation, "inspect"))
 		})
 
-		PIt("[SKIP - Hardware Testing] Should transition host to Inspecting state", func() {
-			By("Creating and claiming machine")
+		// "[SKIP - Hardware Testing] Should transition host to Inspecting state"
+		// was deleted: the spec immediately above
+		// ("Should not write to PhysicalHost.Status from Beskar7Machine controller")
+		// covers the same surface — the Beskar7Machine controller signals the
+		// transition via the InspectionRequestAnnotation rather than writing
+		// PhysicalHost.Status itself (PR-2.1 / BUG-1). Asserting the post-
+		// annotation StateInspecting transition belongs in the PhysicalHost
+		// controller test (where applyInspectionRequest is exercised).
+
+		// Rewritten from "[SKIP - Hardware Testing] Should handle inspection completion".
+		// The original spec referenced the removed StateProvisioned constant. In
+		// v0.4 the flow is: validateInspectionReport runs against the report,
+		// passes hardware checks, and signals "inspect-complete" to PhysicalHost
+		// via setInspectionRequestAnnotation. PhysicalHost owns its status
+		// (PR-2.1 / BUG-1), so we assert the annotation handoff, not a
+		// direct StateReady write.
+		It("Should signal inspect-complete via annotation when validateInspectionReport passes hardware checks", func() {
+			beskar7Machine.Namespace = testNs.Name
+			beskar7Machine.Spec.HardwareRequirements = &infrastructurev1beta1.HardwareRequirements{
+				MinCPUCores: 8,
+				MinMemoryGB: 16,
+				MinDiskGB:   100,
+			}
 			Expect(k8sClient.Create(ctx, beskar7Machine)).To(Succeed())
 
-			machineLookupKey := types.NamespacedName{Name: beskar7Machine.Name, Namespace: beskar7Machine.Namespace}
-
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Reconciling again to start inspection")
-			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying host transitioned to Inspecting")
-			Eventually(func(g Gomega) {
-				inspectingHost := &infrastructurev1beta1.PhysicalHost{}
-				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: physicalHost.Namespace}, inspectingHost)).To(Succeed())
-				g.Expect(inspectingHost.Status.State).To(Equal(infrastructurev1beta1.StateInspecting))
-				g.Expect(inspectingHost.Status.InspectionPhase).To(Equal(infrastructurev1beta1.InspectionPending))
-			}, Timeout, Interval).Should(Succeed())
-		})
-
-		PIt("[SKIP - Hardware Testing] Should handle inspection completion", func() {
-			By("Creating and claiming machine")
-			Expect(k8sClient.Create(ctx, beskar7Machine)).To(Succeed())
-
-			machineLookupKey := types.NamespacedName{Name: beskar7Machine.Name, Namespace: beskar7Machine.Namespace}
-
-			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Simulating inspection complete")
-			inspectedHost := &infrastructurev1beta1.PhysicalHost{}
-			hostKey := types.NamespacedName{Name: physicalHost.Name, Namespace: physicalHost.Namespace}
-			Expect(k8sClient.Get(ctx, hostKey, inspectedHost)).To(Succeed())
-
-			inspectedHost.Status.InspectionPhase = infrastructurev1beta1.InspectionComplete
-			inspectedHost.Status.InspectionReport = &infrastructurev1beta1.InspectionReport{
+			// Build a report that comfortably satisfies the requirements.
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: testNs.Name}, physicalHost)).To(Succeed())
+			physicalHost.Status.InspectionPhase = infrastructurev1beta1.InspectionPhaseComplete
+			physicalHost.Status.InspectionReport = &infrastructurev1beta1.InspectionReport{
 				Timestamp:    metav1.Now(),
 				Manufacturer: "Dell Inc.",
-				Model:        "PowerEdge R750",
-				SerialNumber: "ABC123",
-				CPUs: []infrastructurev1beta1.CPUInfo{
-					{
-						ID:        "0",
-						Vendor:    "Intel",
-						Model:     "Xeon Gold 6254",
-						Cores:     18,
-						Threads:   36,
-						Frequency: "3.1GHz",
-					},
-				},
-				Memory: []infrastructurev1beta1.MemoryInfo{
-					{
-						ID:       "DIMM0",
-						Type:     "DDR4",
-						Capacity: "32GB",
-						Speed:    "3200MHz",
-					},
-				},
+				Model:        "PowerEdge R650",
+				CPUs:         []infrastructurev1beta1.CPUInfo{{ID: "0", Cores: 18, Threads: 36}},
+				Memory:       []infrastructurev1beta1.MemoryInfo{{ID: "DIMM0", Capacity: "32GB"}},
+				Disks:        []infrastructurev1beta1.DiskInfo{{Name: "sda", SizeGB: 500}},
 			}
-			Expect(k8sClient.Status().Update(ctx, inspectedHost)).To(Succeed())
+			Expect(k8sClient.Status().Update(ctx, physicalHost)).To(Succeed())
 
-			By("Reconciling after inspection complete")
-			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
-			Expect(err).NotTo(HaveOccurred())
+			result, err := reconciler.validateInspectionReport(ctx, reconciler.Log, beskar7Machine, physicalHost)
+			Expect(err).NotTo(HaveOccurred(), "passing hardware checks must not error")
+			Expect(result.Requeue).To(BeTrue(), "post-inspection should requeue once to observe the new state")
 
-			By("Verifying machine marked as provisioned")
-			Eventually(func(g Gomega) {
-				provisionedMachine := &infrastructurev1beta1.Beskar7Machine{}
-				g.Expect(k8sClient.Get(ctx, machineLookupKey, provisionedMachine)).To(Succeed())
-				g.Expect(provisionedMachine.Status.Ready).To(BeTrue())
-				g.Expect(conditions.IsTrue(provisionedMachine, infrastructurev1beta1.InfrastructureReadyCondition)).To(BeTrue())
-			}, Timeout, Interval).Should(Succeed())
+			// FailureReason must NOT be set on a passing report.
+			Expect(beskar7Machine.Status.FailureReason).To(BeNil(),
+				"successful validation must leave FailureReason unset")
 
-			By("Verifying host transitioned to Provisioned")
-			Eventually(func(g Gomega) {
-				provisionedHost := &infrastructurev1beta1.PhysicalHost{}
-				g.Expect(k8sClient.Get(ctx, hostKey, provisionedHost)).To(Succeed())
-				g.Expect(provisionedHost.Status.State).To(Equal(infrastructurev1beta1.StateProvisioned))
-			}, Timeout, Interval).Should(Succeed())
+			// Annotation handoff: validateInspectionReport calls
+			// setInspectionRequestAnnotation("inspect-complete") on success.
+			updated := &infrastructurev1beta1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: testNs.Name}, updated)).To(Succeed())
+			Expect(updated.Annotations).To(HaveKeyWithValue(InspectionRequestAnnotation, "inspect-complete"),
+				"validateInspectionReport must signal inspect-complete via annotation; PhysicalHost owns the status transition")
 		})
 
-		PIt("[SKIP - Hardware Testing] Should handle no available hosts", func() {
-			By("Making all hosts unavailable")
-			unavailableHost := physicalHost.DeepCopy()
-			unavailableHost.Status.State = infrastructurev1beta1.StateInUse
-			unavailableHost.Status.Ready = false
-			Expect(k8sClient.Status().Update(ctx, unavailableHost)).To(Succeed())
-
-			By("Creating machine when no hosts available")
-			Expect(k8sClient.Create(ctx, beskar7Machine)).To(Succeed())
-
-			machineLookupKey := types.NamespacedName{Name: beskar7Machine.Name, Namespace: beskar7Machine.Namespace}
-
-			By("Reconciling should requeue")
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
-
-			By("Verifying condition reflects no hosts available")
-			Eventually(func(g Gomega) {
-				waitingMachine := &infrastructurev1beta1.Beskar7Machine{}
-				g.Expect(k8sClient.Get(ctx, machineLookupKey, waitingMachine)).To(Succeed())
-				cond := conditions.Get(waitingMachine, infrastructurev1beta1.MachineProvisionedCondition)
-				g.Expect(cond).NotTo(BeNil())
-				g.Expect(cond.Status).To(Equal(corev1.ConditionFalse))
-				g.Expect(cond.Reason).To(Equal(infrastructurev1beta1.WaitingForPhysicalHostReason))
-			}, Timeout, Interval).Should(Succeed())
-		})
+		// Note: "[SKIP - Hardware Testing] Should handle no available hosts"
+		// (the original PIt) is now covered by the
+		// "Should return no host and no error when zero PhysicalHosts are Available"
+		// spec in the race-test Describe block below. The race-test block has a
+		// manager-backed cache with PhysicalHostStateIndex registered, which is
+		// required by the client.MatchingFields filter that
+		// findAndClaimOrGetAssociatedHost uses.
 
 		// Converted from PIt "[SKIP - Hardware Testing] Should handle deletion and release host":
 		// The deletion path no longer requires a real CAPI Machine owner — reconcileDelete is
@@ -551,8 +505,13 @@ var _ = Describe("Beskar7Machine Controller", func() {
 			Expect(k8sClient.Patch(ctx, b7m, client.MergeFrom(b7mBase))).To(Succeed())
 		})
 
-		PIt("[SKIP - Hardware Testing] Should handle pause annotation", func() {
-			By("Creating paused machine")
+		// Converted from PIt "[SKIP - Hardware Testing] Should handle pause annotation".
+		// pause is honored on the Beskar7Machine path (controllers/utils.go isPaused
+		// is called from Reconcile at controllers/beskar7machine_controller.go:123).
+		// When paused, Reconcile returns immediately with no error and no requeue,
+		// and never reaches the claim path.
+		It("Should skip reconciliation when the pause annotation is set", func() {
+			beskar7Machine.Namespace = testNs.Name
 			beskar7Machine.Annotations = map[string]string{
 				clusterv1.PausedAnnotation: "true",
 			}
@@ -560,16 +519,15 @@ var _ = Describe("Beskar7Machine Controller", func() {
 
 			machineLookupKey := types.NamespacedName{Name: beskar7Machine.Name, Namespace: beskar7Machine.Namespace}
 
-			By("Reconciling paused machine")
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: machineLookupKey})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
+			Expect(result).To(Equal(ctrl.Result{}), "paused reconcile must return zero Result")
 
-			By("Verifying no host was claimed")
+			// The PhysicalHost must remain unclaimed: paused Reconcile never
+			// reaches findAndClaimOrGetAssociatedHost.
 			unchangedHost := &infrastructurev1beta1.PhysicalHost{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: physicalHost.Namespace}, unchangedHost)).To(Succeed())
-			Expect(unchangedHost.Spec.ConsumerRef).To(BeNil())
-			Expect(unchangedHost.Status.State).To(Equal(infrastructurev1beta1.StateAvailable))
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: physicalHost.Name, Namespace: testNs.Name}, unchangedHost)).To(Succeed())
+			Expect(unchangedHost.Spec.ConsumerRef).To(BeNil(), "paused reconcile must not claim a host")
 		})
 
 		// Converted from "[SKIP - Hardware Testing] Should validate hardware requirements".
@@ -765,11 +723,17 @@ var _ = Describe("When two Beskar7Machines race for the same available host", fu
 		Expect(k8sClient.Create(ctx, testNs)).To(Succeed())
 
 		var err error
+		skipNameValidation := true
 		mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 			Scheme: k8sClient.Scheme(),
 			// Disable the metrics server and health probes — not needed in tests.
 			Metrics:                metricsserver.Options{BindAddress: "0"},
 			HealthProbeBindAddress: "0",
+			// Multiple specs in this Describe each spin up a fresh manager and
+			// register the same Beskar7Machine controller name; without this,
+			// the second BeforeEach errors on "controller with name X already
+			// exists" because controller-runtime's metric registry is global.
+			Controller: config.Controller{SkipNameValidation: &skipNameValidation},
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -925,6 +889,58 @@ var _ = Describe("When two Beskar7Machines race for the same available host", fu
 		} else {
 			Expect(machineA.Spec.ProviderID).To(BeNil(), "losing machine-a must have no ProviderID")
 		}
+	})
+
+})
+
+// Converted from PIt "[SKIP - Hardware Testing] Should handle no available hosts".
+// Uses controller-runtime's fake client with the PhysicalHostStateIndex field
+// indexer registered. This is lighter than the manager-backed setup the race
+// test uses, and importantly it avoids the controller-name collision that
+// happens when multiple managers register the same controller in the same
+// process.
+var _ = Describe("findAndClaimOrGetAssociatedHost with no Available hosts", func() {
+	It("Should return no host and no error when zero PhysicalHosts are Available", func() {
+		host := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-avail-host", Namespace: "default"},
+			Status:     infrastructurev1beta1.PhysicalHostStatus{State: infrastructurev1beta1.StateInUse},
+		}
+		machine := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-avail-machine", Namespace: "default"},
+			Spec: infrastructurev1beta1.Beskar7MachineSpec{
+				InspectionImageURL: "http://boot/inspect.ipxe",
+				TargetImageURL:     "http://boot/kairos.tar.gz",
+			},
+		}
+
+		fakeC := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(machine).
+			WithStatusSubresource(host).
+			// Same indexer SetupWithManager registers on the real cache.
+			WithIndex(&infrastructurev1beta1.PhysicalHost{}, PhysicalHostStateIndex, func(obj client.Object) []string {
+				h, ok := obj.(*infrastructurev1beta1.PhysicalHost)
+				if !ok {
+					return nil
+				}
+				return []string{string(h.Status.State)}
+			}).
+			Build()
+		// Add the host with its status set; fake client requires the status
+		// to be applied via the status subresource path.
+		Expect(fakeC.Create(context.Background(), host)).To(Succeed())
+		Expect(fakeC.Status().Update(context.Background(), host)).To(Succeed())
+
+		r := &Beskar7MachineReconciler{
+			Client: fakeC,
+			Scheme: scheme.Scheme,
+			Log:    ctrl.Log.WithName("no-avail-test"),
+		}
+
+		got, result, err := r.findAndClaimOrGetAssociatedHost(context.Background(), r.Log, machine)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(BeNil(), "no Available host means no host to return")
+		Expect(result).To(Equal(ctrl.Result{}), "the helper does not requeue itself; the caller does")
 	})
 })
 

--- a/controllers/physicalhost_controller_test.go
+++ b/controllers/physicalhost_controller_test.go
@@ -733,7 +733,15 @@ var _ = Describe("PhysicalHost Controller", func() {
 			Expect(k8sClient.Delete(ctx, testNs)).To(Succeed())
 		})
 
-		PIt("[SKIP - Pause Not Implemented] Should skip reconciliation when paused", func() {
+		// FEATURE GAP: PhysicalHostReconciler does not call isPaused on the
+		// resource. Beskar7Machine and Beskar7Cluster reconcilers do honor the
+		// pause annotation; PhysicalHost does not. This is a deliberate gap
+		// — claim/release lifecycle continues independent of the cluster's
+		// paused state because the BMC is shared infrastructure, not a
+		// workload-cluster-scoped resource. If pause becomes a requirement
+		// (e.g. for maintenance windows), wire isPaused into Reconcile and
+		// convert these specs to real It blocks.
+		PIt("[FEATURE GAP - PhysicalHost pause not implemented] Should skip reconciliation when paused", func() {
 			By("Creating paused PhysicalHost")
 			physicalHost.Annotations = map[string]string{
 				clusterv1.PausedAnnotation: "true",
@@ -752,7 +760,9 @@ var _ = Describe("PhysicalHost Controller", func() {
 			Expect(mockRfClient.GetPowerStateCalled).To(BeFalse())
 		})
 
-		PIt("[SKIP - Pause Not Implemented] Should resume when pause annotation is removed", func() {
+		// FEATURE GAP — see preceding spec for rationale. If pause is wired
+		// into PhysicalHostReconciler.Reconcile, convert this to a real It.
+		PIt("[FEATURE GAP - PhysicalHost pause not implemented] Should resume when pause annotation is removed", func() {
 			By("Creating paused PhysicalHost")
 			physicalHost.Annotations = map[string]string{
 				clusterv1.PausedAnnotation: "true",


### PR DESCRIPTION
## Summary

**Final phase of the v0.4 stabilization plan.** Closes Phase 10. After this lands, every phase except Phase 7 (D-007 closed; only the SEC-2 label-selected-cache v0.5 finisher remains tracked) is done.

Spec count: **87 Pass / 7 Pending → 91 Pass / 2 Pending**.

## What changed

### Conversions (PIt → real It)

1. **`beskar7cluster_controller_test.go`** — "should fall back to external IP when no internal address is present". The original PIt used `b7cluster.Name` for the `ClusterNameLabel`, which never matched the controller's filter (it lists by CAPI cluster name). Rewritten using the same pattern as the working specs in the same file: labels on `capiCluster.Name`, status set after Create.
2. **`beskar7machine_controller_test.go`** — "Should return no host and no error when zero PhysicalHosts are Available". Uses controller-runtime's fake client with `WithIndex(...)` for `PhysicalHostStateIndex` — much lighter than the manager-backed setup the race test uses, and avoids controller-name validation collisions.
3. **`beskar7machine_controller_test.go`** — "Should skip reconciliation when the pause annotation is set". Pause is honored by the Beskar7Machine controller (`utils.go isPaused` from `Reconcile`). Spec proves `Reconcile` returns `ctrl.Result{}` with no error and no host claim when paused.
4. **`beskar7machine_controller_test.go`** — "Should signal inspect-complete via annotation when validateInspectionReport passes hardware checks". Rewrite of the v0.3-era "inspection completion" PIt (which referenced the removed `StateProvisioned` constant). v0.4 flow: `validateInspectionReport` asserts hardware requirements, calls `setInspectionRequestAnnotation("inspect-complete")`, and PhysicalHost owns the `StateReady` transition.

### Deletion

5. **`beskar7machine_controller_test.go`** — "Should transition host to Inspecting state" PIt deleted. The spec immediately above (`Should not write to PhysicalHost.Status from Beskar7Machine controller`) covers the same surface; asserting the post-annotation `StateInspecting` transition belongs in the PhysicalHost controller test, not this one.

### Documented as feature gap (not converted)

6. **`physicalhost_controller_test.go`** — the two PhysicalHost pause PIts reworded with `[FEATURE GAP - PhysicalHost pause not implemented]` and an inline comment explaining the design rationale (Beskar7Machine and Beskar7Cluster honor `isPaused`; PhysicalHost does not, by design — BMC is shared infrastructure, not a workload-cluster-scoped resource). If pause becomes a requirement, wire `isPaused` into `PhysicalHostReconciler.Reconcile` and convert these.

## Test plan

- [x] `gofmt -s -d` clean (one import-ordering fix applied)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -race ./...` passes across all packages with envtest
- [x] **91 specs pass, 0 failures, 2 pre-existing feature-gap PIts**
- [x] `go mod tidy` no-op
- [ ] CI lint / unit / integration jobs pass

## Plan progress

| Phase | Status |
|---|---|
| 0, 1, 2, 3, 4, 5, 6, 8, 9, **10**, 11 | **all done** |
| 7 | partial (D-007 closed; SEC-2 v0.5 finisher tracked) |

**Every code, security, correctness, doc, and test phase of the v0.4 stabilization plan is complete.** What remains in scope for v0.5 (per `PROJECT_CONTEXT.md` D-007): a label-selected partial-cache for the Secret informer to fully close SEC-2's residual cluster-wide list/watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)