### PR TITLE
chore(chart): bump Chart.yaml to 0.4.0-alpha.1 (prerequisite for gh-pages republish)

### DIFF
--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0-alpha
-appVersion: "v0.4.0-alpha"
+version: 0.4.0-alpha.1
+appVersion: "v0.4.0-alpha.1"
 keywords:
   - cluster-api
   - infrastructure


### PR DESCRIPTION
## Summary

Bumps `charts/beskar7/Chart.yaml` from `0.4.0-alpha` to `0.4.0-alpha.1`. Prerequisite for republishing the gh-pages chart index with a working v0.4 chart.

## Why

The chart on `https://projectbeskar.github.io/beskar7/` at version `0.4.0-alpha` was packaged from the **pre-refactor** codebase — it still has `kube-rbac-proxy` (removed in PR-11.1), no callback Service (added in PR-4), no webhook configuration templates. Republishing the same version with a different digest would surprise anyone who pinned to it. Bumping to a new pre-release version (`0.4.0-alpha.1`) gives the freshly-built chart its own identity.

After this PR + #59 (workflow fix) merge, I'll trigger the workflow to publish `0.4.0-alpha.1` cleanly. Users can then install with:

```bash
helm install --devel beskar7 beskar7/beskar7 \
  --namespace beskar7-system --create-namespace
```

(The `--devel` flag is required because `0.4.0-alpha.1` is a pre-release version per semver. Drop `--devel` once the project graduates from alpha.)

## Test plan

- [x] `helm lint charts/beskar7` clean
- [x] `helm template charts/beskar7` renders 11 resources (no chart logic change; only metadata)
- [ ] CI lint / unit / integration jobs pass (no Go change; should be trivial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)