### PR TITLE
chore: pin controller-gen to v0.21.0 and regenerate CRDs (unblocks #59, #60)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,16 @@ build:
 generate:
 	$(GO) generate ./...
 
-# Install controller-gen
+# Install controller-gen.
+# Pinned to v0.21.0 so the CRD `controller-gen.kubebuilder.io/version` annotation
+# stays stable across machines. Bumping to @latest caused every PR's
+# "Generate and Validate Manifests" job to fail with a one-line annotation diff
+# (controller-tools releases tend to bump that annotation on every release).
+# To upgrade: bump the pin, run `make manifests && make sync-chart-crds`,
+# commit the regenerated YAML alongside the Makefile change.
+CONTROLLER_GEN_VERSION ?= v0.21.0
 install-controller-gen:
-	$(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+	$(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
 # Generate manifests e.g. CRDs, RBAC, and DeepCopy objects
 manifests: install-controller-gen

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7clusters.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: beskar7clusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: beskar7machines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: beskar7machinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: physicalhosts.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7clusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: beskar7clusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: beskar7machines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: beskar7machinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: physicalhosts.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
## Summary

The Makefile installed `controller-gen` from `@latest`, so every machine and every CI run picked up whichever version was current at the time. controller-tools releases tend to bump the `controller-gen.kubebuilder.io/version:` annotation on each release, so any drift between the last commit's controller-gen and the runner's controller-gen fails the "Generate and Validate Manifests" check on every PR with a one-line annotation diff.

This is what's currently blocking **PR #59** (helm-publish workflow patch) and **PR #60** (chart version bump). Both will pass once this lands and they rebase.

## What changed

- **`Makefile`**: introduce `CONTROLLER_GEN_VERSION ?= v0.21.0` and use `@$(CONTROLLER_GEN_VERSION)` in `install-controller-gen`. Includes a comment with the upgrade procedure (bump pin → `make manifests && make sync-chart-crds` → commit regenerated YAML alongside the Makefile change).
- **`config/crd/bases/*.yaml`** (4 files): regenerated with v0.21.0. The only content change in the CRD YAML is the version annotation `v0.20.1` → `v0.21.0`.
- **`charts/beskar7/crds/*.yaml`** (4 files): synced from `config/crd/bases/` via `make sync-chart-crds` so the chart's bundled CRDs match.

## Test plan

- [x] `make manifests && make sync-chart-crds` is a no-op on re-run (idempotent)
- [x] `go build ./...` clean
- [x] All four chart CRDs byte-identical to `config/crd/bases/`
- [ ] CI "Generate and Validate Manifests" job passes (the gate that's been failing)
- [ ] CI lint / unit / integration jobs pass (no Go semantic change)

## Follow-up

Once this lands, **PR #59 and #60 will need a rebase** to pick it up. Otherwise their CI will keep failing on the same drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)