### PR TITLE
fix(chart): set fsGroup + runAsGroup, default namespace.create=false

### DIFF
--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0-alpha.1
-appVersion: "v0.4.0-alpha.1"
+version: 0.4.0-alpha.2
+appVersion: "v0.4.0-alpha.2"
 keywords:
   - cluster-api
   - infrastructure

--- a/charts/beskar7/values.yaml
+++ b/charts/beskar7/values.yaml
@@ -37,9 +37,20 @@ serviceAccount:
 
 podAnnotations: {}
 
+# Pod-level security context. fsGroup and runAsGroup must be set so the
+# non-root container (UID 65532, GID 65532) can read the webhook serving cert
+# Secret mounted at /tmp/k8s-webhook-server/serving-certs. The Secret volume
+# uses defaultMode 0400 (owner-only) to match config/manager/manager.yaml;
+# without fsGroup the kubelet leaves the files as root:root and the manager
+# crashes with "permission denied" on the eager TLS load in the inspection
+# callback server. seccompProfile is required by the Restricted PSA profile.
 podSecurityContext:
   runAsNonRoot: true
-  # fsGroup: 2000
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -49,6 +60,7 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 65532
+  runAsGroup: 65532
 
 # Webhook configuration
 webhook:
@@ -75,9 +87,12 @@ certManager:
     duration: 8760h # 1 year
     renewBefore: 720h # 30 days
 
-# Namespace configuration
+# Namespace configuration. `create: false` is the default so that the standard
+# `helm install --create-namespace` flow works without a conflict on the
+# chart-rendered Namespace resource. Set `create: true` only if you install
+# without `--create-namespace` and want the chart to render the Namespace.
 namespace:
-  create: true
+  create: false
   name: beskar7-system
 
 # RBAC configuration


### PR DESCRIPTION
## Summary

Two chart bugs surfaced during the first end-to-end Helm install of `v0.4.0-alpha.1`:

1. **Manager crashloop on first install** — the pod's `securityContext` was missing `fsGroup: 65532` and `runAsGroup: 65532`, both present in the equivalent `config/manager/manager.yaml` kustomize spec. The webhook cert Secret mounts at `defaultMode: 0400` (owner-only) to match kustomize. Without `fsGroup`, kubelet leaves the files owned by `root:root`; the non-root container (UID 65532) cannot read `tls.crt`. The webhook server tolerates it (controller-runtime defers TLS load), but the inspection callback server in `controllers/inspection_handler.go` loads the cert eagerly at startup and `mgr.Start` returns `permission denied`, crashlooping the manager.

2. **`helm install --create-namespace` conflicts with the chart's own Namespace template** — every documented install command in `README.md`, `docs/quick-start.md`, and `docs/deployment-best-practices.md` uses `--create-namespace`. With `namespace.create: true` (the previous default), helm pre-creates the namespace and then tries to apply the chart-rendered `kind: Namespace`, producing `Error: INSTALLATION FAILED: namespaces "beskar7-system" already exists`. Flipping the default to `false` makes the documented flow work; operators installing without `--create-namespace` can opt in.

## Changes

`charts/beskar7/values.yaml`:
- `podSecurityContext`: add `runAsUser: 65532`, `runAsGroup: 65532`, `fsGroup: 65532`, `seccompProfile.type: RuntimeDefault` to match `config/manager/manager.yaml`.
- `securityContext`: add `runAsGroup: 65532`.
- `namespace.create`: default flipped from `true` to `false`.

`charts/beskar7/Chart.yaml`:
- `version: 0.4.0-alpha.2`
- `appVersion: "v0.4.0-alpha.2"`

## Test plan

- [x] `helm lint charts/beskar7` passes
- [x] `helm template foo charts/beskar7 --namespace beskar7-system` no longer renders `kind: Namespace`
- [x] Rendered Deployment shows full pod `securityContext` with fsGroup/runAsGroup/seccompProfile
- [x] Manual diagnosis confirmed: live-patching the running v0.4.0-alpha.1 install with the same fsGroup/runAsGroup recovers the crashlooping pod to `1/1 Running`
- [ ] CI green (lint + tests + chart verify)
- [ ] After merge, cut `v0.4.0-alpha.2` tag → release workflow builds image; helm-publish workflow republishes chart pointing at the new image; verify `helm install --devel --create-namespace` works from a clean cluster

## Notes

This is chart-only; no Go code change. The image at `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.1` is unchanged behavior-wise, but cutting `v0.4.0-alpha.2` keeps chart and image versions aligned (helm-publish.yml rewrites `controllerManager.image.tag` from the workflow input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)