### PR TITLE
fix(smoke): auto-derive mock-redfish image tag from controller

### DIFF
--- a/hack/smoke/manifests/10-mock-redfish.yaml
+++ b/hack/smoke/manifests/10-mock-redfish.yaml
@@ -33,9 +33,12 @@ spec:
           type: RuntimeDefault
       containers:
       - name: mock-redfish
-        # Image tag is rewritten by hack/smoke/run.sh from $MOCK_IMAGE.
-        # Default points at the same release as the controller chart.
-        image: ghcr.io/projectbeskar/beskar7/mock-redfish:v0.4.0-alpha.2
+        # Default image. hack/smoke/run.sh auto-derives the tag from the
+        # installed controller (so the mock always matches the chart in use)
+        # and overrides this field on apply. The literal below is only used
+        # when the runner is bypassed (e.g. plain `kubectl apply -f hack/smoke/manifests/`).
+        # Bump it in lockstep with each release as a sane fallback.
+        image: ghcr.io/projectbeskar/beskar7/mock-redfish:v0.4.0-alpha.3
         imagePullPolicy: IfNotPresent
         args:
         - --listen-addr=:8443

--- a/hack/smoke/run.sh
+++ b/hack/smoke/run.sh
@@ -174,18 +174,39 @@ layer_3_reconcile() {
   info "[layer 3] applying mock BMC + PhysicalHost"
   kubectl apply -f "${MANIFEST_DIR}/00-namespace.yaml" >/dev/null
 
-  # Optional MOCK_IMAGE override. When overriding (typically a local
-  # iterative build that reuses a tag) we also force imagePullPolicy=Always
-  # so the kubelet does not serve a stale cached layer.
+  # Resolve the mock image. Priority:
+  #   1. MOCK_IMAGE env var (operator override; forces imagePullPolicy=Always
+  #      because iterative dev usually reuses the same tag).
+  #   2. Auto-derive from the installed controller: same registry path with
+  #      "/beskar7" swapped for "/mock-redfish". This keeps the mock in
+  #      lockstep with the chart, so `make smoke` works against any released
+  #      version without manifest edits.
+  #   3. Fall back to the literal in the manifest (a release-time default
+  #      that lags by one alpha when a fresh tag has just been cut).
+  local controller_img mock_image="" pull_policy=""
   if [[ -n "${MOCK_IMAGE}" ]]; then
-    info "  overriding mock image: ${MOCK_IMAGE}"
-    kubectl apply -f "${MANIFEST_DIR}/10-mock-redfish.yaml" >/dev/null
-    kubectl -n "${SMOKE_NS}" set image deploy/mock-redfish "mock-redfish=${MOCK_IMAGE}" >/dev/null
-    kubectl -n "${SMOKE_NS}" patch deploy mock-redfish --type=json -p='[
-      {"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"Always"}
-    ]' >/dev/null
+    mock_image="${MOCK_IMAGE}"
+    pull_policy="Always"
+    info "  mock image: ${mock_image} (from MOCK_IMAGE)"
   else
-    kubectl apply -f "${MANIFEST_DIR}/10-mock-redfish.yaml" >/dev/null
+    controller_img="$(kubectl -n "${OPERATOR_NS}" get deploy "${OPERATOR_DEPLOY}" \
+      -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+    if [[ "${controller_img}" =~ ^(.+)/beskar7:(.+)$ ]]; then
+      mock_image="${BASH_REMATCH[1]}/mock-redfish:${BASH_REMATCH[2]}"
+      info "  mock image: ${mock_image} (auto-derived from ${OPERATOR_DEPLOY})"
+    else
+      info "  mock image: <manifest default> (could not parse controller image '${controller_img}')"
+    fi
+  fi
+
+  kubectl apply -f "${MANIFEST_DIR}/10-mock-redfish.yaml" >/dev/null
+  if [[ -n "${mock_image}" ]]; then
+    kubectl -n "${SMOKE_NS}" set image deploy/mock-redfish "mock-redfish=${mock_image}" >/dev/null
+  fi
+  if [[ -n "${pull_policy}" ]]; then
+    kubectl -n "${SMOKE_NS}" patch deploy mock-redfish --type=json -p="[
+      {\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/imagePullPolicy\",\"value\":\"${pull_policy}\"}
+    ]" >/dev/null
   fi
 
   kubectl apply -f "${MANIFEST_DIR}/20-bmc-secret.yaml" >/dev/null


### PR DESCRIPTION
## Summary

After cutting v0.4.0-alpha.3 — the first release that publishes the mock-redfish image — running \`make smoke\` against a fresh install fails at layer 3 with \`ImagePullBackOff\`. The smoke manifest hardcoded \`mock-redfish:v0.4.0-alpha.2\`, but that tag never existed: mock-redfish only starts publishing in alpha.3.

## Fix

1. **Bump the manifest literal** from alpha.2 → alpha.3 so plain \`kubectl apply -f hack/smoke/manifests/\` works.
2. **Auto-derive the mock tag in run.sh** from the installed controller image: split \`<registry>/beskar7:<tag>\` and substitute \`beskar7\` → \`mock-redfish\`. Future releases (alpha.4, .5, ...) won't need manifest edits.

The \`MOCK_IMAGE\` env var still overrides for iterative dev, and now forces \`imagePullPolicy=Always\` so reused tags actually re-pull.

## Verification

End-to-end run on virtrigaud against a fresh v0.4.0-alpha.3 install:

\`\`\`
[PASS]  [layer 1] operator running, 4 CRDs present
[PASS]  [layer 2] CRD validation rejects malformed addresses
[INFO]    mock image: ghcr.io/projectbeskar/beskar7/mock-redfish:v0.4.0-alpha.3 (auto-derived from beskar7-controller-manager)
[PASS]  [layer 3] PhysicalHost Ready=true, state=Available
[WARN]  [layer 4] beskar7 CRDs missing CAPI contract-version labels
[PASS]  smoke test PASSED on context virtrigaud
\`\`\`

## Test plan

- [x] \`bash -n hack/smoke/run.sh\` clean
- [x] Live \`make smoke\` against virtrigaud + alpha.3 chart: 3 PASS + 1 WARN
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)