### PR TITLE
feat(api): add CAPI contract-version labels; harden smoke layer 4

### DIFF
--- a/api/v1beta1/beskar7cluster_types.go
+++ b/api/v1beta1/beskar7cluster_types.go
@@ -53,6 +53,8 @@ type Beskar7ClusterStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Beskar7Cluster"
 // +kubebuilder:object:generate=true
 // +kubebuilder:storageversion
+// +kubebuilder:metadata:labels=cluster.x-k8s.io/v1beta1=v1beta1
+// +kubebuilder:metadata:labels=cluster.x-k8s.io/v1beta2=v1beta1
 
 // Beskar7Cluster is the Schema for the beskar7clusters API.
 type Beskar7Cluster struct {

--- a/api/v1beta1/beskar7machine_types.go
+++ b/api/v1beta1/beskar7machine_types.go
@@ -142,6 +142,8 @@ type Beskar7MachineStatus struct {
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Beskar7Machine phase"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Beskar7Machine"
 // +kubebuilder:object:generate=true
+// +kubebuilder:metadata:labels=cluster.x-k8s.io/v1beta1=v1beta1
+// +kubebuilder:metadata:labels=cluster.x-k8s.io/v1beta2=v1beta1
 
 // Beskar7Machine is the Schema for the beskar7machines API.
 type Beskar7Machine struct {

--- a/api/v1beta1/beskar7machinetemplate_types.go
+++ b/api/v1beta1/beskar7machinetemplate_types.go
@@ -36,6 +36,8 @@ type Beskar7MachineTemplateResource struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=beskar7machinetemplates,scope=Namespaced,categories=cluster-api,shortName=b7mt
 // +kubebuilder:storageversion
+// +kubebuilder:metadata:labels=cluster.x-k8s.io/v1beta1=v1beta1
+// +kubebuilder:metadata:labels=cluster.x-k8s.io/v1beta2=v1beta1
 
 // Beskar7MachineTemplate is the Schema for the beskar7machinetemplates API.
 //

--- a/api/v1beta1/physicalhost_types.go
+++ b/api/v1beta1/physicalhost_types.go
@@ -392,6 +392,8 @@ type RedfishConnectionInfo struct {
 // +kubebuilder:printcolumn:name="Ready",type="boolean",JSONPath=".status.ready",description="Indicates if the host is ready"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Creation timestamp"
 // +kubebuilder:storageversion
+// +kubebuilder:metadata:labels=cluster.x-k8s.io/v1beta1=v1beta1
+// +kubebuilder:metadata:labels=cluster.x-k8s.io/v1beta2=v1beta1
 
 // PhysicalHost is the Schema for the physicalhosts API
 type PhysicalHost struct {

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7clusters.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7clusters.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta2: v1beta1
   name: beskar7clusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta2: v1beta1
   name: beskar7machines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta2: v1beta1
   name: beskar7machinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta2: v1beta1
   name: physicalhosts.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7clusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7clusters.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta2: v1beta1
   name: beskar7clusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta2: v1beta1
   name: beskar7machines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta2: v1beta1
   name: beskar7machinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta2: v1beta1
   name: physicalhosts.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -13,7 +13,7 @@ For a CAPI infrastructure provider, smoke testing splits into five layers. The f
 | 1. Static | Chart installs, pod runs, CRDs land, webhook + RBAC objects exist | No |
 | 2. Admission | CRD validation + webhook accept valid CRs and reject invalid ones | No |
 | 3. Reconcile mechanics | Controller talks to a Redfish endpoint, updates Status, surfaces errors | No — fake BMC |
-| 4. CAPI claim | `Beskar7Machine` claims a `PhysicalHost`, sets `ProviderID`, releases on delete | No — fake BMC |
+| 4. CAPI claim | `Beskar7Machine` claims a `PhysicalHost` and the host state machine progresses (Available → InUse/Inspecting) | No — fake BMC |
 | 5. Boot / inspector | iPXE actually boots, inspector posts callback, OS comes up | Yes (or libvirt VMs) |
 
 The rig in `hack/smoke/` covers layers 1–4. Layer 5 belongs in a dedicated CI runner using [sushy-tools](https://opendev.org/openstack/sushy-tools) — it's not in scope here.
@@ -49,7 +49,7 @@ It generates a self-signed RSA cert in memory at startup (configurable via `--tl
 1. Verifies the operator pod is running and the 4 CRDs are installed
 2. Submits a CR with a malformed Redfish address via `kubectl --dry-run=server` and asserts CRD validation rejects it
 3. Applies the mock + a `PhysicalHost`, waits for `Status.Ready=true`
-4. Applies `Beskar7Machine` + CAPI `Machine`, waits for `consumerRef` to be set on the `PhysicalHost` and `ProviderID` to be set on the `Beskar7Machine`
+4. Applies `Beskar7Cluster` + `Beskar7Machine` + CAPI `Machine`. Verifies (a) the controller sets `consumerRef` on the `PhysicalHost` and (b) the host state machine progresses out of `Available` (typically to `InUse`/`Inspecting`). The final `ProviderID` set only happens after the inspection callback completes — that needs the inspector simulator (a separate follow-up); the smoke runner stops at the claim+progression boundary.
 
 Failures print the relevant `describe` output and the tail of the controller log to make root-causing fast.
 
@@ -114,10 +114,6 @@ End-to-end runtime is typically 60–120 seconds, dominated by the initial contr
 The chart bug that shipped in `v0.4.0-alpha.1` — pod `securityContext` missing `fsGroup` and `runAsGroup`, causing the controller to crashloop on `permission denied` when reading its TLS cert — would have been caught at layer 1 (pod never reaches Running). `make smoke` is now a release-gating signal: if it doesn't pass against a freshly installed chart on `kind`, the release isn't shippable.
 
 Layer 3 catches RBAC misconfiguration (controller can't read the BMC `Secret`), CRD-vs-controller drift (controller doesn't know about a field the CRD requires), and TLS / connection regressions (controller can't talk to the BMC at all). Layer 4 catches finalizer leaks, owner-ref mistakes, and `ProviderID` formatting bugs.
-
-## Known limitations
-
-**CAPI v1.10+ contract labels missing on beskar7 CRDs.** When CAPI core runs a conversion webhook on `Cluster` or `Machine`, it reads a `cluster.x-k8s.io/v1beta1` (or `v1beta2`) label off the referenced infrastructure CRD. The beskar7 CRDs do not yet carry that label, so on a CAPI v1.10+ cluster the conversion fails with `cannot find any versions matching contract versions [v1beta2 v1beta1] for CRD beskar7clusters.infrastructure.cluster.x-k8s.io`. The smoke runner detects the missing label up front and skips layer 4 with a `[WARN]` rather than half-applying fixtures. Tracked as a separate fix: add `+kubebuilder:metadata:labels` markers to the `api/v1beta1` types and regenerate manifests + chart CRDs.
 
 ## What this does not catch
 

--- a/hack/smoke/manifests/10-mock-redfish.yaml
+++ b/hack/smoke/manifests/10-mock-redfish.yaml
@@ -33,9 +33,12 @@ spec:
           type: RuntimeDefault
       containers:
       - name: mock-redfish
-        # Image tag is rewritten by hack/smoke/run.sh from $MOCK_IMAGE.
-        # Default points at the same release as the controller chart.
-        image: ghcr.io/projectbeskar/beskar7/mock-redfish:v0.4.0-alpha.2
+        # Default image. hack/smoke/run.sh auto-derives the tag from the
+        # installed controller (so the mock always matches the chart in use)
+        # and overrides this field on apply. The literal below is only used
+        # when the runner is bypassed (e.g. plain `kubectl apply -f hack/smoke/manifests/`).
+        # Bump it in lockstep with each release as a sane fallback.
+        image: ghcr.io/projectbeskar/beskar7/mock-redfish:v0.4.0-alpha.3
         imagePullPolicy: IfNotPresent
         args:
         - --listen-addr=:8443

--- a/hack/smoke/run.sh
+++ b/hack/smoke/run.sh
@@ -174,18 +174,39 @@ layer_3_reconcile() {
   info "[layer 3] applying mock BMC + PhysicalHost"
   kubectl apply -f "${MANIFEST_DIR}/00-namespace.yaml" >/dev/null
 
-  # Optional MOCK_IMAGE override. When overriding (typically a local
-  # iterative build that reuses a tag) we also force imagePullPolicy=Always
-  # so the kubelet does not serve a stale cached layer.
+  # Resolve the mock image. Priority:
+  #   1. MOCK_IMAGE env var (operator override; forces imagePullPolicy=Always
+  #      because iterative dev usually reuses the same tag).
+  #   2. Auto-derive from the installed controller: same registry path with
+  #      "/beskar7" swapped for "/mock-redfish". This keeps the mock in
+  #      lockstep with the chart, so `make smoke` works against any released
+  #      version without manifest edits.
+  #   3. Fall back to the literal in the manifest (a release-time default
+  #      that lags by one alpha when a fresh tag has just been cut).
+  local controller_img mock_image="" pull_policy=""
   if [[ -n "${MOCK_IMAGE}" ]]; then
-    info "  overriding mock image: ${MOCK_IMAGE}"
-    kubectl apply -f "${MANIFEST_DIR}/10-mock-redfish.yaml" >/dev/null
-    kubectl -n "${SMOKE_NS}" set image deploy/mock-redfish "mock-redfish=${MOCK_IMAGE}" >/dev/null
-    kubectl -n "${SMOKE_NS}" patch deploy mock-redfish --type=json -p='[
-      {"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"Always"}
-    ]' >/dev/null
+    mock_image="${MOCK_IMAGE}"
+    pull_policy="Always"
+    info "  mock image: ${mock_image} (from MOCK_IMAGE)"
   else
-    kubectl apply -f "${MANIFEST_DIR}/10-mock-redfish.yaml" >/dev/null
+    controller_img="$(kubectl -n "${OPERATOR_NS}" get deploy "${OPERATOR_DEPLOY}" \
+      -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+    if [[ "${controller_img}" =~ ^(.+)/beskar7:(.+)$ ]]; then
+      mock_image="${BASH_REMATCH[1]}/mock-redfish:${BASH_REMATCH[2]}"
+      info "  mock image: ${mock_image} (auto-derived from ${OPERATOR_DEPLOY})"
+    else
+      info "  mock image: <manifest default> (could not parse controller image '${controller_img}')"
+    fi
+  fi
+
+  kubectl apply -f "${MANIFEST_DIR}/10-mock-redfish.yaml" >/dev/null
+  if [[ -n "${mock_image}" ]]; then
+    kubectl -n "${SMOKE_NS}" set image deploy/mock-redfish "mock-redfish=${mock_image}" >/dev/null
+  fi
+  if [[ -n "${pull_policy}" ]]; then
+    kubectl -n "${SMOKE_NS}" patch deploy mock-redfish --type=json -p="[
+      {\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/imagePullPolicy\",\"value\":\"${pull_policy}\"}
+    ]" >/dev/null
   fi
 
   kubectl apply -f "${MANIFEST_DIR}/20-bmc-secret.yaml" >/dev/null

--- a/hack/smoke/run.sh
+++ b/hack/smoke/run.sh
@@ -98,10 +98,31 @@ teardown() {
     return 0
   fi
   info "tearing down ${SMOKE_NS}"
-  # Drop CRs first so finalizers don't block the namespace delete
+
+  # Drop CRs in dependency order so finalizers can release. Skip if the
+  # namespace is already gone (idempotent re-runs).
+  kubectl get ns "${SMOKE_NS}" >/dev/null 2>&1 || return 0
+
   kubectl delete --ignore-not-found=true -n "${SMOKE_NS}" \
     machine,kubeadmconfig,beskar7machine,beskar7cluster,cluster,physicalhost --all \
     --wait=false >/dev/null 2>&1 || true
+
+  # Give controllers a few seconds to honour finalizers, then force-remove
+  # any remaining finalizers so the namespace can actually finalize. CAPI
+  # Cluster/Machine finalizers cancel cleanly; the beskar7 PhysicalHost
+  # finalizer can hang if the Beskar7Machine claim was never fully released
+  # (smoke test exit between layer 4a and layer 4b would leave this state).
+  # Force-removing is safe for ephemeral smoke fixtures.
+  sleep 5
+  local obj name
+  for obj in machine kubeadmconfig beskar7machine beskar7cluster cluster physicalhost; do
+    while read -r name; do
+      [[ -z "${name}" ]] && continue
+      kubectl -n "${SMOKE_NS}" patch "${name}" --type=merge \
+        -p '{"metadata":{"finalizers":[]}}' >/dev/null 2>&1 || true
+    done < <(kubectl -n "${SMOKE_NS}" get "${obj}" -o name 2>/dev/null || true)
+  done
+
   kubectl delete --ignore-not-found=true namespace "${SMOKE_NS}" --wait=false >/dev/null 2>&1 || true
 }
 
@@ -244,27 +265,6 @@ layer_3_reconcile() {
 # ---------------------------------------------------------------------------
 
 layer_4_claim() {
-  info "[layer 4] checking CAPI conformance labels on beskar7 CRDs"
-  # CAPI v1.10+ runs a conversion webhook on Cluster/Machine that looks up
-  # the contract-version label on the infrastructure CRDs. If the labels
-  # are missing the conversion fails with:
-  #   "cannot find any versions matching contract versions [v1beta2 v1beta1]"
-  # We detect this and skip layer 4 cleanly instead of leaving fixtures
-  # half-applied. Tracked as a follow-up: add
-  # `+kubebuilder:metadata:labels="cluster.x-k8s.io/v1beta1=v1_beta1"`
-  # markers to api/v1beta1 types and regenerate manifests + chart CRDs.
-  local label_v1beta1 label_v1beta2
-  label_v1beta1="$(kubectl get crd beskar7clusters.infrastructure.cluster.x-k8s.io \
-    -o jsonpath='{.metadata.labels.cluster\.x-k8s\.io/v1beta1}' 2>/dev/null || true)"
-  label_v1beta2="$(kubectl get crd beskar7clusters.infrastructure.cluster.x-k8s.io \
-    -o jsonpath='{.metadata.labels.cluster\.x-k8s\.io/v1beta2}' 2>/dev/null || true)"
-  if [[ -z "${label_v1beta1}" && -z "${label_v1beta2}" ]]; then
-    warn "[layer 4] beskar7 CRDs missing CAPI contract-version labels"
-    warn "  CAPI Cluster/Machine conversion will fail; layer 4 cannot run."
-    warn "  Tracked separately. See docs/smoke-testing.md (Known limitations)."
-    return 0
-  fi
-
   info "[layer 4] applying Beskar7Cluster + Beskar7Machine + CAPI Machine"
   kubectl apply -f "${MANIFEST_DIR}/40-cluster-and-machine.yaml" >/dev/null
 
@@ -285,27 +285,44 @@ layer_4_claim() {
   fi
   pass "[layer 4a] PhysicalHost claimed by Beskar7Machine=${consumer}"
 
-  info "  waiting up to ${WAIT_TIMEOUT} for Beskar7Machine.Spec.ProviderID to be set"
+  # Layer 4b: the host progressed out of Available. Without a real inspector
+  # POSTing to the bootstrap callback the state machine parks at "Inspecting"
+  # (the controller's handleReadyHost - which sets ProviderID - only runs
+  # once the host reaches StateReady). So we assert progression, not
+  # ProviderID. Full ProviderID assertion belongs in a future layer that
+  # spins up an inspector-simulator pod.
+  info "  waiting up to ${WAIT_TIMEOUT} for PhysicalHost.Status.State to leave Available"
   local deadline2=$(( $(date +%s) + ${WAIT_TIMEOUT%s} ))
-  local provider=""
+  local state=""
   while [[ "$(date +%s)" -lt "${deadline2}" ]]; do
-    provider="$(kubectl -n "${SMOKE_NS}" get beskar7machine smoke-machine-01 \
-      -o jsonpath='{.spec.providerID}' 2>/dev/null || true)"
-    [[ -n "${provider}" ]] && break
+    state="$(kubectl -n "${SMOKE_NS}" get physicalhost smoke-host-01 \
+      -o jsonpath='{.status.state}' 2>/dev/null || true)"
+    [[ -n "${state}" && "${state}" != "Available" ]] && break
     sleep 3
   done
-  if [[ -z "${provider}" ]]; then
-    fail "[layer 4b] ProviderID was not set within ${WAIT_TIMEOUT}"
-    dim "  --- describe Beskar7Machine ---"
-    kubectl -n "${SMOKE_NS}" describe beskar7machine smoke-machine-01 | tail -40
-    return 1
-  fi
-  pass "[layer 4b] Beskar7Machine ProviderID=${provider}"
-
-  local expected="b7://${SMOKE_NS}/smoke-host-01"
-  if [[ "${provider}" != "${expected}" ]]; then
-    warn "  ProviderID ${provider} != expected ${expected} (may indicate a host-name mismatch)"
-  fi
+  case "${state}" in
+    Inspecting|InUse|Ready)
+      pass "[layer 4b] PhysicalHost progressed to state=${state} (claim drove state machine)"
+      ;;
+    "")
+      fail "[layer 4b] PhysicalHost state empty after ${WAIT_TIMEOUT}"
+      return 1
+      ;;
+    Available)
+      fail "[layer 4b] PhysicalHost stuck in state=Available after claim (controller did not progress)"
+      dim "  --- describe Beskar7Machine ---"
+      kubectl -n "${SMOKE_NS}" describe beskar7machine smoke-machine-01 | tail -30
+      return 1
+      ;;
+    Error)
+      fail "[layer 4b] PhysicalHost transitioned to state=Error"
+      kubectl -n "${SMOKE_NS}" describe physicalhost smoke-host-01 | tail -20
+      return 1
+      ;;
+    *)
+      warn "[layer 4b] PhysicalHost in unexpected state=${state}"
+      ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds the CAPI provider-contract labels to the 4 v1beta1 CRDs so CAPI v1.10+ can convert and reconcile \`Cluster\`/\`Machine\` resources that reference beskar7 infrastructure objects. Without these labels the CAPI conversion webhook fails with:

\`\`\`
cannot find any versions matching contract versions [\"v1beta2\" \"v1beta1\"] for CRD beskar7clusters.infrastructure.cluster.x-k8s.io as contract version label(s) are either missing or empty
\`\`\`

This was the blocker for smoke layer 4 (the \`Beskar7Machine\` claim path was unreachable because CAPI couldn't convert a \`Cluster\` whose \`infrastructureRef.kind=Beskar7Cluster\`).

## Label format

Both CAPI contract versions are mapped to our v1beta1 API:

\`\`\`yaml
labels:
  cluster.x-k8s.io/v1beta1: v1beta1   # for CAPI <v1.10
  cluster.x-k8s.io/v1beta2: v1beta1   # for CAPI >=v1.10 (tries v1beta2 first, falls back to v1beta1)
\`\`\`

Implemented via \`+kubebuilder:metadata:labels\` markers on the four \`Kind\` types:
- \`PhysicalHost\`
- \`Beskar7Cluster\`
- \`Beskar7Machine\`
- \`Beskar7MachineTemplate\`

Regenerated \`config/crd/bases/*\` and synced \`charts/beskar7/crds/*\` via \`make manifests && make sync-chart-crds\`.

## Smoke rig changes that fall out of this

1. **Drop the layer-4 CAPI-label pre-check** in \`hack/smoke/run.sh\`. The labels are now guaranteed by the same PR; no need for the runner to skip on missing labels.

2. **Refine layer 4b assertion**. Previously asserted \`Beskar7Machine.Spec.ProviderID\` is set, but \`ProviderID\` is only set in \`handleReadyHost\`, which requires the \`PhysicalHost\` to reach \`StateReady\` — which requires a real inspection callback. Without an inspector simulator the state machine parks at \`Inspecting\`. New assertion: verify the host state progressed out of \`Available\` (typically to \`InUse\` or \`Inspecting\`). The strict \`ProviderID\` check belongs in a future layer 5 once an inspector-simulator pod is added (separate follow-up).

3. **Harden teardown**. After a 5s grace period for finalizers to run, force-remove any remaining finalizers on smoke fixtures so the namespace can actually finalize. Without this, the runner's exit trap could leave a \`Terminating\` namespace that blocks subsequent \`make smoke\` runs.

4. **Update \`docs/smoke-testing.md\`** to reflect the new layer 4b semantics and drop the CAPI-label known-limitation section.

## Verification

End-to-end on a live cluster (\`virtrigaud\`) against the v0.4.0-alpha.3 chart:

\`\`\`
[PASS]  [layer 1] operator running, 4 CRDs present
[PASS]  [layer 2] CRD validation rejects malformed addresses
[PASS]  [layer 3] PhysicalHost Ready=true, state=Available
[PASS]  [layer 4a] PhysicalHost claimed by Beskar7Machine=smoke-machine-01
[PASS]  [layer 4b] PhysicalHost progressed to state=InUse (claim drove state machine)
[PASS]  smoke test PASSED on context virtrigaud
\`\`\`

Runtime: ~70 seconds. No warnings, no skips.

## Test plan

- [x] \`make manifests && make sync-chart-crds\` clean
- [x] Generated CRDs carry both labels (verified \`kubectl get crd beskar7clusters.infrastructure.cluster.x-k8s.io -o jsonpath='{.metadata.labels}'\`)
- [x] \`go test ./api/... ./controllers/... ./internal/...\` pass
- [x] \`go vet ./...\` clean
- [x] \`go build -tags integration ./test/emulation/...\` clean
- [x] Live cluster: all 4 smoke layers PASS
- [ ] CI green

## Follow-ups (still tracked)

1. **kind-based CI smoke gate** — workflow that spins up kind, installs the just-published chart, runs \`make smoke\` as a release gate. Now possible because the rig is fully self-contained.
2. **Unit tests for \`internal/redfishmock\`** — coverage gap, currently only exercised via test/emulation integration tests.
3. **Inspector-simulator pod** — completes the \`Inspecting → Ready\` transition that layer 4b stops short of, unlocks a future \`ProviderID\` assertion (layer 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)