### PR TITLE
api: drop deprecated PhysicalHost state aliases (BUG-13)

### DIFF
--- a/api/v1beta1/physicalhost_types.go
+++ b/api/v1beta1/physicalhost_types.go
@@ -24,13 +24,6 @@ const (
 	StateReady = "Ready"
 	// StateError indicates the host is in an error state
 	StateError = "Error"
-
-	// Deprecated states - for backward compatibility with old code
-	// These map to new states and should not be used in new code
-	StateClaimed        = "InUse"      // Deprecated: Use StateInUse
-	StateProvisioning   = "Inspecting" // Deprecated: Use StateInspecting
-	StateProvisioned    = "Ready"      // Deprecated: Use StateReady
-	StateDeprovisioning = "Error"      // Deprecated: Handle in controller
 )
 
 // Inspection phases

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -4,7 +4,7 @@
 
 This page describes the lifecycle of a `PhysicalHost` — the states it moves through, what triggers each transition, and how to recover when it gets stuck.
 
-The state constants are defined in `api/v1beta1/physicalhost_types.go:10-26`. The transitions are driven by `controllers/physicalhost_controller.go` and the `Beskar7Machine` reconciler in `controllers/beskar7machine_controller.go`.
+The state constants are defined in `api/v1beta1/physicalhost_types.go`. The transitions are driven by `controllers/physicalhost_controller.go` and the `Beskar7Machine` reconciler in `controllers/beskar7machine_controller.go`.
 
 ## States
 
@@ -19,7 +19,7 @@ The state constants are defined in `api/v1beta1/physicalhost_types.go:10-26`. Th
 | `StateReady` | `"Ready"` | The inspection report has been validated and persisted; the host is ready for the target OS. |
 | `StateError` | `"Error"` | A terminal-or-recoverable error condition. See `Status.ErrorMessage`. |
 
-The legacy `Claimed`, `Provisioning`, `Provisioned`, `Deprovisioning` strings from v0.3 are gone. The Go code retains deprecated aliases (`StateClaimed = "InUse"`, etc.) for backward compatibility, but they all map to the new state strings — do not rely on the old strings appearing in `kubectl get`.
+The legacy `Claimed`, `Provisioning`, `Provisioned`, `Deprovisioning` strings from v0.3 are gone. The Go code previously kept deprecated alias constants (`StateClaimed = "InUse"`, etc.); those aliases have been removed. Code that imported them must switch to the canonical state constants above.
 
 ## State diagram
 


### PR DESCRIPTION
## Summary

Closes **BUG-13** from PROJECT_CONTEXT.md.

`api/v1beta1/physicalhost_types.go` declared four deprecated state constants that aliased to the same underlying string values as the canonical states:

\`\`\`go
StateClaimed        = \"InUse\"      // Deprecated: Use StateInUse
StateProvisioning   = \"Inspecting\" // Deprecated: Use StateInspecting
StateProvisioned    = \"Ready\"      // Deprecated: Use StateReady
StateDeprovisioning = \"Error\"      // Deprecated: Handle in controller
\`\`\`

Because each alias equals its canonical constant's string value, any \`switch\` statement that cased on the deprecated names compiled but never matched at runtime — \`vet\` doesn't flag duplicate case labels when they're named constants with the same value. This was a footgun for anyone who imported them.

## What changed

- Removed the deprecated alias block from \`api/v1beta1/physicalhost_types.go\`.
- Updated \`docs/state-management.md\` (line 22) to note the aliases have been removed; the row table and state diagram are unchanged.
- No CRD schema impact (these constants don't appear in the generated schema). \`make manifests\` produces no diff under \`config/crd/bases/\` or \`charts/beskar7/crds/\`.

## Caller audit

Verified via \`grep -rn 'StateClaimed|StateProvisioning|StateProvisioned|StateDeprovisioning' --include='*.go'\`:
- Zero callers in \`controllers/\`, \`internal/\`, \`cmd/\`, \`api/v1beta1/webhooks/\`.
- The string literal \`phase := \"Provisioned\"\` at \`controllers/beskar7machine_controller.go:688\` is a different field (\`Beskar7Machine.Status.Phase\`, not \`PhysicalHost.Status.State\`) — not affected.
- One test comment in \`controllers/beskar7machine_controller_test.go:267\` explicitly notes \"the removed StateProvisioned constant\" from an earlier cleanup pass — comment retained.

## Behavioural impact

None at runtime. Compile-time break only for any external code that imported the deprecated constants. Acceptable in alpha → alpha.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./controllers/... ./internal/... ./api/...\` all pass
- [x] \`make manifests\` produces no CRD diff
- [x] grep for callers across the tree returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)