### PR TITLE
metrics: drop unused errorType param from RecordPowerOperation (BUG-12)

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -411,10 +411,13 @@ func RecordNetworkAddress(namespace string, outcome ProvisioningOutcome, errorTy
 // operation type. Previously the helper hardcoded PowerOperationOn so every
 // call landed on the "On" label regardless of intent — by-design dead today
 // (no external callers) but actively wrong if the helper were ever wired up.
-// errorType is currently unused; retained on the signature for API parity
-// with the other Record* helpers and for a future error-type label.
-func RecordPowerOperation(operation PowerOperation, namespace string, outcome ProvisioningOutcome, errorType ErrorType) {
-	_ = errorType
+//
+// Error-type cardinality is deliberately not modelled on this counter:
+// power-operation failures are observed against the connection/Redfish-query
+// counters (RecordRedfishConnection, RecordRedfishQuery) which already carry
+// the ErrorType label. Keeping it off this counter avoids double-counting
+// the same failure across two label spaces when a future caller is wired.
+func RecordPowerOperation(operation PowerOperation, namespace string, outcome ProvisioningOutcome) {
 	RecordPhysicalHostPowerOperation(operation, namespace, outcome)
 }
 


### PR DESCRIPTION
## Summary

Closes **BUG-12** from PROJECT_CONTEXT.md.

`RecordPowerOperation` declared an `errorType` parameter that was immediately discarded:

\`\`\`go
func RecordPowerOperation(operation PowerOperation, namespace string, outcome ProvisioningOutcome, errorType ErrorType) {
    _ = errorType
    RecordPhysicalHostPowerOperation(operation, namespace, outcome)
}
\`\`\`

The function has **zero callers in-tree** (and the inner `RecordPhysicalHostPowerOperation` also has zero callers — they're both part of the dead-helper surface I'm tracking separately as BUG-15 in PROJECT_CONTEXT.md), so removing the parameter from the signature is safe.

## Decision

**Remove the parameter rather than wire it through.** Error-type cardinality is already modelled on the Redfish-connection and Redfish-query counters (\`RecordRedfishConnection\`, \`RecordRedfishQuery\`), which carry the \`ErrorType\` label. Adding it to \`PhysicalHostPowerOperationsTotal\` would double-count the same failure across two label spaces when a future caller is wired — both metrics would land in the failure bucket with overlapping attribution.

The function comment is updated to document this design choice so the next person who looks at it doesn't re-add the parameter \"for parity.\"

## What changed

- \`internal/metrics/metrics.go\`: removed \`errorType ErrorType\` from the signature; removed the \`_ = errorType\` line; expanded the comment to explain why error-type cardinality lives on the connection/query counters and not on this one.

## No doc impact

\`docs/metrics.md\` describes the Prometheus surface (metric names + labels exposed on \`:8443\`), not internal helper function signatures. The metric label set on \`PhysicalHostPowerOperationsTotal\` is unchanged.

## Larger context (new BUG-15 in PROJECT_CONTEXT.md)

While verifying \"zero callers\" for BUG-12, I discovered that **19 of 23 \`Record*\` helpers in \`internal/metrics/metrics.go\` have zero callers outside the metrics package.** The Prometheus surface in \`docs/metrics.md\` is largely aspirational — most registered counters/histograms would always be zero in a running deployment. This is now tracked as BUG-15 (separate PR; a per-helper wire-or-delete audit).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race ./internal/metrics/... ./controllers/...\` pass
- [x] No callers in-tree (verified via grep across all .go files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)