### PR TITLE
controllers: exponential backoff on PhysicalHost reconcile failures (BUG-14)

### DIFF
--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -31,11 +31,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -163,9 +165,11 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 		conditions.MarkFalse(physicalHost, infrastructurev1beta1.RedfishConnectionReadyCondition,
 			infrastructurev1beta1.MissingCredentialsReason, clusterv1.ConditionSeverityError,
 			"Failed to retrieve credentials: %v", err)
-		// The deferred patch will persist the error status; return the error so the
-		// caller can decide whether to requeue.
-		return ctrl.Result{RequeueAfter: 1 * time.Minute}, err
+		// Return the error without an explicit RequeueAfter so the workqueue's
+		// exponential rate-limiter (configured in SetupWithManager) governs the
+		// retry interval. A fixed 1-minute requeue would override the rate-limiter
+		// and ping a persistently-misconfigured host every 60s indefinitely.
+		return ctrl.Result{}, err
 	}
 
 	// Determine insecure setting
@@ -196,7 +200,8 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 		conditions.MarkFalse(physicalHost, infrastructurev1beta1.RedfishConnectionReadyCondition,
 			infrastructurev1beta1.CABundleFetchFailedReason, clusterv1.ConditionSeverityError,
 			"%s", err.Error())
-		return ctrl.Result{RequeueAfter: 1 * time.Minute}, err
+		// Workqueue exponential backoff via SetupWithManager handles the retry cadence.
+		return ctrl.Result{}, err
 	}
 
 	// Create Redfish client
@@ -213,7 +218,8 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 		conditions.MarkFalse(physicalHost, infrastructurev1beta1.RedfishConnectionReadyCondition,
 			infrastructurev1beta1.RedfishConnectionFailedReason, clusterv1.ConditionSeverityError,
 			"Connection failed: %v", err)
-		return ctrl.Result{RequeueAfter: 1 * time.Minute}, err
+		// Workqueue exponential backoff via SetupWithManager handles the retry cadence.
+		return ctrl.Result{}, err
 	}
 	defer rfClient.Close(ctx)
 
@@ -225,7 +231,8 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 		conditions.MarkFalse(physicalHost, infrastructurev1beta1.RedfishConnectionReadyCondition,
 			infrastructurev1beta1.RedfishQueryFailedReason, clusterv1.ConditionSeverityError,
 			"Query failed: %v", err)
-		return ctrl.Result{RequeueAfter: 1 * time.Minute}, err
+		// Workqueue exponential backoff via SetupWithManager handles the retry cadence.
+		return ctrl.Result{}, err
 	}
 
 	// Update hardware details
@@ -560,6 +567,18 @@ func (r *PhysicalHostReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.SecretToPhysicalHosts),
 		).
+		WithOptions(controller.Options{
+			// Exponential backoff for transient Redfish failures. The previous
+			// fixed RequeueAfter: 1*time.Minute on every error path meant a
+			// persistently-misconfigured BMC was pinged every 60s forever; now
+			// a failing host backs off geometrically (5s, 10s, 20s, ... capped
+			// at 30m) so a wrong address / wrong creds / unreachable BMC settles
+			// into a low-frequency check instead of a hot loop.
+			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](
+				5*time.Second,
+				30*time.Minute,
+			),
+		}).
 		Complete(r)
 }
 

--- a/controllers/physicalhost_controller_test.go
+++ b/controllers/physicalhost_controller_test.go
@@ -327,9 +327,17 @@ var _ = Describe("PhysicalHost Controller", func() {
 			_, err := failedReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: phLookupKey})
 			Expect(err).NotTo(HaveOccurred()) // First reconcile adds finalizer
 
-			_, err = failedReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: phLookupKey})
+			result, err := failedReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: phLookupKey})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("connection timeout"))
+
+			By("Asserting error paths defer requeue cadence to the workqueue rate-limiter (BUG-14)")
+			// The error returned alongside Result{} signals controller-runtime to
+			// requeue via the configured exponential rate-limiter (set in
+			// SetupWithManager). An explicit RequeueAfter here would override the
+			// rate-limiter and pin a misconfigured BMC to a fixed 60s ping forever.
+			Expect(result.RequeueAfter).To(BeZero(), "Redfish-connection-failure path must not set RequeueAfter; the workqueue rate-limiter governs the retry cadence")
+			Expect(result.Requeue).To(BeFalse(), "Redfish-connection-failure path must not set Requeue=true; the error return already triggers a rate-limited requeue")
 
 			By("Checking error conditions")
 			Eventually(func(g Gomega) {


### PR DESCRIPTION
## Summary

Closes **BUG-14** from PROJECT_CONTEXT.md.

Four error paths in \`PhysicalHostReconciler.reconcileNormal\` (missing credentials, CA-bundle fetch failure, Redfish connect failure, Redfish query failure) previously returned:

\`\`\`go
return ctrl.Result{RequeueAfter: 1 * time.Minute}, err
\`\`\`

The explicit \`RequeueAfter\` overrides controller-runtime's workqueue rate-limiter, so a persistently-misconfigured BMC (wrong address, wrong creds, unreachable) was pinged every 60s indefinitely. \`docs/troubleshooting.md:601\` already claimed \"exponential backoff for Redfish connection failures\" — the doc was right, the code wasn't.

## What changed

- Configured the workqueue with an exponential rate-limiter in \`SetupWithManager\`:
  \`\`\`go
  WithOptions(controller.Options{
      RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](
          5*time.Second,
          30*time.Minute,
      ),
  })
  \`\`\`
- Changed the four affected error paths from \`Result{RequeueAfter: 1*time.Minute}, err\` to \`Result{}, err\`. controller-runtime treats the error return as a rate-limited requeue, which now grows 5s → 10s → 20s → ... capped at 30m.
- Extended the \"Should handle Redfish connection failure\" envtest to assert \`result.RequeueAfter == 0\` and \`result.Requeue == false\` on the failure path, so a regression to fixed-interval requeue is caught.

## What's intentionally kept

Two \`RequeueAfter\` sites in the same file were deliberately preserved:

- **Line 188** (`Result{RequeueAfter: 5 * time.Minute}, nil`): the \`InsecureSkipVerify=true + CABundleSecretRef\` terminal-gate. A misconfigured spec is not a workqueue-retryable error; the long fixed cadence gives the operator time to fix the spec without hot-looping.
- **Line 309** (`Result{RequeueAfter: 5 * time.Minute}, nil`): the bottom of the successful reconcile path — periodic resync, not error backoff.

The existing envtest at \`controllers/physicalhost_controller_test.go:377\` (\"conflict should set a long RequeueAfter\") guards the line-188 invariant.

## Behavioural impact

| Failure mode | Before | After |
|---|---|---|
| BMC unreachable | retry every 60s forever | 5s, 10s, 20s, 40s, 80s, ..., capped at 30m |
| Wrong credentials | retry every 60s forever | same exponential schedule |
| Transient TCP blip | retry in 60s | retry in 5s (fast recovery) |
| Successful reconcile | resync every 5min | resync every 5min (unchanged) |
| TLS misconfig | retry every 5min | retry every 5min (unchanged) |

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] Envtest suite (\`TestAPIs\`) passes — 16.2s including the new RequeueAfter assertion
- [x] No doc change needed — \`docs/troubleshooting.md\` already advertised this behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)