### PR TITLE
metrics: drop broken/redundant Record* helpers + dead metric vars (BUG-15 PR A)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,6 +17,14 @@ The metrics provide insights into:
 - Boot configuration success rates
 - Failure domain discovery
 
+> **Wiring status (v0.4.0-alpha.4 → next):** the controllers currently emit the
+> reconciliation, error, and failure-domain metrics below. The rest (state
+> gauges, power-operation counter, Redfish-connection counter, availability
+> ratio, host-claim attempt/duration, machine provisioning histogram) are
+> registered but always read zero until the BUG-15 wire-up PR lands. If you
+> build dashboards today, gate them on samples present so empty series don't
+> look like outages.
+
 ## Metric Categories
 
 ### Controller Performance Metrics
@@ -52,11 +60,6 @@ These metrics track the overall performance and health of the Beskar7 controller
 - `timeout` - Operation timeout errors
 - `unknown` - Unclassified errors
 
-#### `beskar7_controller_requeue_total`
-**Type:** Counter  
-**Labels:** `controller`, `reason`, `namespace`  
-**Description:** Total number of reconciliation requeues by reason.
-
 ### PhysicalHost Metrics
 
 These metrics track the state and health of physical hosts managed by Beskar7.
@@ -74,11 +77,6 @@ These metrics track the state and health of physical hosts managed by Beskar7.
 - `Error`
 - `Enrolling`
 - `Unknown`
-
-#### `beskar7_controller_physicalhost_provisioning_total`
-**Type:** Counter  
-**Labels:** `outcome`, `namespace`, `error_type`  
-**Description:** Total number of PhysicalHost provisioning attempts.
 
 #### `beskar7_controller_physicalhost_power_operations_total`
 **Type:** Counter  
@@ -100,11 +98,6 @@ These metrics track the state and health of physical hosts managed by Beskar7.
 **Labels:** `namespace`  
 **Description:** Availability ratio of PhysicalHosts (available/total).
 
-#### `beskar7_controller_physicalhost_consumer_mappings_total`
-**Type:** Gauge  
-**Labels:** `consumer_type`, `namespace`  
-**Description:** Number of PhysicalHosts mapped to consumers.
-
 ### Beskar7Machine Metrics
 
 These metrics track machine provisioning and lifecycle management.
@@ -120,11 +113,6 @@ These metrics track machine provisioning and lifecycle management.
 **Description:** Time taken to provision a Beskar7Machine from creation to ready.
 
 **Buckets:** 30s, 60s, 2m, 5m, 10m, 20m, 30m, 1h
-
-#### `beskar7_controller_beskar7machine_boot_configurations_total`
-**Type:** Counter  
-**Labels:** `mode`, `os_family`, `outcome`, `namespace`  
-**Description:** Total number of boot configuration attempts.
 
 ### Beskar7Cluster Metrics
 
@@ -246,14 +234,11 @@ Create dashboards to visualize:
   for: 10m
   annotations:
     summary: "Slow machine provisioning times"
-
-# High requeue rate
-- alert: Beskar7HighRequeueRate
-  expr: rate(beskar7_controller_requeue_total[5m]) > 0.5
-  for: 5m
-  annotations:
-    summary: "High reconciliation requeue rate"
 ```
+
+> The controller-runtime workqueue already exports requeue and workqueue-depth metrics
+> (`workqueue_*`, `controller_runtime_reconcile_total{result="requeue"}`); alert on those
+> rather than a Beskar7-specific requeue counter.
 
 ## Troubleshooting with Metrics
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -41,16 +41,6 @@ var (
 		[]string{"state", "namespace"},
 	)
 
-	PhysicalHostProvisioningTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: MetricNamespace,
-			Subsystem: MetricSubsystem,
-			Name:      "physicalhost_provisioning_total",
-			Help:      "Total number of PhysicalHost provisioning attempts",
-		},
-		[]string{"outcome", "namespace", "error_type"},
-	)
-
 	PhysicalHostPowerOperationsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: MetricNamespace,
@@ -91,16 +81,6 @@ var (
 			Buckets:   []float64{30, 60, 120, 300, 600, 1200, 1800, 3600}, // 30s to 1h
 		},
 		[]string{"outcome", "namespace"},
-	)
-
-	Beskar7MachineBootConfigurationsTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: MetricNamespace,
-			Subsystem: MetricSubsystem,
-			Name:      "beskar7machine_boot_configurations_total",
-			Help:      "Total number of boot configuration attempts",
-		},
-		[]string{"mode", "os_family", "outcome", "namespace"},
 	)
 
 	// Beskar7Cluster metrics
@@ -166,16 +146,6 @@ var (
 		[]string{"controller", "error_type", "namespace"},
 	)
 
-	ControllerRequeueTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: MetricNamespace,
-			Subsystem: MetricSubsystem,
-			Name:      "requeue_total",
-			Help:      "Total number of reconciliation requeues",
-		},
-		[]string{"controller", "reason", "namespace"},
-	)
-
 	// Resource availability metrics
 	PhysicalHostAvailabilityGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -185,16 +155,6 @@ var (
 			Help:      "Availability ratio of PhysicalHosts (available/total)",
 		},
 		[]string{"namespace"},
-	)
-
-	PhysicalHostConsumerMappingsGauge = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: MetricNamespace,
-			Subsystem: MetricSubsystem,
-			Name:      "physicalhost_consumer_mappings_total",
-			Help:      "Number of PhysicalHosts mapped to consumers",
-		},
-		[]string{"consumer_type", "namespace"},
 	)
 
 	// Concurrent provisioning metrics
@@ -230,17 +190,12 @@ const (
 type ErrorType string
 
 const (
-	ErrorTypeTransient    ErrorType = "transient"
-	ErrorTypePermanent    ErrorType = "permanent"
-	ErrorTypeValidation   ErrorType = "validation"
-	ErrorTypeConnection   ErrorType = "connection"
-	ErrorTypeTimeout      ErrorType = "timeout"
-	ErrorTypeQuery        ErrorType = "query"
-	ErrorTypeAddress      ErrorType = "address"
-	ErrorTypePower        ErrorType = "power"
-	ErrorTypeBoot         ErrorType = "boot"
-	ErrorTypeVirtualMedia ErrorType = "virtual_media"
-	ErrorTypeUnknown      ErrorType = "unknown"
+	ErrorTypeTransient  ErrorType = "transient"
+	ErrorTypePermanent  ErrorType = "permanent"
+	ErrorTypeValidation ErrorType = "validation"
+	ErrorTypeConnection ErrorType = "connection"
+	ErrorTypeTimeout    ErrorType = "timeout"
+	ErrorTypeUnknown    ErrorType = "unknown"
 )
 
 // ProvisioningOutcome represents the result of a provisioning operation
@@ -266,14 +221,12 @@ func Init() {
 	metrics.Registry.MustRegister(
 		// PhysicalHost metrics
 		PhysicalHostStatesGauge,
-		PhysicalHostProvisioningTotal,
 		PhysicalHostPowerOperationsTotal,
 		PhysicalHostRedfishConnectionsTotal,
 
 		// Beskar7Machine metrics
 		Beskar7MachineStatesGauge,
 		Beskar7MachineProvisioningDuration,
-		Beskar7MachineBootConfigurationsTotal,
 
 		// Beskar7Cluster metrics
 		Beskar7ClusterStatesGauge,
@@ -284,12 +237,11 @@ func Init() {
 		ControllerReconciliationDuration,
 		ControllerReconciliationTotal,
 		ControllerErrorsTotal,
-		ControllerRequeueTotal,
 
 		// Resource availability metrics
 		PhysicalHostAvailabilityGauge,
-		PhysicalHostConsumerMappingsGauge,
-		// Register new concurrent provisioning metrics
+
+		// Concurrent provisioning metrics
 		hostClaimAttempts,
 		hostClaimDuration,
 	)
@@ -306,23 +258,9 @@ func RecordError(controller string, namespace string, errorType ErrorType) {
 	ControllerErrorsTotal.WithLabelValues(controller, string(errorType), namespace).Inc()
 }
 
-// RecordRequeue records a requeue metric
-func RecordRequeue(controller string, namespace string, reason string) {
-	ControllerRequeueTotal.WithLabelValues(controller, reason, namespace).Inc()
-}
-
 // RecordPhysicalHostState updates the PhysicalHost state gauge
 func RecordPhysicalHostState(state string, namespace string, delta float64) {
 	PhysicalHostStatesGauge.WithLabelValues(state, namespace).Add(delta)
-}
-
-// RecordPhysicalHostProvisioning records a provisioning attempt
-func RecordPhysicalHostProvisioning(namespace string, outcome ProvisioningOutcome, errorType ErrorType) {
-	errorTypeStr := ""
-	if outcome == ProvisioningOutcomeFailed {
-		errorTypeStr = string(errorType)
-	}
-	PhysicalHostProvisioningTotal.WithLabelValues(string(outcome), namespace, errorTypeStr).Inc()
 }
 
 // RecordPhysicalHostPowerOperation records a power operation
@@ -347,11 +285,6 @@ func RecordBeskar7MachineState(phase string, namespace string, delta float64) {
 // RecordBeskar7MachineProvisioning records provisioning duration and outcome
 func RecordBeskar7MachineProvisioning(namespace string, outcome ProvisioningOutcome, duration time.Duration) {
 	Beskar7MachineProvisioningDuration.WithLabelValues(string(outcome), namespace).Observe(duration.Seconds())
-}
-
-// RecordBootConfiguration records a boot configuration attempt
-func RecordBootConfiguration(mode string, osFamily string, namespace string, outcome ProvisioningOutcome) {
-	Beskar7MachineBootConfigurationsTotal.WithLabelValues(mode, osFamily, string(outcome), namespace).Inc()
 }
 
 // RecordBeskar7ClusterState updates the Beskar7Cluster readiness state
@@ -380,70 +313,6 @@ func UpdatePhysicalHostAvailability(namespace string, availableCount, totalCount
 		ratio = float64(availableCount) / float64(totalCount)
 	}
 	PhysicalHostAvailabilityGauge.WithLabelValues(namespace).Set(ratio)
-}
-
-// RecordPhysicalHostConsumerMapping records a consumer mapping
-func RecordPhysicalHostConsumerMapping(consumerType string, namespace string, delta float64) {
-	PhysicalHostConsumerMappingsGauge.WithLabelValues(consumerType, namespace).Add(delta)
-}
-
-// RecordRedfishQuery records a Redfish query operation
-func RecordRedfishQuery(namespace string, outcome ProvisioningOutcome, errorType ErrorType) {
-	errorTypeStr := ""
-	if outcome == ProvisioningOutcomeFailed {
-		errorTypeStr = string(errorType)
-	}
-	PhysicalHostRedfishConnectionsTotal.WithLabelValues(string(outcome), namespace, errorTypeStr).Inc()
-}
-
-// RecordNetworkAddress records a network address detection operation
-func RecordNetworkAddress(namespace string, outcome ProvisioningOutcome, errorType ErrorType) {
-	errorTypeStr := ""
-	if outcome == ProvisioningOutcomeFailed {
-		errorTypeStr = string(errorType)
-	}
-	// Use the same counter as provisioning for now, could be separate if needed
-	PhysicalHostProvisioningTotal.WithLabelValues(string(outcome), namespace, errorTypeStr).Inc()
-}
-
-// RecordPowerOperation records a power operation against the
-// PhysicalHostPowerOperationsTotal counter, parameterised by the actual
-// operation type. Previously the helper hardcoded PowerOperationOn so every
-// call landed on the "On" label regardless of intent — by-design dead today
-// (no external callers) but actively wrong if the helper were ever wired up.
-//
-// Error-type cardinality is deliberately not modelled on this counter:
-// power-operation failures are observed against the connection/Redfish-query
-// counters (RecordRedfishConnection, RecordRedfishQuery) which already carry
-// the ErrorType label. Keeping it off this counter avoids double-counting
-// the same failure across two label spaces when a future caller is wired.
-func RecordPowerOperation(operation PowerOperation, namespace string, outcome ProvisioningOutcome) {
-	RecordPhysicalHostPowerOperation(operation, namespace, outcome)
-}
-
-// RecordVirtualMediaOperation records a virtual media operation
-func RecordVirtualMediaOperation(namespace string, outcome ProvisioningOutcome, errorType ErrorType) {
-	errorTypeStr := ""
-	if outcome == ProvisioningOutcomeFailed {
-		errorTypeStr = string(errorType)
-	}
-	PhysicalHostProvisioningTotal.WithLabelValues(string(outcome), namespace, errorTypeStr).Inc()
-}
-
-// RecordBootOperation records a boot configuration operation
-func RecordBootOperation(namespace string, outcome ProvisioningOutcome, errorType ErrorType) {
-	mode := "iso"         // Default mode
-	osFamily := "unknown" // Default OS family
-	RecordBootConfiguration(mode, osFamily, namespace, outcome)
-}
-
-// RecordDeprovisioningOperation records a deprovisioning operation
-func RecordDeprovisioningOperation(namespace string, outcome ProvisioningOutcome, errorType ErrorType) {
-	errorTypeStr := ""
-	if outcome == ProvisioningOutcomeFailed {
-		errorTypeStr = string(errorType)
-	}
-	PhysicalHostProvisioningTotal.WithLabelValues(string(outcome), namespace, errorTypeStr).Inc()
 }
 
 // ClaimOutcome represents the outcome of a host claim attempt

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -88,35 +88,6 @@ func TestRecordPhysicalHostState(t *testing.T) {
 	}
 }
 
-func TestRecordPhysicalHostProvisioning(t *testing.T) {
-	// Record successful provisioning
-	RecordPhysicalHostProvisioning("test-namespace", ProvisioningOutcomeSuccess, "")
-
-	// Record failed provisioning
-	RecordPhysicalHostProvisioning("test-namespace", ProvisioningOutcomeFailed, ErrorTypeConnection)
-
-	// Verify counters
-	successCounter := PhysicalHostProvisioningTotal.WithLabelValues("success", "test-namespace", "")
-	failureCounter := PhysicalHostProvisioningTotal.WithLabelValues("failed", "test-namespace", "connection")
-
-	successMetric := &dto.Metric{}
-	failureMetric := &dto.Metric{}
-
-	if err := successCounter.Write(successMetric); err != nil {
-		t.Fatalf("Failed to write success metric: %v", err)
-	}
-	if err := failureCounter.Write(failureMetric); err != nil {
-		t.Fatalf("Failed to write failure metric: %v", err)
-	}
-
-	if successMetric.GetCounter().GetValue() != 1 {
-		t.Errorf("Expected success counter to be 1, got %v", successMetric.GetCounter().GetValue())
-	}
-	if failureMetric.GetCounter().GetValue() != 1 {
-		t.Errorf("Expected failure counter to be 1, got %v", failureMetric.GetCounter().GetValue())
-	}
-}
-
 func TestUpdatePhysicalHostAvailability(t *testing.T) {
 	// Test availability calculation
 	UpdatePhysicalHostAvailability("test-namespace", 3, 10)


### PR DESCRIPTION
## Summary

Closes the first half of **BUG-15** from PROJECT_CONTEXT.md.

Audit context: of the 23 \`Record*\` helpers in \`internal/metrics/metrics.go\`, only 4 had callers outside the metrics package. The audit (see PROJECT_CONTEXT.md for the full per-helper table) split the remaining 19 into three categories:

- **Wire in PR B (10 helpers):** Operationally valuable observability — backs alerts and dashboards. Will be instrumented at the right controller call sites in a follow-up PR.
- **Delete (this PR — 10 helpers):** Broken (wrong counter / v0.3-leftover features / degenerate labels) or duplicates of controller-runtime built-ins.

This PR is the **delete half**. Net diff: −195 / +20.

## Deleted helpers (10)

### Broken / wrong counter / v0.3 leftover (7)

| Helper | Why delete |
|---|---|
| \`RecordRedfishQuery\` | Writes to the same counter as \`RecordRedfishConnection\` — alias/duplicate. Keeping \`RecordRedfishConnection\`. |
| \`RecordNetworkAddress\` | Writes to \`PhysicalHostProvisioningTotal\` despite the name. Wrong counter. |
| \`RecordVirtualMediaOperation\` | Virtual media is not a Beskar7 feature — we use iPXE. v0.3 leftover. |
| \`RecordBootOperation\` | Calls \`RecordBootConfiguration\` with hardcoded \`\"iso\"\`/\`\"unknown\"\` defaults. v0.3 mode/os_family concept. |
| \`RecordBootConfiguration\` | Same v0.3 label dimensionality (\`mode\`/\`os_family\` are pre-v0.4 concepts). |
| \`RecordDeprovisioningOperation\` | No \"deprovisioning\" phase in v0.4. Writes to wrong counter (provisioning). |
| \`RecordPhysicalHostConsumerMapping\` | Only one consumer kind exists (\`Beskar7Machine\`); the \`consumer_type\` label is degenerate. |

### Redundant / duplicates built-in (3)

| Helper | Why delete |
|---|---|
| \`RecordRequeue\` | controller-runtime already exports \`workqueue_*\` + \`controller_runtime_reconcile_total{result=\"requeue\"}\`. Duplicates a built-in. |
| \`RecordPhysicalHostProvisioning\` | Overlaps with the kept \`Beskar7MachineProvisioningDuration\` — per-host AND per-machine counters of the same event is noise. |
| \`RecordPowerOperation\` | Wrapper of \`RecordPhysicalHostPowerOperation\` (kept). PR B will wire \`RecordPhysicalHostPowerOperation\` directly. |

## Deleted metric variables (4)

Only referenced by deleted helpers:

- \`ControllerRequeueTotal\`
- \`PhysicalHostProvisioningTotal\`
- \`Beskar7MachineBootConfigurationsTotal\`
- \`PhysicalHostConsumerMappingsGauge\`

## Deleted ErrorType enum values (5)

Only referenced by deleted helpers:

- \`ErrorTypeQuery\`, \`ErrorTypeAddress\`, \`ErrorTypePower\`, \`ErrorTypeBoot\`, \`ErrorTypeVirtualMedia\`

## Kept (no change in this PR)

The 13 helpers PR B will wire (or keep wired):

- Already wired today: \`RecordReconciliation\`, \`RecordError\`, \`RecordFailureDomains\`, \`RecordFailureDomainDiscovery\`
- Wire in PR B: \`RecordPhysicalHostState\`, \`RecordPhysicalHostPowerOperation\`, \`RecordRedfishConnection\`, \`RecordBeskar7MachineState\`, \`RecordBeskar7MachineProvisioning\`, \`RecordBeskar7ClusterState\`, \`UpdatePhysicalHostAvailability\`, \`RecordHostClaimAttempt\`, \`RecordHostClaimDuration\`

## Doc updates

- \`docs/metrics.md\` drops the four deleted metric sections.
- Replaces the deleted \`Beskar7HighRequeueRate\` alert with a one-line pointer to controller-runtime's built-in workqueue metrics.
- Adds a \"wiring status\" disclaimer at the top so operators building dashboards before PR B lands know which metrics currently read zero.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race\` clean across \`internal/metrics\`, \`internal/auth\`, \`internal/redfish\`, \`internal/redfishmock\`, \`controllers\`, \`api/v1beta1/webhooks\`
- [x] One test removed (\`TestRecordPhysicalHostProvisioning\`) — helper deleted; no replacement needed
- [x] No regressions in the kept 13 helpers

## Follow-up

**BUG-15 PR B** (tracked in PROJECT_CONTEXT.md): wire the 10 kept-but-unwired helpers at the right controller call sites; extend \`RecordError\` to fire from all 3 controllers instead of just \`Beskar7ClusterReconciler\`. New tests for the wiring. Expected to be a larger PR than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)