### PR TITLE
build: add make lint target pinning golangci-lint to CI version (LINT-1)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,12 @@
-# Basic golangci-lint configuration for clean builds
+# golangci-lint v1 configuration. CI pins golangci-lint to v1.64.8
+# (.github/workflows/ci.yml). Run `make lint` locally — it installs the same
+# binary into $GOBIN so the config schema matches. A system-installed v2
+# binary will reject this file with "unsupported version of the configuration"
+# because v2 requires a top-level `version:` key and renamed sections; v1 does
+# not.
 run:
   timeout: 5m
   tests: true
-  skip-dirs:
-    - vendor
 
 linters:
   enable:
@@ -16,6 +19,8 @@ linters:
     - unused
 
 issues:
+  exclude-dirs:
+    - vendor
   exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,19 @@ CONTROLLER_GEN_VERSION ?= v0.21.0
 install-controller-gen:
 	$(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION)
 
+# Install golangci-lint pinned to the version CI uses. .golangci.yml targets
+# v1 schema; installing a v2 binary will reject the config. Use this target
+# instead of `go install` so local lint matches CI.
+GOLANGCI_LINT = $(GOBIN)/golangci-lint
+GOLANGCI_LINT_VERSION ?= v1.64.8
+install-golangci-lint:
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+# Run linters. Pins to the CI version via install-golangci-lint so a system-
+# installed v2 binary doesn't reject .golangci.yml's v1 syntax.
+lint: install-golangci-lint
+	$(GOLANGCI_LINT) run --timeout=5m
+
 # Generate manifests e.g. CRDs, RBAC, and DeepCopy objects
 manifests: install-controller-gen
 	$(CONTROLLER_GEN) object:headerFile="./hack/boilerplate.go.txt" paths="./..."
@@ -156,4 +169,4 @@ release-manifests:
 	git checkout config/overlays/ 2>/dev/null || true
 	@echo "Release manifests generated: beskar7-manifests-$(VERSION).yaml"
 
-.PHONY: build build-mock-redfish build-mock-inspector generate manifests test docker-build docker-build-mock-redfish docker-build-mock-inspector docker-push deploy install-controller-gen install uninstall undeploy rbac crd release-manifests sync-chart-crds manifests-and-sync smoke smoke-teardown
+.PHONY: build build-mock-redfish build-mock-inspector generate manifests test lint docker-build docker-build-mock-redfish docker-build-mock-inspector docker-push deploy install-controller-gen install-golangci-lint install uninstall undeploy rbac crd release-manifests sync-chart-crds manifests-and-sync smoke smoke-teardown


### PR DESCRIPTION
## Summary

Closes **LINT-1** from PROJECT_CONTEXT.md.

CI pins golangci-lint to **v1.64.8** (\`.github/workflows/ci.yml\`). The repo's \`.golangci.yml\` uses v1 schema. Without a top-level \`version:\` key, a system-installed v2 binary rejects the config with \"unsupported version of the configuration.\" Local devs running \`golangci-lint run\` directly hit this whenever their installed version is v2.

## What changed

- **New \`make lint\` target** depending on \`make install-golangci-lint\`. Installs v1.64.8 into \`\$GOBIN\` via \`go install\`. Local lint now matches CI exactly.
- \`GOLANGCI_LINT_VERSION ?= v1.64.8\` is parameterized for future bumps.
- Both targets added to \`.PHONY\`.
- \`.golangci.yml\` gains a header comment explaining the v1 pinning and pointing devs at \`make lint\`.
- Fixed the existing \`skip-dirs\` deprecation warning by moving \`vendor\` to \`issues.exclude-dirs\` (v1.64.8 still accepts \`run.skip-dirs\` but emits a warning).

## Why not migrate to v2 instead

Migrating \`.golangci.yml\` to v2 schema would also force bumping CI's pinned golangci-lint to v2.x, which could surface previously-lenient lint findings mid-cycle. The minimal fix here keeps local-and-CI consistent without touching the lint surface. A full v2 migration is tracked separately in PROJECT_CONTEXT.md for whoever wants to take it on.

## Verification

\`\`\`
$ make lint
go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
/home/wrkode/go/bin/golangci-lint run --timeout=5m
$
\`\`\`

No warnings, no findings.

## Test plan

- [x] \`make install-golangci-lint\` installs v1.64.8
- [x] \`make lint\` runs clean (no findings, no deprecation warnings)
- [x] CI's existing lint job continues to use v1.64.8 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)