### PR TITLE
chart: bump Chart.yaml to 0.4.0-alpha.4 (REL-1)

### DIFF
--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0-alpha.2
-appVersion: "v0.4.0-alpha.2"
+version: 0.4.0-alpha.4
+appVersion: "v0.4.0-alpha.4"
 keywords:
   - cluster-api
   - infrastructure


### PR DESCRIPTION
## Summary

Closes **REL-1** from PROJECT_CONTEXT.md.

Bumps \`charts/beskar7/Chart.yaml\` \`version\` and \`appVersion\` from \`0.4.0-alpha.2\` to \`0.4.0-alpha.4\` to match the latest released manager tag.

## Why this is cosmetic but worth doing

\`.github/workflows/helm-publish.yml\` rewrites both keys via \`sed\` at tag push (lines 73-74), so the **published** Helm chart always matches the tag regardless of the committed value. The bump matters for:

- Operators reading the repo without invoking the publish workflow
- \`helm template ./charts/beskar7\` invocations during local development
- Out-of-band inspection (Artifact Hub mirrors, archive snapshots, etc.)

## No values.yaml change needed

\`controllerManager.image.tag\` in \`charts/beskar7/values.yaml\` is already \`\"\"\`, deferring to \`Chart.appVersion\`. The publish workflow does also overwrite that key, but the in-repo state is correct as-is.

## Test plan

- [x] \`helm template ./charts/beskar7\` renders cleanly
- [x] Diff is exactly two lines (version + appVersion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)