### PR TITLE
controllers: use clusterv1.MachineControlPlaneLabel constant (REFACTOR-1)

### DIFF
--- a/controllers/beskar7cluster_controller.go
+++ b/controllers/beskar7cluster_controller.go
@@ -350,8 +350,8 @@ func (r *Beskar7ClusterReconciler) findControlPlaneEndpoint(ctx context.Context,
 	listOpts := []client.ListOption{
 		client.InNamespace(cluster.Namespace),
 		client.MatchingLabels{
-			clusterv1.ClusterNameLabel:       cluster.Name,
-			"cluster.x-k8s.io/control-plane": "", // Use literal string for the label key
+			clusterv1.ClusterNameLabel:         cluster.Name,
+			clusterv1.MachineControlPlaneLabel: "",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Closes **REFACTOR-1** from PROJECT_CONTEXT.md.

Replaces the hardcoded string literal \`\"cluster.x-k8s.io/control-plane\"\` in \`Beskar7ClusterReconciler.findControlPlaneEndpoint\` with the canonical constant \`clusterv1.MachineControlPlaneLabel\`.

\`\`\`diff
 listOpts := []client.ListOption{
     client.InNamespace(cluster.Namespace),
     client.MatchingLabels{
-        clusterv1.ClusterNameLabel:       cluster.Name,
-        \"cluster.x-k8s.io/control-plane\": \"\", // Use literal string for the label key
+        clusterv1.ClusterNameLabel:         cluster.Name,
+        clusterv1.MachineControlPlaneLabel: \"\",
     },
 }
\`\`\`

## Why

- \`clusterv1\` was already imported in the file (used at lines 28, 167, 346 etc.).
- CAPI v1.10.1 exports \`MachineControlPlaneLabel = \"cluster.x-k8s.io/control-plane\"\` in \`sigs.k8s.io/cluster-api@v1.10.1/api/v1beta1/machine_types.go:31\`.
- The trailing comment \`// Use literal string for the label key\` was a leftover from an earlier era when the constant wasn't reachable. CAPI exports it directly now, so the workaround is no longer needed.
- Per CLAUDE.md: \"Use existing constants in \`api/v1beta1/*_types.go\` rather than string literals.\" Same principle applies to upstream CAPI constants.

## Behaviour

Identical at runtime — \`MachineControlPlaneLabel\`'s string value is exactly \`\"cluster.x-k8s.io/control-plane\"\`. The improvement is purely build-time: if CAPI ever changes the label name, we pick it up automatically through the gomod upgrade.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`make lint\` clean (added in #77)
- [x] \`go test -race ./controllers/...\` envtest suite passes (15.4s)
- [x] No CRD/manifest diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)