### PR TITLE
cmd/manager: add --watch-namespaces flag for scoped informers (SEC-2 PR 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 *.dll
 *.so
 *.dylib
-manager
+# Anchored to the repo root so we ignore the built binary `./manager` without
+# accidentally hiding everything under `cmd/manager/` (which was matched by
+# the unanchored rule, blocking new files in that directory).
+/manager
 
 # Test binary, built with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,10 @@ COPY controllers/ controllers/
 # More info: https://doc.crds.dev/reference/go/go-env
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager cmd/manager/main.go
+# Build the package, not a single file — multi-file packages
+# (cmd/manager/{main,flags}.go) require ./cmd/manager so all sources
+# in the package are picked up.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager ./cmd/manager
 
 # Use distroless as minimal base image to package the manager binary.
 # Refer to https://github.com/GoogleContainerTools/distroless for more details.

--- a/Dockerfile.mock-inspector
+++ b/Dockerfile.mock-inspector
@@ -16,7 +16,7 @@ COPY controllers/ controllers/
 
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o mock-inspector cmd/mock-inspector/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o mock-inspector ./cmd/mock-inspector
 
 # gcr.io/distroless/static:nonroot (refreshed 2026-05-03)
 FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39

--- a/Dockerfile.mock-redfish
+++ b/Dockerfile.mock-redfish
@@ -16,7 +16,7 @@ COPY controllers/ controllers/
 
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o mock-redfish cmd/mock-redfish/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o mock-redfish ./cmd/mock-redfish
 
 # gcr.io/distroless/static:nonroot (refreshed 2026-05-03)
 FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39

--- a/Makefile
+++ b/Makefile
@@ -20,17 +20,19 @@ IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "generateEmbeddedObjectMeta=true,maxDescLen=0"
 
-# Build the manager binary
+# Build the manager binary. Builds the package (./cmd/manager) instead of
+# just main.go so additional .go files in the package (e.g. flags.go) are
+# picked up.
 build:
-	$(GO) build -o bin/manager cmd/manager/main.go
+	$(GO) build -o bin/manager ./cmd/manager
 
-# Build the mock Redfish server binary
+# Build the mock Redfish server binary.
 build-mock-redfish:
-	$(GO) build -o bin/mock-redfish cmd/mock-redfish/main.go
+	$(GO) build -o bin/mock-redfish ./cmd/mock-redfish
 
-# Build the mock inspector binary
+# Build the mock inspector binary.
 build-mock-inspector:
-	$(GO) build -o bin/mock-inspector cmd/mock-inspector/main.go
+	$(GO) build -o bin/mock-inspector ./cmd/mock-inspector
 
 # Run code generators
 generate:

--- a/cmd/manager/flags.go
+++ b/cmd/manager/flags.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"sort"
+	"strings"
+)
+
+// parseWatchNamespaces parses a --watch-namespaces flag value into a
+// deduplicated, sorted list of namespace names. Empty entries and pure
+// whitespace are dropped. Input is comma-separated; whitespace around each
+// entry is trimmed.
+//
+// Returns an empty slice for an empty / whitespace-only input — the caller
+// interprets that as "watch all namespaces" (current default).
+//
+// Sorting is for determinism so two equivalent flag values produce identical
+// cache.Options.DefaultNamespaces maps when iterated.
+func parseWatchNamespaces(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, part := range strings.Split(raw, ",") {
+		ns := strings.TrimSpace(part)
+		if ns == "" {
+			continue
+		}
+		seen[ns] = struct{}{}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(seen))
+	for ns := range seen {
+		out = append(out, ns)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/manager/flags_test.go
+++ b/cmd/manager/flags_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseWatchNamespaces(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "empty string → nil (watch all namespaces)",
+			in:   "",
+			want: nil,
+		},
+		{
+			name: "whitespace-only → nil",
+			in:   "   \t  ",
+			want: nil,
+		},
+		{
+			name: "single namespace",
+			in:   "default",
+			want: []string{"default"},
+		},
+		{
+			name: "multiple namespaces",
+			in:   "default,beskar7-system,rack-1",
+			want: []string{"beskar7-system", "default", "rack-1"},
+		},
+		{
+			name: "whitespace around entries is trimmed",
+			in:   " default , beskar7-system , rack-1 ",
+			want: []string{"beskar7-system", "default", "rack-1"},
+		},
+		{
+			name: "duplicates collapsed",
+			in:   "default,default,beskar7-system,default",
+			want: []string{"beskar7-system", "default"},
+		},
+		{
+			name: "trailing/leading commas ignored",
+			in:   ",default,beskar7-system,",
+			want: []string{"beskar7-system", "default"},
+		},
+		{
+			name: "consecutive commas ignored",
+			in:   "default,,,beskar7-system",
+			want: []string{"beskar7-system", "default"},
+		},
+		{
+			name: "single comma → nil",
+			in:   ",",
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseWatchNamespaces(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseWatchNamespaces(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,6 +31,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -78,6 +79,7 @@ func main() {
 	var bootstrapURLBase string
 	var inspectionPort int
 	var inspectionCertDir string
+	var watchNamespacesRaw string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -108,6 +110,13 @@ func main() {
 		"Directory containing tls.crt and tls.key for the inspection HTTPS endpoint. "+
 			"Defaults to the webhook cert dir; both endpoints are served from the same Pod and "+
 			"can share a cert covering the controller-manager Service DNS name.")
+	flag.StringVar(&watchNamespacesRaw, "watch-namespaces", "",
+		"Comma-separated list of namespaces the controller should watch. Empty "+
+			"(default) means watch all namespaces (the historical behavior). When set, "+
+			"informers are scoped to the listed namespaces — used together with "+
+			"per-namespace Role/RoleBinding to tighten Secret RBAC (SEC-2). RBAC and "+
+			"chart-side per-namespace bindings ship in follow-up PRs; this flag alone "+
+			"only narrows the cache.")
 
 	// Default to production-safe zap config: structured JSON output, no stack
 	// traces below Error, level-based encoding. Operators who want
@@ -144,7 +153,7 @@ func main() {
 		metricsOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	managerOpts := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsOptions,
 		WebhookServer:          webhook.NewServer(webhookServerOptions),
@@ -154,7 +163,22 @@ func main() {
 		LeaseDuration:          &leaderElectionLeaseDuration,
 		RenewDeadline:          &leaderElectionRenewDeadline,
 		RetryPeriod:            &leaderElectionRetryPeriod,
-	})
+	}
+
+	// Scope informers to the listed namespaces when --watch-namespaces is set.
+	// Empty list = all namespaces (default cache.Options behavior); we deliberately
+	// avoid setting DefaultNamespaces in that case so we don't accidentally lock
+	// the cache to an empty map (which would cache nothing).
+	if watchNamespaces := parseWatchNamespaces(watchNamespacesRaw); len(watchNamespaces) > 0 {
+		defaultNamespaces := make(map[string]cache.Config, len(watchNamespaces))
+		for _, ns := range watchNamespaces {
+			defaultNamespaces[ns] = cache.Config{}
+		}
+		managerOpts.Cache = cache.Options{DefaultNamespaces: defaultNamespaces}
+		setupLog.Info("Scoping informers to namespaces", "namespaces", watchNamespaces)
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), managerOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

First of the **SEC-2** multi-PR sequence: tighten the cluster-wide Secret RBAC scope by introducing a watched-namespaces mode (per the design decision in PROJECT_CONTEXT.md).

This PR adds the manager flag and scopes the cache. RBAC and docs follow:

| PR | Scope |
|---|---|
| **PR 1 (this PR)** | Manager flag + `cache.Options.DefaultNamespaces` wiring + parser tests. |
| PR 2 | Helm chart: switch from `ClusterRole`/`ClusterRoleBinding` to per-namespace `Role`/`RoleBinding` when `bootstrap.watchNamespaces` is set in values. |
| PR 3 | kustomize parity for raw-manifest installs. |
| PR 4 | `docs/security/rbac-hardening.md` update covering the flag + chart values + tightened scope. |

## What this PR does

- **New flag** \`--watch-namespaces\` (string, default empty). Comma-separated list. Empty = watch all namespaces (current behavior, **default unchanged**).
- When non-empty: populates \`ctrl.Options.Cache.DefaultNamespaces\` with a \`map[ns]cache.Config{}\` so informers scope server-side. Reduces cache footprint and shrinks what RBAC needs to grant.
- **\`parseWatchNamespaces\` helper** in \`cmd/manager/flags.go\` — trim, dedupe, sort for determinism. Returns \`nil\` for empty / whitespace-only input so the caller cleanly distinguishes \"narrow scope\" from \"watch all\".
- **9 table-driven tests** (\`cmd/manager/flags_test.go\`) covering: empty, whitespace-only, single ns, multi ns, dupes, whitespace around entries, leading/trailing/consecutive commas, single-comma-only.

## .gitignore fix (prerequisite)

The repo's \`.gitignore\` had an **unanchored \`manager\` rule** (intended for the built binary at repo root) that was accidentally matching every untracked file under \`cmd/manager/\` — including the new \`flags.go\` and \`flags_test.go\`. Anchored to \`/manager\` (repo-root-only). Already-tracked files (\`main.go\`, \`metrics_options_test.go\`) were unaffected because git only consults gitignore for untracked paths.

## Behaviour matrix

| \`--watch-namespaces\` | Cache scope | Note |
|---|---|---|
| (unset) | all namespaces | Default. No change for existing operators. |
| \`default\` | \`default\` only | Single-ns deployments — the common alpha case. |
| \`ns1,ns2,ns3\` | three namespaces | Multi-tenant carve-out. |
| \`  \` / \`,\` / \`,,\` | all namespaces | Parser returns nil; treated as unset. |

## What this PR does NOT yet do

- ❌ **Does not change RBAC.** The chart and kustomize still create a cluster-scoped \`ClusterRole\`/\`ClusterRoleBinding\` for Secrets. The tightening happens in PR 2 / PR 3.
- ❌ **Does not update docs.** \`docs/security/rbac-hardening.md\` stays as-is until PR 4, when the RBAC actually tightens.
- ❌ **Does not affect single-ns operators today** beyond the cache narrowing — and even that is opt-in via the flag.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`make lint\` clean (uses the pinned v1.64.8 from #77)
- [x] \`go test -race ./cmd/manager/...\` — 9/9 \`TestParseWatchNamespaces\` subtests pass + existing \`metrics_options_test.go\` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)