### PR TITLE
docs(ci-cd-and-testing): strip emoji + bold-wrap from headings (REL-2)

### DIFF
--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -4,13 +4,13 @@
 
 This document describes the comprehensive CI/CD pipeline and hardware emulation testing framework for Beskar7, enabling development and testing without access to real BMC hardware.
 
-## 🚀 **CI/CD Pipeline Overview**
+## CI/CD Pipeline Overview
 
 Beskar7 uses GitHub Actions for automated testing, building, and releasing. The pipeline consists of several workflows designed to ensure code quality and release readiness.
 
-### **Main Workflows**
+### Main Workflows
 
-#### 1. **CI Workflow** (`.github/workflows/ci.yml`)
+#### 1. CI Workflow (`.github/workflows/ci.yml`)
 Runs on every push and pull request to `main` and `develop` branches.
 
 **Jobs:**
@@ -23,7 +23,7 @@ Runs on every push and pull request to `main` and `develop` branches.
 - **E2E Setup Validation**: End-to-end deployment testing in kind cluster
 - **Performance Benchmarks**: Automated benchmark testing
 
-#### 2. **Release Workflow** (`.github/workflows/release.yml`)
+#### 2. Release Workflow (`.github/workflows/release.yml`)
 Triggered on Git tags starting with `v*`.
 
 **Jobs:**
@@ -34,7 +34,7 @@ Triggered on Git tags starting with `v*`.
 - **GitHub Release**: Automated release creation with artifacts
 - **Documentation Updates**: Version updates in documentation
 
-### **Pipeline Features**
+### Pipeline Features
 
 Yes **Multi-arch builds** (linux/amd64, linux/arm64)
 Yes **Security scanning** with SARIF reports
@@ -44,11 +44,11 @@ Yes **Helm chart automation**
 Yes **SBOM generation** for supply chain security
 Yes **Automated releases** with proper versioning
 
-## 🧪 **Hardware Emulation Testing Framework**
+## Hardware Emulation Testing Framework
 
 Since real BMC hardware isn't always available, Beskar7 includes a comprehensive hardware emulation framework that simulates different vendor BMCs and failure scenarios.
 
-### **Mock Redfish Server**
+### Mock Redfish Server
 
 The `MockRedfishServer` simulates realistic BMC behavior:
 
@@ -68,33 +68,33 @@ client := createRedfishClient(mockServer.GetURL(), "admin", "password123")
 systemInfo, err := client.GetSystemInfo(ctx)
 ```
 
-### **Supported Vendor Emulations**
+### Supported Vendor Emulations
 
-#### **Dell PowerEdge**
+#### Dell PowerEdge
 - Manufacturer: "Dell Inc."
 - Model: "PowerEdge R750"
 - BIOS Attributes: `KernelArgs`, `BootMode`, `SecureBoot`
 - Vendor-specific boot parameter handling
 
-#### **HPE ProLiant**
+#### HPE ProLiant
 - Manufacturer: "HPE"
 - Model: "ProLiant DL380 Gen10"
 - BIOS Attributes: `UefiOptimizedBoot`, `BootOrderPolicy`
 - UEFI target boot override support
 
-#### **Lenovo ThinkSystem**
+#### Lenovo ThinkSystem
 - Manufacturer: "Lenovo"
 - Model: "ThinkSystem SR650"
 - BIOS Attributes: `SystemBootSequence`, `SecureBootEnable`
 - Intelligent BIOS fallback mechanisms
 
-#### **Supermicro**
+#### Supermicro
 - Manufacturer: "Supermicro"
 - Model: "X12DPi-NT6"
 - BIOS Attributes: `BootFeature`, `QuietBoot`
 - Multiple fallback mechanisms
 
-### **Failure Scenario Testing**
+### Failure Scenario Testing
 
 The emulation framework supports various failure modes:
 
@@ -125,7 +125,7 @@ failureConfig := FailureConfig{
 }
 ```
 
-### **Integration Testing**
+### Integration Testing
 
 Run hardware emulation tests:
 
@@ -143,9 +143,9 @@ go test -v -tags=integration ./test/emulation/... -run TestFailureScenarios
 go test -v -tags=integration ./test/emulation/... -run TestStressTesting
 ```
 
-## 📊 **Performance Testing & Benchmarks**
+## Performance Testing & Benchmarks
 
-### **Running Benchmarks**
+### Running Benchmarks
 
 ```bash
 # Run all benchmarks
@@ -164,7 +164,7 @@ go test -bench=. -benchmem ./... > benchmark-after.txt
 benchcmp benchmark-before.txt benchmark-after.txt
 ```
 
-### **Performance Targets**
+### Performance Targets
 
 | Operation | Target | Current |
 |-----------|--------|---------|
@@ -173,9 +173,9 @@ benchcmp benchmark-before.txt benchmark-after.txt
 | Queue Operations | < 1ms | Measured in CI |
 | Leader Election Check | < 10ms | Measured in CI |
 
-## 🔍 **Code Quality & Security**
+## Code Quality & Security
 
-### **Linting Configuration**
+### Linting Configuration
 
 The project uses `golangci-lint` with comprehensive rules:
 
@@ -190,7 +190,7 @@ golangci-lint run --verbose
 golangci-lint run --fix
 ```
 
-### **Security Scanning**
+### Security Scanning
 
 Multiple security tools are integrated:
 
@@ -206,9 +206,9 @@ gosec ./...
 trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 ```
 
-## 🚀 **Development Workflow**
+## Development Workflow
 
-### **Local Development**
+### Local Development
 
 1. **Setup Environment**
    ```bash
@@ -251,7 +251,7 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
   docker run --rm ghcr.io/projectbeskar/beskar7/beskar7:${VERSION}
    ```
 
-### **Pull Request Workflow**
+### Pull Request Workflow
 
 1. **Create Feature Branch**
    ```bash
@@ -269,7 +269,7 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 4. **Review Process** - Automated checks must pass before merge
 
-### **Release Process**
+### Release Process
 
 1. **Create Release Tag** — the current release line is `v0.4.0-alpha.N`; bump N for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
@@ -284,9 +284,9 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
    - Publishes GitHub release
    - Updates documentation
 
-## 🧪 **Testing Without Real Hardware**
+## Testing Without Real Hardware
 
-### **Complete Testing Strategy**
+### Complete Testing Strategy
 
 The emulation framework enables comprehensive testing without real BMCs:
 
@@ -297,7 +297,7 @@ The emulation framework enables comprehensive testing without real BMCs:
 5. **Performance Tests**: Benchmark operations under load
 6. **End-to-End Tests**: Full workflow testing in kind clusters
 
-### **Example: Testing Dell-Specific Behavior**
+### Example: Testing Dell-Specific Behavior
 
 ```go
 func TestDellKernelArgsHandling(t *testing.T) {
@@ -319,7 +319,7 @@ func TestDellKernelArgsHandling(t *testing.T) {
 }
 ```
 
-### **Testing Failure Scenarios**
+### Testing Failure Scenarios
 
 ```go
 func TestNetworkFailureRecovery(t *testing.T) {
@@ -342,9 +342,9 @@ func TestNetworkFailureRecovery(t *testing.T) {
 }
 ```
 
-## 📈 **Monitoring & Observability**
+## Monitoring & Observability
 
-### **CI/CD Metrics**
+### CI/CD Metrics
 
 The pipeline tracks:
 - **Build Success Rate**: Percentage of successful builds
@@ -353,16 +353,16 @@ The pipeline tracks:
 - **Security Vulnerabilities**: New vulnerabilities introduced
 - **Deployment Success**: Release deployment success rate
 
-### **Integration with External Services**
+### Integration with External Services
 
 - **Codecov**: Code coverage reporting and trends
 - **GitHub Security**: SARIF report integration
 - **Container Registry**: Automated image scanning
 - **Dependabot**: Automated dependency updates
 
-## 🔧 **Configuration & Customization**
+## Configuration & Customization
 
-### **CI/CD Configuration**
+### CI/CD Configuration
 
 Key configuration files:
 - `.github/workflows/ci.yml`: Main CI pipeline
@@ -370,7 +370,7 @@ Key configuration files:
 - `.golangci.yml`: Code quality rules
 - `Dockerfile`: Container build configuration
 
-### **Emulation Configuration**
+### Emulation Configuration
 
 Customize emulation behavior:
 - Vendor-specific configurations
@@ -378,7 +378,7 @@ Customize emulation behavior:
 - Performance characteristics
 - Authentication requirements
 
-### **Environment Variables**
+### Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -390,35 +390,35 @@ Customize emulation behavior:
 | `MAX_RETRIES` | Guarded state transition retries | `3` |
 | `KUBEBUILDER_VERSION` | Kubebuilder version | `latest` |
 
-## 🎯 **Best Practices**
+## Best Practices
 
-### **Development**
+### Development
 - Yes Write tests first (TDD approach)
 - Yes Use emulation for development without real hardware
 - Yes Run full test suite before committing
 - Yes Keep benchmarks for performance-critical code
 
-### **Testing**
+### Testing
 - Yes Test vendor-specific behaviors separately
 - Yes Include failure scenario testing
 - Yes Use realistic data in tests
 - Yes Test concurrent operations
 
-### **CI/CD**
+### CI/CD
 - Yes Keep builds fast (< 10 minutes)
 - Yes Fail fast on critical errors
 - Yes Generate comprehensive reports
 - Yes Automate security scanning
 
-### **Releases**
+### Releases
 - Yes Use semantic versioning
 - Yes Generate detailed changelogs
 - Yes Include security assessments
 - Yes Test upgrade paths
 
-## 🚨 **Troubleshooting**
+## Troubleshooting
 
-### **Common CI Issues**
+### Common CI Issues
 
 1. **Test Timeouts**
    ```bash
@@ -442,7 +442,7 @@ Customize emulation behavior:
    //nolint:gosec
    ```
 
-### **Emulation Issues**
+### Emulation Issues
 
 1. **Mock Server Connection**
    ```go


### PR DESCRIPTION
## Summary

Closes **REL-2** from PROJECT_CONTEXT.md.

\`docs/ci-cd-and-testing.md\` was style-inconsistent with the rest of \`docs/\`: every H2 had a leading emoji (🚀 🧪 📊 🔍 📈 🔧 🎯 🚨), and every heading at all levels had its content wrapped in \`**…**\` bold markdown (rendering as bold inside an already-bold heading element).

## What changed

43 heading lines normalized to plain form, matching the convention used by every other doc in the tree.

\`\`\`diff
- ## 🚀 **CI/CD Pipeline Overview**
+ ## CI/CD Pipeline Overview

- ### **Main Workflows**
+ ### Main Workflows

- #### 1. **CI Workflow** (\`.github/workflows/ci.yml\`)
+ #### 1. CI Workflow (\`.github/workflows/ci.yml\`)
\`\`\`

## Anchor-link impact

None observed. Markdown anchor IDs are derived from heading text after stripping emoji and markdown formatting, so the slugged anchors stay the same. Grep across the rest of \`docs/\` finds no cross-references that rely on emoji-or-bold-inclusive anchor fragments.

## Test plan

- [x] grep confirms zero emoji remain in headings: \`grep -nP \"^#{1,6}.*[\x{1F300}-\x{1F9FF}\x{2600}-\x{27BF}]\" docs/ci-cd-and-testing.md\` → empty
- [x] grep confirms zero bold-wrap remains in headings: \`grep -nE \"^#{1,6}.*\*\*\" docs/ci-cd-and-testing.md\` → empty
- [x] Diff is exactly 43 inserts + 43 deletes (1:1 line replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)