### PR TITLE
chart: switch to per-namespace RBAC when watchNamespaces is set (SEC-2 PR 2)

### DIFF
--- a/charts/beskar7/README.md
+++ b/charts/beskar7/README.md
@@ -87,7 +87,8 @@ All configurable values with their defaults:
 | `certManager.certificate.renewBefore` | `720h` | Renew 30 days before expiry. |
 | `namespace.create` | `false` | Render a Namespace resource. Set `true` only when not using `--create-namespace`. |
 | `namespace.name` | `beskar7-system` | Namespace for all chart resources. |
-| `rbac.create` | `true` | Create ClusterRole and ClusterRoleBinding for the manager. |
+| `rbac.create` | `true` | Create RBAC resources for the manager. With `watchNamespaces` empty, renders a cluster-scoped ClusterRole + ClusterRoleBinding. With `watchNamespaces` set, renders a minimal ClusterRole + per-namespace Role/RoleBinding pairs (see `watchNamespaces`). |
+| `watchNamespaces` | `[]` | Namespaces the controller watches. Empty (default) = all namespaces, cluster-scoped RBAC. Non-empty list scopes both the cache (`--watch-namespaces` flag on the manager) and the RBAC (per-namespace Role/RoleBinding in each listed namespace + leader-election Role in the operator's own namespace). Beskar7 CRs outside the listed namespaces are ignored. |
 | `networkPolicy.enabled` | `false` | Deploy NetworkPolicy rules for the manager pod. |
 | `monitoring.enabled` | `true` | Enable the metrics server on `:8443` (HTTPS, TokenReview/SAR auth). |
 | `monitoring.serviceMonitor.enabled` | `false` | Create a Prometheus Operator `ServiceMonitor`. |

--- a/charts/beskar7/templates/deployment.yaml
+++ b/charts/beskar7/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         - --enable-webhook=true
         - --webhook-port=9443
         {{- end }}
+        {{- with .Values.watchNamespaces }}
+        - --watch-namespaces={{ join "," . }}
+        {{- end }}
         ports:
         - containerPort: 8443
           name: metrics

--- a/charts/beskar7/templates/rbac.yaml
+++ b/charts/beskar7/templates/rbac.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.rbac.create }}
+{{- if not .Values.watchNamespaces }}
+# Cluster-wide RBAC (default — watchNamespaces is empty).
+# Grants the manager access to Beskar7 CRDs, Secrets, ConfigMaps, etc. in
+# ALL namespaces. This is the historical scope. To tighten, set
+# .Values.watchNamespaces to a non-empty list — the rendered manifest then
+# switches to per-namespace Role/RoleBinding pairs (see the else branch).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -8,10 +14,7 @@ metadata:
 rules:
 # ConfigMaps: inspection-result handoff (D-005). list+watch are required
 # so the controller-runtime cache can populate the ConfigMap informer
-# used by the inspection handler's CreateOrUpdate path. Without them the
-# reflector loops on "configmaps is forbidden" and the first inspection
-# POST blocks until the informer sync timeout returns 5xx. (Supersedes
-# the SEC-2 / D-007 note that previously omitted list/watch.)
+# used by the inspection handler's CreateOrUpdate path.
 - apiGroups:
   - ""
   resources:
@@ -35,7 +38,7 @@ rules:
 # create/update/patch/delete for the per-host bootstrap-token Secret.
 # list/watch are required because PhysicalHostReconciler.SetupWithManager
 # registers a .Watches(&corev1.Secret{}, ...) informer for credential
-# rotation. SEC-2 residual scope after PR-7 (D-007).
+# rotation. SEC-2 residual cluster-wide scope (tighten via watchNamespaces).
 - apiGroups:
   - ""
   resources:
@@ -135,4 +138,207 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "beskar7.serviceAccountName" . }}
   namespace: {{ include "beskar7.namespace" . }}
+{{- else }}
+# Tightened RBAC: watchNamespaces is non-empty (SEC-2 PR 2).
+#
+# Three pieces:
+#   1. Minimal ClusterRole + ClusterRoleBinding for genuinely cluster-scoped
+#      reads (rbac.authorization.k8s.io/clusterroles + clusterrolebindings).
+#      These are not narrowable to a namespace.
+#   2. Role + RoleBinding in the operator's own namespace for leader-election
+#      (Lease) and operator-side Event creation.
+#   3. Role + RoleBinding per watched namespace for everything else: Secrets,
+#      ConfigMaps, Beskar7 CRDs, cluster.x-k8s.io Machine/Cluster reads, Events.
+#
+# All of this is bound to the manager's single ServiceAccount.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "beskar7.fullname" . }}-manager-clusterscope
+  labels:
+    {{- include "beskar7.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "beskar7.fullname" . }}-manager-clusterscope
+  labels:
+    {{- include "beskar7.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "beskar7.fullname" . }}-manager-clusterscope
+subjects:
+- kind: ServiceAccount
+  name: {{ include "beskar7.serviceAccountName" . }}
+  namespace: {{ include "beskar7.namespace" . }}
+---
+# Leader-election + operator-side events in the operator's own namespace.
+# Separate from the per-watched-namespace Roles below because the lease
+# always lives where the operator runs, independent of where user CRs live.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "beskar7.fullname" . }}-manager-leaderelection
+  namespace: {{ include "beskar7.namespace" . }}
+  labels:
+    {{- include "beskar7.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "beskar7.fullname" . }}-manager-leaderelection
+  namespace: {{ include "beskar7.namespace" . }}
+  labels:
+    {{- include "beskar7.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "beskar7.fullname" . }}-manager-leaderelection
+subjects:
+- kind: ServiceAccount
+  name: {{ include "beskar7.serviceAccountName" . }}
+  namespace: {{ include "beskar7.namespace" . }}
+{{- range $ns := .Values.watchNamespaces }}
+---
+# Per-watched-namespace Role: Secrets, ConfigMaps, Beskar7 CRDs, CAPI Machine
+# reads, and Event creation in {{ $ns }}.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "beskar7.fullname" $ }}-manager-watch
+  namespace: {{ $ns }}
+  labels:
+    {{- include "beskar7.labels" $ | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - beskar7clusters
+  - beskar7machines
+  - physicalhosts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - beskar7clusters/finalizers
+  - beskar7machines/finalizers
+  - physicalhosts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - beskar7clusters/status
+  - beskar7machines/status
+  - physicalhosts/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - beskar7machinetemplates
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "beskar7.fullname" $ }}-manager-watch
+  namespace: {{ $ns }}
+  labels:
+    {{- include "beskar7.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "beskar7.fullname" $ }}-manager-watch
+subjects:
+- kind: ServiceAccount
+  name: {{ include "beskar7.serviceAccountName" $ }}
+  namespace: {{ include "beskar7.namespace" $ }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/beskar7/values.yaml
+++ b/charts/beskar7/values.yaml
@@ -99,6 +99,28 @@ namespace:
 rbac:
   create: true
 
+# Namespaces the controller watches. When empty (default), the chart creates
+# a cluster-scoped ClusterRole + ClusterRoleBinding granting the manager
+# access to ALL Secrets/ConfigMaps/Beskar7 CRDs across all namespaces — the
+# historical behavior. When set to a non-empty list, RBAC narrows to
+# per-namespace Role/RoleBinding pairs in each listed namespace plus a
+# leader-election Role in the operator's own namespace; the cluster-wide
+# binding is replaced with a minimal ClusterRole covering only the genuinely
+# cluster-scoped reads (ClusterRoles/ClusterRoleBindings) that the manager
+# requires.
+#
+# The same list is passed to the manager via --watch-namespaces so its cache
+# informers scope to these namespaces. Beskar7 CRs (PhysicalHost, Beskar7Machine,
+# Beskar7Cluster, Beskar7MachineTemplate) and their associated CAPI Machines
+# must live in one of the watched namespaces; objects elsewhere are ignored.
+#
+# Example:
+#   watchNamespaces:
+#     - default
+#     - tenant-a
+#     - tenant-b
+watchNamespaces: []
+
 # Network policies
 networkPolicy:
   enabled: false


### PR DESCRIPTION
## Summary

Second of the **SEC-2** multi-PR sequence. PR 1 (#80) added the \`--watch-namespaces\` manager flag and scoped the cache; this PR makes the Helm chart's RBAC follow suit.

| PR | Scope | Status |
|---|---|---|
| #80 (PR 1) | Manager flag + cache scoping | ✅ merged |
| **This PR (PR 2)** | Helm chart RBAC split | 🟡 open |
| PR 3 | kustomize parity for raw-manifest installs | queued |
| PR 4 | \`docs/security/rbac-hardening.md\` rewrite | queued |

## Behavior matrix

| \`watchNamespaces\` | RBAC topology |
|---|---|
| \`[]\` (default) | 1 ClusterRole + 1 ClusterRoleBinding — **byte-equivalent to the previous chart output**. Operators see no diff on \`helm upgrade\`. |
| \`[ns1, ns2, ns3]\` | 1 minimal ClusterRole + 1 ClusterRoleBinding (only the clusterroles/clusterrolebindings read rule the manager has via a kubebuilder marker) + 1 leader-election Role + RoleBinding in the **operator's namespace** + 1 watch Role + RoleBinding in **each watched namespace** (Secrets, ConfigMaps, Events, Beskar7 CRDs, CAPI Machine/Cluster reads). |

## What's notably preserved

- Same single ServiceAccount bound to all the new Roles + ClusterRole.
- Leader-election lease stays in the operator's own namespace (independent of \`watchNamespaces\`). The lease lives where the operator runs, not where its target CRs live.
- The vestigial \`rbac.authorization.k8s.io clusterroles/clusterrolebindings\` read rule (auto-generated by a kubebuilder marker) is kept in a minimal ClusterRole rather than dropped — removing it is a separate concern (the marker would re-add it on next \`make manifests\`).

## Files

- \`charts/beskar7/values.yaml\`: new top-level \`watchNamespaces: []\` with an operator-facing comment.
- \`charts/beskar7/templates/deployment.yaml\`: passes \`--watch-namespaces={{ join \",\" . }}\` to the manager when \`watchNamespaces\` is non-empty.
- \`charts/beskar7/templates/rbac.yaml\`: full split into the two modes above. Both branches are inside the existing \`{{- if .Values.rbac.create }}\` so \`rbac.create: false\` continues to render nothing.
- \`charts/beskar7/README.md\`: \`rbac.create\` row updated; new \`watchNamespaces\` row added.

## Validation

- [x] \`helm lint ./charts/beskar7\` clean
- [x] \`helm template ./charts/beskar7\` (default) → 1 ClusterRole + 1 ClusterRoleBinding (byte-equivalent surface)
- [x] \`helm template ./charts/beskar7 --set watchNamespaces='{default,tenant-a,tenant-b}'\` → 1 ClusterRole + 1 ClusterRoleBinding + 4 Role + 4 RoleBinding
- [x] Manager Deployment args include \`--watch-namespaces=default,tenant-a,tenant-b\` in the multi-namespace render
- [x] Default render omits the \`--watch-namespaces\` arg entirely (uses Sprig \`{{- with }}\`)

## Test plan checklist

After merge, the kind-based E2E smoke gate will install the chart in its default mode and verify the existing reconcile flow. A future explicit watchNamespaces test would be a nice-to-have but isn't required to close SEC-2 PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)