### PR TITLE
config/rbac: add namespace-scoped RBAC overlay (SEC-2 PR 3)

### DIFF
--- a/config/rbac/namespace-scoped/README.md
+++ b/config/rbac/namespace-scoped/README.md
@@ -1,0 +1,76 @@
+# Namespace-scoped RBAC overlay
+
+This directory contains the kustomize manifests for tightening the manager's
+RBAC from cluster-wide to per-namespace, equivalent to setting
+`.Values.watchNamespaces` in the Helm chart (SEC-2).
+
+It is **not included in `config/default/`**. Operators opt in by editing
+their own overlay to reference this dir instead of `../rbac`.
+
+## What's in here
+
+| File | Purpose |
+|---|---|
+| `minimal-clusterrole.yaml` | Cluster-scoped reads only (`clusterroles`, `clusterrolebindings` — auto-generated from a kubebuilder marker in `cmd/manager/main.go`). |
+| `leader-election-role.yaml` | `Role` + `RoleBinding` in `beskar7-system` for leader-election `Lease` access and operator-side `Event` creation. Leases live where the operator runs, not where its watched CRs live. |
+| `watch-role.template.yaml` | **Template** for the per-namespace `Role` + `RoleBinding`. Not included in `kustomization.yaml`. Copy and patch the `namespace:` fields once per watched namespace. |
+| `kustomization.yaml` | Resource list — references everything except `watch-role.template.yaml`. |
+
+## Usage
+
+For each namespace the manager should reconcile in:
+
+1. Copy `watch-role.template.yaml` to `watch-role.<namespace>.yaml`.
+2. Edit the two `namespace:` fields in the copy to that namespace name.
+3. Append the new filename to `kustomization.yaml`'s `resources:` list.
+
+Then in your own overlay (for example `config/overlays/<env>/kustomization.yaml`), stack the namespace-scoped RBAC with the shared bits from `config/rbac/`:
+
+```yaml
+namespace: beskar7-system
+resources:
+# Namespace-scoped manager RBAC (replaces the cluster-scoped role.yaml +
+# role_binding.yaml from config/rbac/).
+- ../../rbac/namespace-scoped
+# Shared bits — kept in the parent dir because they apply to both topologies.
+- ../../rbac/service_account.yaml
+- ../../rbac/metrics_auth_role.yaml
+- ../../rbac/metrics_auth_role_binding.yaml
+- ../../rbac/metrics_reader_role.yaml
+# Manager + CRDs + webhook + certmanager + security as before.
+- ../../manager
+- ../../crd
+- ../../webhook
+- ../../certmanager
+- ../../security
+```
+
+This is the equivalent of replacing `config/default/`'s `../rbac` base with the namespace-scoped variant. **Do not** also include `../../rbac` (the parent dir) — it ships the cluster-scoped role + binding that this overlay is meant to replace, and kustomize will error on the duplicate `manager-role` name.
+
+And patch the manager Deployment to pass `--watch-namespaces` with the same
+comma-separated list:
+
+```yaml
+patches:
+- target:
+    kind: Deployment
+    name: controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --watch-namespaces=ns1,ns2,ns3
+```
+
+The Helm chart automates all of this via `.Values.watchNamespaces`; see
+`charts/beskar7/values.yaml` and `charts/beskar7/templates/rbac.yaml` for
+the templated equivalent.
+
+## Why kustomize can't auto-generate per-namespace Roles
+
+Helm's templating supports `{{- range $ns := .Values.watchNamespaces }}` to
+emit one Role per namespace. Kustomize has no loop construct — it operates
+on a fixed set of YAML files plus patches. The manual copy-template-per-
+namespace step is the kustomize-idiomatic way to express this.
+
+For very large numbers of watched namespaces, a generator script wrapping
+kustomize (or migrating to Helm) is more ergonomic.

--- a/config/rbac/namespace-scoped/kustomization.yaml
+++ b/config/rbac/namespace-scoped/kustomization.yaml
@@ -1,0 +1,39 @@
+# Namespace-scoped RBAC overlay. SEC-2 follow-on to the Helm chart's
+# watchNamespaces support (charts/beskar7/templates/rbac.yaml).
+#
+# This overlay is the manual kustomize equivalent of setting
+# .Values.watchNamespaces in the chart. The default kustomize build
+# (config/default/) still references ../rbac (cluster-scoped); operators
+# wanting tightened RBAC swap the base to this directory in their own
+# overlay.
+#
+# What's here:
+#   - minimal-clusterrole.yaml      Cluster-scoped reads only (clusterroles,
+#                                   clusterrolebindings auto-generated from
+#                                   a kubebuilder marker).
+#   - leader-election-role.yaml     Role + RoleBinding in beskar7-system for
+#                                   leader-election leases + operator events.
+#   - watch-role.template.yaml      TEMPLATE for the per-namespace Role +
+#                                   RoleBinding. Copy and patch the
+#                                   namespace fields for each watched ns,
+#                                   then add to `resources:` below.
+#   - service_account.yaml,         Reused unchanged from the parent dir.
+#     metrics_*                     (Symlinks would also work; explicit
+#                                   refs are clearer.)
+#
+# To enable, point your own overlay's `bases:` at this dir instead of
+# ../rbac, AND set --watch-namespaces=<csv> on the manager Deployment so
+# the controller-runtime cache matches the RBAC.
+namespace: beskar7-system
+
+resources:
+- minimal-clusterrole.yaml
+- leader-election-role.yaml
+# watch-role.template.yaml is intentionally NOT listed — it's a template.
+# Copy it to watch-role.<namespace>.yaml per watched namespace, edit the
+# namespace fields, and append the new filenames here.
+#
+# Shared resources (ServiceAccount, metrics_auth_*, metrics_reader_role)
+# are NOT replicated here. Reference them from your own top-level overlay
+# by listing the individual files alongside this directory. See README.md
+# for a worked example.

--- a/config/rbac/namespace-scoped/leader-election-role.yaml
+++ b/config/rbac/namespace-scoped/leader-election-role.yaml
@@ -1,0 +1,49 @@
+# Leader-election Role + RoleBinding in the operator's own namespace.
+#
+# Even when --watch-namespaces narrows the cache to user-data namespaces,
+# the leader-election lease lives where the operator runs (beskar7-system
+# by default). Operator-side Event creation is in the same namespace for
+# the same reason.
+#
+# Mirrors the chart's "manager-leaderelection" Role when
+# .Values.watchNamespaces is non-empty (charts/beskar7/templates/rbac.yaml).
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manager-leaderelection-role
+  namespace: beskar7-system
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-leaderelection-rolebinding
+  namespace: beskar7-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-leaderelection-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: beskar7-system

--- a/config/rbac/namespace-scoped/minimal-clusterrole.yaml
+++ b/config/rbac/namespace-scoped/minimal-clusterrole.yaml
@@ -1,0 +1,37 @@
+# Minimal ClusterRole for the manager when --watch-namespaces is used.
+#
+# Contains only the genuinely cluster-scoped reads the manager requires:
+# clusterroles and clusterrolebindings (auto-generated from a kubebuilder
+# marker in cmd/manager/main.go). Every namespaced permission has been
+# moved to the per-namespace Role(s) in this directory.
+#
+# Mirrors the chart's "manager-clusterscope" ClusterRole when
+# .Values.watchNamespaces is non-empty (charts/beskar7/templates/rbac.yaml).
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-clusterscope-role
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-clusterscope-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-clusterscope-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: beskar7-system

--- a/config/rbac/namespace-scoped/watch-role.template.yaml
+++ b/config/rbac/namespace-scoped/watch-role.template.yaml
@@ -1,0 +1,121 @@
+# PER-NAMESPACE TEMPLATE — duplicate this file for each watched namespace.
+#
+# This file is a TEMPLATE, not a kustomize-rendered manifest. The default
+# overlay (config/default/) does NOT include it. To deploy the namespace-
+# scoped variant:
+#
+#   1. Copy this file to watch-role.<namespace>.yaml for every namespace
+#      you want the manager to reconcile in.
+#   2. Edit the two `namespace:` fields below to the target namespace name.
+#   3. Add the resulting filenames to kustomization.yaml's `resources:` list.
+#   4. Set --watch-namespaces=<comma-separated-list> on the manager
+#      Deployment so the controller-runtime cache matches the RBAC.
+#
+# The chart automates all of the above through .Values.watchNamespaces; this
+# is the manual kustomize equivalent.
+#
+# Mirrors the chart's per-namespace "manager-watch" Role when
+# .Values.watchNamespaces is non-empty (charts/beskar7/templates/rbac.yaml).
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manager-watch-role
+  namespace: REPLACE_WITH_WATCHED_NAMESPACE
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - beskar7clusters
+  - beskar7machines
+  - physicalhosts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - beskar7clusters/finalizers
+  - beskar7machines/finalizers
+  - physicalhosts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - beskar7clusters/status
+  - beskar7machines/status
+  - physicalhosts/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - beskar7machinetemplates
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-watch-rolebinding
+  namespace: REPLACE_WITH_WATCHED_NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-watch-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: beskar7-system


### PR DESCRIPTION
## Summary

Third of the **SEC-2** multi-PR sequence — kustomize parity for the chart's \`watchNamespaces\` support.

| PR | Scope | Status |
|---|---|---|
| #80 | Manager flag + cache scoping | ✅ merged |
| #82 | Helm chart RBAC split | ✅ merged |
| **This PR (PR 3)** | Kustomize parity (reference overlay) | 🟡 open |
| PR 4 | \`docs/security/rbac-hardening.md\` rewrite | queued |

## Why kustomize can't auto-generate per-namespace Roles

Helm's templating supports \`{{- range $ns := .Values.watchNamespaces }}\` to emit one Role per namespace. Kustomize operates on a fixed set of YAML files plus patches — no loop construct. So the kustomize equivalent is a **reference overlay** that operators opt into by editing their own top-level kustomization.

## What's in the new directory

\`\`\`
config/rbac/namespace-scoped/
├── README.md                      # Worked example for the swap path
├── kustomization.yaml             # Resource list (the 2 non-template files)
├── minimal-clusterrole.yaml       # Cluster-scoped reads only (clusterroles + clusterrolebindings, kubebuilder marker)
├── leader-election-role.yaml      # Role + RoleBinding in beskar7-system for Lease + Event
└── watch-role.template.yaml       # TEMPLATE for per-namespace Role+RoleBinding (copy per ns)
\`\`\`

## Output shape

\`\`\`
$ kustomize build config/rbac/namespace-scoped/
ClusterRole/manager-clusterscope-role          (cluster-scoped reads)
ClusterRoleBinding/manager-clusterscope-rolebinding
Role/manager-leaderelection-role               (in beskar7-system)
RoleBinding/manager-leaderelection-rolebinding
\`\`\`

Per-watched-namespace Roles materialize once the operator copies \`watch-role.template.yaml\` → \`watch-role.<namespace>.yaml\`, patches the two \`namespace:\` fields, and appends to \`kustomization.yaml\`. Mirrors what the chart's range loop produces.

## Operator workflow

The new README documents the full swap. In an operator's overlay:

\`\`\`yaml
namespace: beskar7-system
resources:
- ../../rbac/namespace-scoped              # replaces ../../rbac for the manager role
- ../../rbac/service_account.yaml          # shared bits, unchanged
- ../../rbac/metrics_auth_role.yaml
- ../../rbac/metrics_auth_role_binding.yaml
- ../../rbac/metrics_reader_role.yaml
- ../../manager
# ... rest of the standard bases ...
\`\`\`

Plus a Deployment patch adding \`--watch-namespaces=<csv>\` to the manager args.

## What's NOT changed

- \`config/default/\` still references \`../rbac\` (cluster-scoped). \`make deploy\` and the release manifest pipeline retain historical behavior.
- \`config/rbac/role.yaml\` + \`role_binding.yaml\` are untouched — they're still regenerated by \`make manifests\` from kubebuilder markers.
- No automatic flag wiring; operators add \`--watch-namespaces=…\` to their Deployment patch (documented).

## Validation

- [x] \`kustomize build config/rbac/namespace-scoped/\` → 4 resources (ClusterRole + ClusterRoleBinding + Role + RoleBinding)
- [x] \`kustomize build config/rbac/\` → unchanged (3 ClusterRole + 2 ClusterRoleBinding + 1 ServiceAccount)
- [x] \`kustomize build config/default/\` → unchanged (full default overlay still renders identically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)