### PR TITLE
release: v0.4.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 *No unreleased work — see the per-tag entries below. Going forward, each released tag gets its own entry; this section stays empty between tags.*
 
+## [v0.4.0-alpha.5] - 2026-05-24
+
+The "backlog cleanup arc": tightened RBAC to per-namespace scope as an opt-in, brought the Prometheus metric surface in line with reality (delete what was dead, wire what should emit), and closed every correctness bug + hygiene item that had been carried since the v0.4-alpha review.
+
+### Added
+- **`--watch-namespaces` manager flag** (PR #80) — comma-separated list of namespaces. Empty (default) = watch all namespaces (historical behavior). When set, `ctrl.Options.Cache.DefaultNamespaces` scopes informers to the listed namespaces. Parser is stateless (trim, dedupe, sort) with table-driven coverage in `cmd/manager/flags_test.go`.
+- **Helm chart `watchNamespaces` value** (PR #82) — switches the chart's RBAC topology from cluster-wide ClusterRole to per-namespace Role/RoleBinding when set. Default (empty list) is byte-for-byte equivalent to the previous chart output; opting in renders a minimal residual ClusterRole + a leader-election Role in the operator's namespace + a watch Role in each listed namespace. Manager Deployment also picks up the `--watch-namespaces` arg automatically.
+- **`config/rbac/namespace-scoped/` overlay** (PR #83) — kustomize parity for the chart change. Reference manifests + per-namespace template + worked-example README. Operators swap their overlay's RBAC base from `../rbac` to `../rbac/namespace-scoped` and duplicate the template per watched namespace.
+- **Wire-up of 9 previously-registered-but-unemitted metric helpers** (PR #76): `RecordPhysicalHostState`, `RecordPhysicalHostPowerOperation`, `RecordRedfishConnection`, `RecordBeskar7MachineState`, `RecordBeskar7MachineProvisioning`, `RecordBeskar7ClusterState`, `UpdatePhysicalHostAvailability`, `RecordHostClaimAttempt`, `RecordHostClaimDuration`. Plus extended `RecordError` to fire from `Beskar7MachineReconciler` and `PhysicalHostReconciler` (was only `Beskar7ClusterReconciler`). The advertised metric surface in `docs/metrics.md` now matches what the controllers actually emit.
+- **`make lint` Makefile target** (PR #77) pinning golangci-lint to v1.64.8, the version CI uses. Local devs no longer hit "unsupported version of the configuration" errors when a system-installed golangci-lint v2 reads the v1-syntax `.golangci.yml`.
+
+### Fixed
+- **BUG-12**: `RecordPowerOperation` accepted an `errorType` parameter that it silently discarded. Parameter removed; error-type cardinality lives on the Redfish-connection / Redfish-query counters already (PR #73).
+- **BUG-13**: removed the deprecated `PhysicalHost` state alias constants (`StateClaimed = "InUse"`, `StateProvisioning = "Inspecting"`, `StateProvisioned = "Ready"`, `StateDeprovisioning = "Error"`). They collided with the canonical constants on string value, so switch statements casing on the deprecated names compiled but never matched at runtime. Zero in-tree callers (PR #72).
+- **BUG-14**: `PhysicalHostReconciler` error paths no longer return `Result{RequeueAfter: 1*time.Minute}, err`. The workqueue is configured with `workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](5*time.Second, 30*time.Minute)`; error returns now use `Result{}, err` and the rate-limiter governs the retry cadence (5s → 10s → 20s → ... capped at 30m). A persistently-misconfigured BMC settles into a low-frequency check instead of a 60s hot loop (PR #74).
+- **BUG-15 dead-metric surface**: deleted 10 broken/redundant `Record*` helpers (`RecordRequeue`, `RecordPhysicalHostProvisioning`, `RecordBootConfiguration`, `RecordPhysicalHostConsumerMapping`, `RecordRedfishQuery`, `RecordNetworkAddress`, `RecordPowerOperation`, `RecordVirtualMediaOperation`, `RecordBootOperation`, `RecordDeprovisioningOperation`), 4 metric variables only referenced by them, and 5 unused `ErrorType` enum values (`ErrorTypeQuery`, `ErrorTypeAddress`, `ErrorTypePower`, `ErrorTypeBoot`, `ErrorTypeVirtualMedia`). Companion `docs/metrics.md` sections removed (PR #75).
+- **REFACTOR-1**: `controllers/beskar7cluster_controller.go` no longer uses a string literal for the `"cluster.x-k8s.io/control-plane"` label. Uses `clusterv1.MachineControlPlaneLabel` from the CAPI v1beta1 package, which was already imported (PR #79).
+- **`.gitignore`** `manager` rule was unanchored, accidentally hiding any untracked file under `cmd/manager/`. Anchored to `/manager` (repo-root binary only) (PR #80).
+- **Dockerfile + Makefile** builds now use `go build ./cmd/...` (package) instead of `go build cmd/.../main.go` (single file). The latter silently dropped sibling files in the same package — broke the Container Build job when `cmd/manager/flags.go` was added (PR #80).
+- **`.golangci.yml`** `run.skip-dirs` deprecation warning eliminated by moving `vendor` to `issues.exclude-dirs` (PR #77).
+
+### Changed
+- **State-gauge helper API refactored to per-reconcile Set** (PR #76): `RecordPhysicalHostState`/`RecordBeskar7MachineState`/`RecordBeskar7ClusterState` (which took `(label, namespace, delta float64)` and made the caller track previous state to subtract correctly) replaced with `UpdatePhysicalHostStateCounts(ns, map[string]int)`, `UpdateBeskar7MachineStateCounts(...)`, `UpdateBeskar7ClusterStateCounts(...)`. Each reconciler computes counts via a namespace-scoped List at the top of `Reconcile` and Sets each gauge series including zero for absent states. Stateless, restart-safe, no drift.
+- **`Beskar7ClusterFailureDomainsGauge`** call patterns unchanged; only the unwired helpers were touched.
+- **`RecordReconciliation`, `RecordError`, `RecordFailureDomains`, `RecordFailureDomainDiscovery`** retain their existing behavior; this release wires them more broadly across the three reconcilers (previously only `Beskar7ClusterReconciler` fired `RecordError`).
+- **Chart RBAC topology is now selectable** via `.Values.watchNamespaces`. Default (empty) keeps the existing ClusterRole+ClusterRoleBinding. Non-empty list switches to per-namespace Role+RoleBinding pairs plus a minimal ClusterRole for the residual cluster-scoped reads (`clusterroles`, `clusterrolebindings` — kubebuilder-marker autogen).
+- **`charts/beskar7/Chart.yaml`** `version` and `appVersion` bumped to v0.4.0-alpha.5 (this release).
+- **`Makefile` `VERSION`** bumped to v0.4.0-alpha.5 — image-tag default for `make docker-build`, `make release-manifests`, etc.
+- **`Beskar7MachineReconciler.findAndClaimOrGetAssociatedHost`** now records `RecordHostClaimAttempt` + `RecordHostClaimDuration` at all 6 exit branches (success / conflict-via-optimistic-lock / no-hosts / error), giving observability for the PR-2.2 race fix.
+
+### Docs
+- **`docs/security/rbac-hardening.md`** rewritten with a two-topology framing (cluster-wide default vs. namespace-scoped opt-in), Helm and kustomize activation paths, and a 4-step backward-compatible migration recipe (PR #84).
+- **`docs/security/README.md`** section 5 ("Per-namespace Secret/ConfigMap RBAC scope") updated: no longer punts to a hypothetical v0.5 label-selected partial cache. The actual closure path (watchNamespaces) is documented with links.
+- **`docs/ci-cd-and-testing.md`** style-normalized: 43 heading lines stripped of leading emoji and `**...**` bold-wrap to match the rest of `docs/` (PR #81).
+- **`docs/metrics.md`** lost the "Wiring status (v0.4.0-alpha.4 → next)" disclaimer that PR #75 added: every advertised metric now emits data.
+
+### Internal
+- **9 previously-orphan metric helpers** are now wired at the right controller call sites. Per-reconcile `recompute*Metrics` helpers (`recomputePhysicalHostMetrics`, `recomputeBeskar7MachineMetrics`, `recomputeBeskar7ClusterMetrics`) run at the top of each `Reconcile` so the state gauges and availability ratio stay current even when downstream reconcile errors. Cost is one namespace-scoped List per reconcile, dominated by the reconcile itself.
+
 ## [v0.4.0-alpha.4] - 2026-05-23
 
 The "smoke-test arc": a hardware-free CI smoke gate, the four production bugs the gate uncovered, and the CAPI v1.10+ conformance work needed to make any of it run.
@@ -673,7 +712,8 @@ For detailed implementation information, see the examples directory and document
 - CI: lint, tests, container build, CRD generation, Kind sanity checks.
 - Core controllers and CRDs for `PhysicalHost`, `Beskar7Machine`, `Beskar7Cluster`.
 
-[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.4...HEAD
+[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.5...HEAD
+[v0.4.0-alpha.5]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.4...v0.4.0-alpha.5
 [v0.4.0-alpha.4]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha...v0.4.0-alpha.4
 [v0.4.0-alpha]: https://github.com/projectbeskar/beskar7/compare/v0.3.4-alpha...v0.4.0-alpha
 [v0.3.4-alpha]: https://github.com/projectbeskar/beskar7/compare/v0.2.7...v0.3.4-alpha

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.0-alpha.4
+VERSION ?= v0.4.0-alpha.5
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.0-alpha.4  
+**Version:** v0.4.0-alpha.5  
 **Status:** Alpha - Under active development. API may still change before v0.4.0 GA.  
 **Breaking Changes:** v0.4.0 is NOT compatible with v0.3.x ([see CHANGELOG](CHANGELOG.md))
 
@@ -51,12 +51,12 @@ helm install --devel beskar7 beskar7/beskar7 \
   --namespace beskar7-system --create-namespace
 ```
 
-The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.4`); drop it once a non-prerelease tag is cut.
+The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.5`); drop it once a non-prerelease tag is cut.
 
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.4/beskar7-manifests-v0.4.0-alpha.4.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.5/beskar7-manifests-v0.4.0-alpha.5.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0-alpha.4
-appVersion: "v0.4.0-alpha.4"
+version: 0.4.0-alpha.5
+appVersion: "v0.4.0-alpha.5"
 keywords:
   - cluster-api
   - infrastructure

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -273,8 +273,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.0-alpha.N`; bump N for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.0-alpha.4
-   git push origin v0.4.0-alpha.4
+   git tag v0.4.0-alpha.5
+   git push origin v0.4.0-alpha.5
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.4`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.5`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ The `bootstrap.urlBase` value is rendered into `PhysicalHost.Status.Bootstrap.UR
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.4/beskar7-manifests-v0.4.0-alpha.4.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.5/beskar7-manifests-v0.4.0-alpha.5.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -171,7 +171,7 @@ Memory Limit = (Host Count × 0.5MB) + (Webhook Concurrency × 10MB) + 100MB (ba
 Configure reconciliation intervals based on your needs:
 
 ```yaml
-# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.4.4.
+# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.5.
 args:
 - --leader-elect=true
 - --metrics-bind-address=:8443
@@ -179,6 +179,9 @@ args:
 - --health-probe-bind-address=:8081
 - --inspection-port=8082
 - --bootstrap-url-base=https://beskar7-controller-manager.beskar7-system.svc:8082
+# Optional: scope informers to specific namespaces (SEC-2 / watched-namespaces mode).
+# Empty (default) watches all namespaces. See docs/security/rbac-hardening.md.
+- --watch-namespaces=
 ```
 
 There is no `--max-concurrent-reconciles*` or `--reconciliation-interval` flag; the controller-runtime defaults apply (one reconciler per controller; per-resource requeue intervals encoded in the controllers themselves). Per-controller concurrency would have to be raised in code in `controllers/<kind>_controller.go:SetupWithManager`.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Operators
 
-This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.4. Each item is anchored to source code so you can verify the claim.
+This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.5. Each item is anchored to source code so you can verify the claim.
 
 If you are looking for hardening recommendations, see [Configuration](configuration.md). For RBAC details, see [RBAC Hardening](rbac-hardening.md). For incident debugging, see [Troubleshooting](troubleshooting.md).
 

--- a/examples/complete-cluster.md
+++ b/examples/complete-cluster.md
@@ -1,6 +1,6 @@
 # Complete Cluster Deployment Example
 
-This walkthrough deploys a 1-control-plane + 2-worker Kubernetes cluster on bare metal using Beskar7 v0.4.0-alpha.4. The accompanying YAML is [`complete-cluster.yaml`](complete-cluster.yaml).
+This walkthrough deploys a 1-control-plane + 2-worker Kubernetes cluster on bare metal using Beskar7 v0.4.0-alpha.5. The accompanying YAML is [`complete-cluster.yaml`](complete-cluster.yaml).
 
 ## Prerequisites
 

--- a/examples/complete-cluster.yaml
+++ b/examples/complete-cluster.yaml
@@ -1,5 +1,5 @@
 # Complete Beskar7 Cluster Example
-# Deploys a 1 control-plane + 2 worker cluster using Beskar7 v0.4.0-alpha.4.
+# Deploys a 1 control-plane + 2 worker cluster using Beskar7 v0.4.0-alpha.5.
 #
 # Prerequisites:
 #   1. Beskar7 controller is installed (Helm or release manifests).

--- a/examples/minimal-test-cluster.yaml
+++ b/examples/minimal-test-cluster.yaml
@@ -1,6 +1,6 @@
 # Minimal Test Cluster Example
 #
-# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.4
+# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.5
 # inspection workflow. NOT a working cluster — bring this up first to verify the
 # inspection round-trip, then graduate to examples/complete-cluster.yaml.
 #

--- a/examples/security/README.md
+++ b/examples/security/README.md
@@ -1,6 +1,6 @@
 # Beskar7 Security Examples
 
-Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.4 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
+Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.5 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
 
 ## What's actually enforced
 

--- a/examples/security/development.yaml
+++ b/examples/security/development.yaml
@@ -1,4 +1,4 @@
-# Development-style security configuration for Beskar7 v0.4.0-alpha.4.
+# Development-style security configuration for Beskar7 v0.4.0-alpha.5.
 #
 # Loosens TLS verification for self-signed BMC certs typical in lab setups.
 # Do NOT use this configuration in production.

--- a/examples/security/production.yaml
+++ b/examples/security/production.yaml
@@ -1,4 +1,4 @@
-# Production-style security configuration for Beskar7 v0.4.0-alpha.4.
+# Production-style security configuration for Beskar7 v0.4.0-alpha.5.
 #
 # This file demonstrates the enforced security knobs only — the
 # beskar7-security-policy ConfigMap and the various "security framework"


### PR DESCRIPTION
## Summary

Cuts **v0.4.0-alpha.5**. CHANGELOG entry + version-string bumps across the repo. After merge, tag with \`git tag v0.4.0-alpha.5 && git push origin v0.4.0-alpha.5\` to fire the helm-publish + release workflows.

## CHANGELOG: the alpha.5 entry covers 13 PRs in four themes

| Theme | PRs | Outcome |
|---|---|---|
| **SEC-2 closure** | #80, #82, #83, #84 | \`--watch-namespaces\` flag + chart per-namespace RBAC + kustomize overlay + docs/security rewrite |
| **Metric surface alignment** | #75, #76 | 10 broken/redundant helpers deleted; 9 kept helpers wired; state-gauge API refactored to per-reconcile Set; \`RecordError\` extended to all 3 controllers |
| **Correctness fixes** | #72 (BUG-13), #73 (BUG-12), #74 (BUG-14) | Deprecated state aliases removed; \`errorType\` param removed; PhysicalHost reconcile gains exponential backoff |
| **Hygiene / housekeeping** | #77 (LINT-1), #78 (REL-1), #79 (REFACTOR-1), #81 (REL-2) | \`make lint\` target; Chart.yaml bump; control-plane label constant; emoji-heading strip |

## Version-string bumps

| File | Change |
|---|---|
| \`Makefile\` | \`VERSION ?= v0.4.0-alpha.5\` |
| \`charts/beskar7/Chart.yaml\` | \`version\` + \`appVersion\` to \`v0.4.0-alpha.5\` |
| \`README.md\` | Current-status line + helm-install \`--devel\` note + release-manifest URL |
| \`docs/installation.md\` | Release-manifest URL |
| \`docs/development-setup.md\` | IMG default |
| \`docs/ci-cd-and-testing.md\` | Release-tag example in Release Process |
| \`docs/resource-planning.md\` | Typo fix (\`alpha.4.4\` → \`alpha.5\`) + new \`--watch-namespaces\` flag added to listed manager args |
| \`docs/security/README.md\` | \"What alpha.* enforces\" preamble |
| \`examples/{complete-cluster,minimal-test-cluster}.yaml\` + \`.md\` | Header comments |
| \`examples/security/{README,development,production}.{md,yaml}\` | Header comments |

## Held back

- \`docs/beskar7cluster.md:37\` — references \"the gap fixed in v0.4.0-alpha.4\". Historical, correct as-is.
- CHANGELOG.md per-tag entries below \`[v0.4.0-alpha.5]\` are untouched.

## Validation

- [x] \`go build ./...\` clean
- [x] \`helm template ./charts/beskar7\` renders 10 resources (default mode), all version labels show \`v0.4.0-alpha.5\`
- [x] \`kustomize build config/default/\` renders 20 resources cleanly
- [x] CHANGELOG compare-URL footer updated: new \`[v0.4.0-alpha.5]: compare/v0.4.0-alpha.4...v0.4.0-alpha.5\` entry, \`[Unreleased]\` retargeted

## Post-merge steps

\`\`\`bash
git checkout main && git pull
git tag v0.4.0-alpha.5
git push origin v0.4.0-alpha.5
\`\`\`

The \`helm-publish.yml\` workflow takes over (auto-rewrites Chart.yaml + values.yaml image tag at publish time, packages the chart, updates gh-pages). \`release.yml\` builds container images + the release manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)