### PR TITLE
controllers: honor pause annotation in PhysicalHost reconciler (GAP-1)

### DIFF
--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -126,6 +126,17 @@ func (r *PhysicalHostReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// add, pause). A List error here is non-fatal — the metric is best-effort.
 	r.recomputePhysicalHostMetrics(ctx, logger, req.Namespace)
 
+	// Respect the cluster.x-k8s.io/paused annotation. PhysicalHost is standalone
+	// inventory with no owner Cluster, so only the resource-level annotation
+	// applies (there is no cluster-pause to inherit). Returning before the patch
+	// helper is set up means a paused host is left completely untouched — no
+	// finalizer add, no Redfish I/O, no status write. Reconciliation resumes on
+	// the next event after the annotation is removed.
+	if isPaused(physicalHost) {
+		logger.Info("PhysicalHost reconciliation is paused")
+		return ctrl.Result{}, nil
+	}
+
 	// Initialize patch helper. A single deferred Patch replaces both r.Update (finalizer)
 	// and r.Status().Update calls — controller-runtime merges spec and status in one round-trip.
 	patchHelper, err := patch.NewHelper(physicalHost, r.Client)

--- a/controllers/physicalhost_controller_test.go
+++ b/controllers/physicalhost_controller_test.go
@@ -741,15 +741,12 @@ var _ = Describe("PhysicalHost Controller", func() {
 			Expect(k8sClient.Delete(ctx, testNs)).To(Succeed())
 		})
 
-		// FEATURE GAP: PhysicalHostReconciler does not call isPaused on the
-		// resource. Beskar7Machine and Beskar7Cluster reconcilers do honor the
-		// pause annotation; PhysicalHost does not. This is a deliberate gap
-		// — claim/release lifecycle continues independent of the cluster's
-		// paused state because the BMC is shared infrastructure, not a
-		// workload-cluster-scoped resource. If pause becomes a requirement
-		// (e.g. for maintenance windows), wire isPaused into Reconcile and
-		// convert these specs to real It blocks.
-		PIt("[FEATURE GAP - PhysicalHost pause not implemented] Should skip reconciliation when paused", func() {
+		// PhysicalHostReconciler honors the cluster.x-k8s.io/paused annotation on
+		// the resource itself (GAP-1 / #87). PhysicalHost is standalone inventory
+		// with no owner Cluster, so only the resource-level annotation applies —
+		// there is no cluster-pause to inherit. A paused host is left completely
+		// untouched: no finalizer add, no Redfish I/O, no status write.
+		It("Should skip reconciliation when paused", func() {
 			By("Creating paused PhysicalHost")
 			physicalHost.Annotations = map[string]string{
 				clusterv1.PausedAnnotation: "true",
@@ -768,9 +765,7 @@ var _ = Describe("PhysicalHost Controller", func() {
 			Expect(mockRfClient.GetPowerStateCalled).To(BeFalse())
 		})
 
-		// FEATURE GAP — see preceding spec for rationale. If pause is wired
-		// into PhysicalHostReconciler.Reconcile, convert this to a real It.
-		PIt("[FEATURE GAP - PhysicalHost pause not implemented] Should resume when pause annotation is removed", func() {
+		It("Should resume when pause annotation is removed", func() {
 			By("Creating paused PhysicalHost")
 			physicalHost.Annotations = map[string]string{
 				clusterv1.PausedAnnotation: "true",


### PR DESCRIPTION
## Summary

Closes **#87** (GAP-1). `PhysicalHostReconciler.Reconcile` ignored the `cluster.x-k8s.io/paused` annotation — `Beskar7Machine` and `Beskar7Cluster` reconcilers both honor it, but `PhysicalHost` did not. CLAUDE.md lists pause handling as non-negotiable CAPI conformance.

## What changed

- Added an `isPaused(physicalHost)` check in `Reconcile`, placed after the metric recompute and **before** the patch-helper setup. A paused host is left completely untouched: no finalizer add, no Redfish I/O, no status write. Reconciliation resumes on the next event after the annotation is removed.
- **Resource-level only**: PhysicalHost is standalone inventory with no owner Cluster, so there's no cluster-pause to inherit (no `isClusterPaused` call, unlike the machine/cluster reconcilers).

## Tests

Converted the two parked specs in `physicalhost_controller_test.go` from `PIt` → `It`:

| Spec | Asserts |
|---|---|
| "Should skip reconciliation when paused" | `Reconcile` returns `ctrl.Result{}`, no Redfish calls (`GetSystemInfoCalled` / `GetPowerStateCalled` both false) |
| "Should resume when pause annotation is removed" | resumed reconcile returns `Requeue=true`, finalizer is added |

The stale `[FEATURE GAP - PhysicalHost pause not implemented]` comments (which argued the gap was deliberate) are replaced with the implemented behavior's rationale.

## Placement rationale

The check returns before the patch helper so a paused host gets zero writes. This matches the test expectation that a paused reconcile returns exactly `ctrl.Result{}` and that the finalizer only appears *after* unpause (the first post-unpause reconcile returns `Requeue=true` to persist it).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [x] `go test -race -run TestAPIs ./controllers/...` passes (16.4s) with both pause specs active
- [x] Zero `PIt` blocks remain in `physicalhost_controller_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)