### PR TITLE
chart: self-signed webhook cert path when certManager.enabled=false (GAP-2)

### DIFF
--- a/charts/beskar7/README.md
+++ b/charts/beskar7/README.md
@@ -10,14 +10,31 @@ Beskar7 provisions bare-metal Kubernetes nodes via Redfish power management, iPX
 
 - Kubernetes v1.31+ ([docs](https://kubernetes.io/docs/setup/))
 - Cluster API v1.10+ ([install with clusterctl](https://cluster-api.sigs.k8s.io/user/quick-start.html))
-- cert-manager v1.16+ ([installation guide](https://cert-manager.io/docs/installation/))
+- cert-manager v1.16+ ([installation guide](https://cert-manager.io/docs/installation/)) — **recommended but optional** (see TLS section below)
 
-Install cert-manager before installing this chart:
+### TLS certificates
 
-```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.crds.yaml
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
-```
+The webhook server and the inspection/bootstrap callback server both need a
+serving certificate. Two modes:
+
+- **`certManager.enabled=true` (default)** — cert-manager issues the cert and
+  injects the CA into the webhook configs. Install cert-manager first:
+
+  ```bash
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.crds.yaml
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
+  ```
+
+- **`certManager.enabled=false`** — the chart self-generates a self-signed
+  serving cert and writes the matching CA into the webhook `caBundle`. No
+  cert-manager required. The cert is reused across upgrades and valid 10 years.
+  Use this on clusters where you don't run cert-manager:
+
+  ```bash
+  helm install --devel beskar7 beskar7/beskar7 \
+    --namespace beskar7-system --create-namespace \
+    --set certManager.enabled=false
+  ```
 
 ## Installation
 
@@ -78,7 +95,7 @@ All configurable values with their defaults:
 | `webhook.matchPolicy` | `Equivalent` | Webhook match policy. |
 | `webhook.service.port` | `443` | Port the webhook Service exposes. |
 | `webhook.service.targetPort` | `9443` | Container port the webhook handler listens on. |
-| `certManager.enabled` | `true` | Use cert-manager to issue the TLS certificate for the webhook and callback server. |
+| `certManager.enabled` | `true` | `true`: cert-manager issues the TLS cert + injects the webhook caBundle. `false`: the chart self-generates a self-signed cert and writes the caBundle directly (no cert-manager dependency). |
 | `certManager.issuer.name` | `beskar7-selfsigned-issuer` | cert-manager Issuer or ClusterIssuer name. |
 | `certManager.issuer.kind` | `ClusterIssuer` | Kind of the cert-manager issuer (`Issuer` or `ClusterIssuer`). |
 | `certManager.certificate.name` | `beskar7-serving-cert` | Name of the cert-manager Certificate resource. |

--- a/charts/beskar7/templates/_helpers.tpl
+++ b/charts/beskar7/templates/_helpers.tpl
@@ -85,3 +85,49 @@ Create the controller manager image
 {{- printf "%s:%s" $repository $tag }}
 {{- end }}
 
+{{/*
+Self-signed webhook serving certificate (used when certManager.enabled=false).
+
+Populates a memoized dict at $._beskar7WebhookCerts with base64-encoded
+{crt, key, ca} so the Secret template (selfsigned-cert.yaml) and the webhook
+configuration template (webhook-configuration.yaml) reference the SAME cert +
+CA within a single render. Generating per-file would produce mismatched CAs
+and the apiserver would reject the webhook.
+
+Resolution order:
+  1. Reuse an existing Secret of the same name (via lookup) so the cert is
+     stable across `helm upgrade` and so an operator-provisioned cert is
+     honored. caBundle uses ca.crt when present, else falls back to tls.crt
+     (a self-signed leaf verifies itself).
+  2. Otherwise generate a fresh self-signed CA + leaf covering the webhook
+     Service DNS name, valid 10 years.
+
+During `helm template` / `--dry-run` (no cluster) the lookup returns empty
+and a fresh cert is generated each render — fine for inspection; the real
+install/upgrade path hits the cluster and is stable.
+*/}}
+{{- define "beskar7.webhookCerts" -}}
+{{- if not (hasKey . "_beskar7WebhookCerts") -}}
+  {{- $ns := include "beskar7.namespace" . -}}
+  {{- $secretName := .Values.certManager.certificate.secretName -}}
+  {{- $svc := .Values.webhook.service.name -}}
+  {{- $cn := printf "%s.%s.svc" $svc $ns -}}
+  {{- $existing := (lookup "v1" "Secret" $ns $secretName) -}}
+  {{- $data := dict -}}
+  {{- if $existing -}}
+    {{- $data = ($existing.data | default dict) -}}
+  {{- end -}}
+  {{- $certs := dict -}}
+  {{- if and (hasKey $data "tls.crt") (hasKey $data "tls.key") -}}
+    {{- $ca := index $data "tls.crt" -}}
+    {{- if hasKey $data "ca.crt" -}}{{- $ca = index $data "ca.crt" -}}{{- end -}}
+    {{- $certs = dict "crt" (index $data "tls.crt") "key" (index $data "tls.key") "ca" $ca -}}
+  {{- else -}}
+    {{- $caCert := genCA (printf "%s-ca" $svc) 3650 -}}
+    {{- $cert := genSignedCert $cn nil (list $cn) 3650 $caCert -}}
+    {{- $certs = dict "crt" (b64enc $cert.Cert) "key" (b64enc $cert.Key) "ca" (b64enc $caCert.Cert) -}}
+  {{- end -}}
+  {{- $_ := set . "_beskar7WebhookCerts" $certs -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/beskar7/templates/deployment.yaml
+++ b/charts/beskar7/templates/deployment.yaml
@@ -70,8 +70,10 @@ spec:
           {{- toYaml .Values.securityContext | nindent 10 }}
         # The cert volume is mounted unconditionally because the callback server
         # (inspection POST + bootstrap GET on :8082) requires TLS regardless of
-        # whether webhook admission is enabled. Both servers share the same cert
-        # issued by cert-manager. Operators must have certManager.enabled=true.
+        # whether webhook admission is enabled. Both servers share the same cert.
+        # When certManager.enabled=true the cert is issued by cert-manager; when
+        # false the chart self-generates it (templates/selfsigned-cert.yaml) into
+        # the same Secret name, so this mount works in both modes.
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/charts/beskar7/templates/selfsigned-cert.yaml
+++ b/charts/beskar7/templates/selfsigned-cert.yaml
@@ -1,0 +1,24 @@
+{{- if not .Values.certManager.enabled }}
+{{- /*
+When cert-manager is disabled, the chart generates a self-signed serving
+certificate itself (see the beskar7.webhookCerts helper) and renders it into
+the same Secret name the Deployment mounts. This makes certManager.enabled=false
+a fully working mode: the callback server (:8082) and the webhook server (:9443)
+both get TLS, and the webhook configurations get a matching caBundle.
+
+The Secret is reused across upgrades via lookup, so the cert is stable.
+*/ -}}
+{{- include "beskar7.webhookCerts" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.certManager.certificate.secretName }}
+  namespace: {{ include "beskar7.namespace" . }}
+  labels:
+    {{- include "beskar7.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ ._beskar7WebhookCerts.crt }}
+  tls.key: {{ ._beskar7WebhookCerts.key }}
+  ca.crt: {{ ._beskar7WebhookCerts.ca }}
+{{- end }}

--- a/charts/beskar7/templates/webhook-configuration.yaml
+++ b/charts/beskar7/templates/webhook-configuration.yaml
@@ -1,18 +1,35 @@
 {{- if .Values.webhook.enabled }}
+{{- /*
+caBundle / CA-injection strategy:
+  - certManager.enabled=true  → cert-manager's CA injector populates caBundle
+    from the named Certificate via the cert-manager.io/inject-ca-from
+    annotation (the historical path).
+  - certManager.enabled=false → the chart self-generates the serving cert
+    (beskar7.webhookCerts helper) and writes the matching CA into caBundle
+    directly. No annotation, no cert-manager dependency.
+*/ -}}
+{{- if not .Values.certManager.enabled }}
+{{- include "beskar7.webhookCerts" . -}}
+{{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "beskar7.fullname" . }}-mutating-webhook-configuration
+  {{- if .Values.certManager.enabled }}
   annotations:
     # cert-manager injects the CA bundle from the named Certificate's secret.
     cert-manager.io/inject-ca-from: {{ printf "%s/%s" (include "beskar7.namespace" .) .Values.certManager.certificate.name }}
+  {{- end }}
   labels:
     {{- include "beskar7.labels" . | nindent 4 }}
 webhooks:
 - admissionReviewVersions:
     {{- toYaml .Values.webhook.admissionReviewVersions | nindent 4 }}
   clientConfig:
+    {{- if not .Values.certManager.enabled }}
+    caBundle: {{ ._beskar7WebhookCerts.ca }}
+    {{- end }}
     service:
       name: {{ .Values.webhook.service.name }}
       namespace: {{ include "beskar7.namespace" . }}
@@ -37,15 +54,20 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "beskar7.fullname" . }}-validating-webhook-configuration
+  {{- if .Values.certManager.enabled }}
   annotations:
     # cert-manager injects the CA bundle from the named Certificate's secret.
     cert-manager.io/inject-ca-from: {{ printf "%s/%s" (include "beskar7.namespace" .) .Values.certManager.certificate.name }}
+  {{- end }}
   labels:
     {{- include "beskar7.labels" . | nindent 4 }}
 webhooks:
 - admissionReviewVersions:
     {{- toYaml .Values.webhook.admissionReviewVersions | nindent 4 }}
   clientConfig:
+    {{- if not .Values.certManager.enabled }}
+    caBundle: {{ ._beskar7WebhookCerts.ca }}
+    {{- end }}
     service:
       name: {{ .Values.webhook.service.name }}
       namespace: {{ include "beskar7.namespace" . }}

--- a/charts/beskar7/values.yaml
+++ b/charts/beskar7/values.yaml
@@ -75,7 +75,19 @@ webhook:
     port: 443
     targetPort: 9443
 
-# Certificate manager configuration
+# Certificate configuration for the webhook + callback server TLS.
+#
+# enabled: true (default) — cert-manager issues the serving cert (Certificate +
+#   ClusterIssuer) and injects the CA bundle into the webhook configs via the
+#   cert-manager.io/inject-ca-from annotation. Requires cert-manager in the
+#   cluster.
+# enabled: false — the chart self-generates a self-signed serving cert
+#   (templates/selfsigned-cert.yaml) into the Secret named below and writes the
+#   matching CA directly into the webhook caBundle. No cert-manager dependency.
+#   The cert is reused across upgrades (looked up by Secret name) and is valid
+#   10 years. Use this on clusters without cert-manager.
+#
+# Either way the Deployment mounts the Secret named `certificate.secretName`.
 certManager:
   enabled: true
   issuer:


### PR DESCRIPTION
## Summary

Closes **#88** (GAP-2). Makes `certManager.enabled=false` a fully working install mode via a Helm-native self-signed cert.

## The bug

With `certManager.enabled=false`, two things broke on a cluster without cert-manager:

1. **No serving-cert Secret** was created (Certificate/Issuer are gated on `certManager.enabled`), but the Deployment mounts that Secret **unconditionally** — the callback server on `:8082` needs TLS regardless of webhook admission. The pod couldn't start unless the operator hand-provisioned the Secret.
2. The webhook configs carried only the `cert-manager.io/inject-ca-from` annotation, so `caBundle` stayed empty and admission failed with `x509: certificate signed by unknown authority` — exactly what the v0.4.0-alpha.5 smoke test hit at layer 4.

## The fix

- **`_helpers.tpl`** — new memoized `beskar7.webhookCerts` helper. Resolves the cert once per render and caches it on the root context so the Secret template and **both** webhook configs share the same CA (per-file generation would mismatch → apiserver rejects). Reuses an existing Secret via `lookup` for upgrade stability and to honor an operator-supplied cert; otherwise generates a self-signed CA + leaf covering the webhook Service DNS, valid 10 years.
- **`templates/selfsigned-cert.yaml`** (new) — renders a `kubernetes.io/tls` Secret from the helper. Only when `!certManager.enabled`.
- **`templates/webhook-configuration.yaml`** — when `!certManager.enabled`, drop the cert-manager annotation and set `clientConfig.caBundle` from the helper on both Mutating + Validating configs. cert-manager path unchanged.
- **`deployment.yaml`** / **`values.yaml`** / **`README.md`** — comment + doc updates; cert-manager is now "recommended but optional" with a worked `--set certManager.enabled=false` example.

## Default mode unchanged

`certManager.enabled=true` renders byte-equivalent output to before (Certificate + ClusterIssuer + `inject-ca-from` annotation, no caBundle, no self-signed Secret). Existing installs see no diff.

## Validation

| Check | Result |
|---|---|
| `helm lint` | clean |
| `helm template` (default) | Certificate + annotation, no caBundle, no self-signed Secret |
| `helm template --set certManager.enabled=false` | self-signed Secret + **identical** caBundle on both webhook configs (proves memoization shares one CA) |
| Real install, cert-manager-LESS cluster, `certManager.enabled=false` | pod Ready, chart-generated Secret present, caBundle populated |
| `make smoke` | **all 5 layers PASS** — layer 4 (the x509 failure before this fix) now succeeds |
| `openssl verify -CAfile <caBundle> <serving-cert>` | OK |
| Serving cert SAN | `DNS:beskar7-webhook-service.beskar7-system.svc` (matches the Service the apiserver dials) |

## Test plan

- [x] helm lint + helm template both modes
- [x] Real install on a cluster without cert-manager
- [x] Full smoke test passes (the exact scenario #88 reported)
- [x] openssl chain + SAN verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)