### PR TITLE
controllers: expose inspection timeout as --inspection-timeout flag (#91)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -80,6 +80,7 @@ func main() {
 	var inspectionPort int
 	var inspectionCertDir string
 	var watchNamespacesRaw string
+	var inspectionTimeout time.Duration
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -117,6 +118,10 @@ func main() {
 			"per-namespace Role/RoleBinding to tighten Secret RBAC (SEC-2). RBAC and "+
 			"chart-side per-namespace bindings ship in follow-up PRs; this flag alone "+
 			"only narrows the cache.")
+	flag.DurationVar(&inspectionTimeout, "inspection-timeout", controllers.DefaultInspectionTimeout,
+		"How long a host may stay in the Inspecting phase before the Beskar7Machine is "+
+			"marked terminally failed (InspectionTimedOut). Raise this for hardware with "+
+			"slow BIOS POST or slow first-boot inspection.")
 
 	// Default to production-safe zap config: structured JSON output, no stack
 	// traces below Error, level-based encoding. Operators who want
@@ -188,10 +193,11 @@ func main() {
 	// RedfishClientFactory is intentionally omitted; SetupWithManager defaults it to
 	// internalredfish.NewClient and returns an error if it remains nil after defaulting.
 	if err = (&controllers.Beskar7MachineReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		Log:              ctrl.Log.WithName("controllers").WithName("Beskar7Machine"),
-		BootstrapURLBase: bootstrapURLBase,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Log:               ctrl.Log.WithName("controllers").WithName("Beskar7Machine"),
+		BootstrapURLBase:  bootstrapURLBase,
+		InspectionTimeout: inspectionTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Beskar7Machine")
 		os.Exit(1)

--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -83,6 +83,21 @@ type Beskar7MachineReconciler struct {
 	// <BootstrapURLBase>/api/v1/bootstrap/<namespace>/<name>. Must be non-empty;
 	// validated in SetupWithManager.
 	BootstrapURLBase string
+	// InspectionTimeout bounds how long a host may stay in Inspecting before the
+	// machine is marked terminally failed (InspectionTimedOut). Zero means use
+	// DefaultInspectionTimeout. Set from the --inspection-timeout manager flag so
+	// operators with slow-POST hardware can raise it.
+	InspectionTimeout time.Duration
+}
+
+// inspectionTimeout returns the configured inspection timeout, falling back to
+// DefaultInspectionTimeout when unset (zero). Guards against a zero-value field
+// that would otherwise time out every inspection instantly.
+func (r *Beskar7MachineReconciler) inspectionTimeout() time.Duration {
+	if r.InspectionTimeout > 0 {
+		return r.InspectionTimeout
+	}
+	return DefaultInspectionTimeout
 }
 
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=beskar7machines,verbs=get;list;watch;create;update;patch;delete
@@ -569,16 +584,17 @@ func (r *Beskar7MachineReconciler) handleInspectingHost(ctx context.Context, log
 	// misconfiguration or unreachable callback endpoint) and either
 	// delete-and-recreate the Beskar7Machine or fix the iPXE setup.
 	if physicalHost.Status.InspectionTimestamp != nil {
+		timeout := r.inspectionTimeout()
 		elapsed := time.Since(physicalHost.Status.InspectionTimestamp.Time)
-		if elapsed > DefaultInspectionTimeout {
-			logger.Info("Inspection timed out (terminal)", "elapsed", elapsed, "timeout", DefaultInspectionTimeout)
+		if elapsed > timeout {
+			logger.Info("Inspection timed out (terminal)", "elapsed", elapsed, "timeout", timeout)
 			// Best-effort signal to the PhysicalHost controller. Don't block the
 			// terminal marking on the annotation patch — the PhysicalHost catches
 			// up on its next reconcile regardless.
 			if err := r.setInspectionRequestAnnotation(ctx, logger, physicalHost, "timeout"); err != nil {
 				logger.Error(err, "Failed to set inspection timeout annotation")
 			}
-			msg := fmt.Sprintf("Inspection did not complete within %s", DefaultInspectionTimeout)
+			msg := fmt.Sprintf("Inspection did not complete within %s", timeout)
 			r.markTerminalFailure(b7machine, infrastructurev1beta1.InspectionTimedOutReason, msg)
 			return ctrl.Result{}, nil
 		}

--- a/controllers/inspection_timeout_test.go
+++ b/controllers/inspection_timeout_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInspectionTimeoutResolver(t *testing.T) {
+	cases := []struct {
+		name string
+		set  time.Duration
+		want time.Duration
+	}{
+		{
+			name: "zero falls back to the default",
+			set:  0,
+			want: DefaultInspectionTimeout,
+		},
+		{
+			name: "negative falls back to the default",
+			set:  -5 * time.Minute,
+			want: DefaultInspectionTimeout,
+		},
+		{
+			name: "positive value is honored",
+			set:  30 * time.Minute,
+			want: 30 * time.Minute,
+		},
+		{
+			name: "small positive value is honored",
+			set:  1 * time.Second,
+			want: 1 * time.Second,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Beskar7MachineReconciler{InspectionTimeout: tc.set}
+			if got := r.inspectionTimeout(); got != tc.want {
+				t.Errorf("inspectionTimeout() with InspectionTimeout=%v = %v, want %v", tc.set, got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/beskar7machine.md
+++ b/docs/beskar7machine.md
@@ -47,7 +47,7 @@ The reconciler runs through these phases. Each phase corresponds to a state of t
     - `SetBootSourcePXE` then `SetPowerState(On)` if not already powered on.
     - Mint a per-host bearer token unless an unexpired one is already in `Status.Bootstrap` (re-using avoids invalidating in-flight kernel cmdlines). The plaintext goes into a per-host Secret (`<host>-bootstrap-token`); only the SHA-256 hash and lifetime ride the `bootstrap-token` annotation. See `internal/auth/token.go` and decision D-004.
     - Patch the `inspection-request` annotation on the host with value `inspect`. The host reconciler transitions to `Inspecting`.
-6. **Wait for inspection.** While the host is `Inspecting`, monitor `Status.InspectionPhase`. If `Status.InspectionTimestamp` is older than `DefaultInspectionTimeout` (10 minutes), call `markTerminalFailure(InspectionTimedOut, ...)` and stop. Inspection timeout is terminal — the operator must investigate (likely an iPXE misconfiguration) and delete-and-recreate.
+6. **Wait for inspection.** While the host is `Inspecting`, monitor `Status.InspectionPhase`. If `Status.InspectionTimestamp` is older than the inspection timeout (default 10 minutes; override with the `--inspection-timeout` manager flag for slow-POST hardware), call `markTerminalFailure(InspectionTimedOut, ...)` and stop. Inspection timeout is terminal — the operator must investigate (likely an iPXE misconfiguration) and delete-and-recreate.
 7. **Validate hardware.** When `Status.InspectionPhase == Complete`, sum CPU cores across `report.cpus[]`, parse memory across `report.memory[]` (using the `parseMemoryCapacityGB` helper for `GB`/`GiB`/`MB`/`MiB`/`TB`/`TiB` suffixes), and sum disk size across `report.disks[]`. If any minimum is violated, call `markTerminalFailure(HardwareRequirementsNotMet, ...)`. Hardware-validation failures are terminal — the BMC's hardware does not change at runtime.
 8. **Mark ready.** When validation passes, signal the host (`inspection-request: inspect-complete`) which moves the host to `Ready`. The Beskar7Machine then sets `Spec.ProviderID = b7://<ns>/<name>`, copies addresses from the host, sets `InfrastructureReady=True`, `Status.Ready=true`, and `Status.Initialization.Provisioned=true` (the CAPI v1beta2 contract field that CAPI core lifts into `Machine.status.initialization.infrastructureProvisioned` and uses to advance the parent Machine past `Pending`).
 
@@ -68,7 +68,7 @@ These set `Status.FailureReason` and `Status.FailureMessage`. Once set, the cont
 |---|---|
 | `BootstrapDataUnavailable` | The Secret named by `Machine.Spec.Bootstrap.DataSecretName` does not exist. |
 | `HardwareRequirementsNotMet` | Inspection report falls below `hardwareRequirements`. |
-| `InspectionTimedOut` | No inspection report received within `DefaultInspectionTimeout` (10 min). |
+| `InspectionTimedOut` | No inspection report received within the inspection timeout (default 10 min; `--inspection-timeout` flag). |
 
 To recover, delete the Beskar7Machine (and its owner `Machine`); the host returns to `Available` and a fresh attempt can be made.
 

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -182,6 +182,9 @@ args:
 # Optional: scope informers to specific namespaces (SEC-2 / watched-namespaces mode).
 # Empty (default) watches all namespaces. See docs/security/rbac-hardening.md.
 - --watch-namespaces=
+# Optional: how long a host may stay Inspecting before InspectionTimedOut.
+# Default 10m; raise for hardware with slow BIOS POST / slow first-boot inspection.
+- --inspection-timeout=10m
 ```
 
 There is no `--max-concurrent-reconciles*` or `--reconciliation-interval` flag; the controller-runtime defaults apply (one reconciler per controller; per-resource requeue intervals encoded in the controllers themselves). Per-controller concurrency would have to be raised in code in `controllers/<kind>_controller.go:SetupWithManager`.


### PR DESCRIPTION
## Summary

Closes **#91**. `DefaultInspectionTimeout` was hardcoded at 10m and used in the `InspectionTimedOut` terminal-failure path. Hardware with slow BIOS POST or slow first-boot inspection can legitimately exceed 10m; operators had no way to raise it without recompiling.

## What changed

- `Beskar7MachineReconciler` gains an `InspectionTimeout time.Duration` field + an `inspectionTimeout()` resolver that returns it when `> 0`, else falls back to `DefaultInspectionTimeout` (guards against a zero-value field timing out every inspection instantly).
- New `--inspection-timeout` manager flag (default `DefaultInspectionTimeout`), wired onto the reconciler in `cmd/manager/main.go`.
- The terminal-timeout check uses `r.inspectionTimeout()` instead of the bare const.

## Why this and not #90 (redfish-call-timeout)

The inspection timeout is a **user-facing provisioning SLA** that genuinely varies by hardware (how long to wait for a server to POST + network-boot + run the inspector). The Redfish HTTP call timeout (#90) is an **internal transport detail** where 30s is always enough for a single API call. Different in kind — this one earns a flag; #90 is being closed as won't-do.

## Tests

- New `TestInspectionTimeoutResolver` (table: zero/negative → default, positive → honored).
- Existing envtest timeout spec still passes against the default.
- `go build` / `go vet` / `make lint` clean.

## Docs

- `docs/beskar7machine.md` — reconcile step 6 + terminal-failure table now mention the flag.
- `docs/resource-planning.md` — added `--inspection-timeout=10m` to the manager flag list.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -run TestInspectionTimeoutResolver ./controllers/...`
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)