### PR TITLE
docs: scrub fictional performance-tuning flags/env vars (#89)

### DIFF
--- a/docs/deployment-best-practices.md
+++ b/docs/deployment-best-practices.md
@@ -722,40 +722,41 @@ spec:
 
 ### 1. Controller Tuning
 
-**Performance Configuration:**
+The manager exposes leader-election timing flags for HA tuning. The full set
+of real flags is enumerated in [Resource Planning → Performance Tuning](resource-planning.md#performance-tuning);
+the performance-relevant ones are:
+
 ```yaml
-# Manager args for high-scale deployments
+# Real manager args (see cmd/manager/main.go).
 args:
-- --concurrent-reconciles=10
-- --max-concurrent-reconciles=20
-- --worker-count=5
-- --resync-period=5m
-- --leader-elect-lease-duration=30s
-- --leader-elect-renew-deadline=20s
+- --leader-elect=true
+- --leader-elect-lease-duration=15s   # default 15s
+- --leader-elect-renew-deadline=10s   # default 10s
+- --leader-elect-retry-period=2s      # default 2s
+- --inspection-timeout=10m            # raise for slow-POST hardware
 ```
 
-### 2. Caching Strategy
+There is **no** `--concurrent-reconciles`, `--max-concurrent-reconciles`,
+`--worker-count`, or `--resync-period` flag. Each controller runs with
+controller-runtime's default `MaxConcurrentReconciles = 1`. Raising
+per-controller concurrency is a code change in
+`controllers/<kind>_controller.go:SetupWithManager`, not configuration — open
+an issue with your scaling profile if the serial default is a real constraint.
 
-**Informer Cache Configuration:**
-```yaml
-# Configure informer resync periods
-env:
-- name: CONTROLLER_RESYNC_PERIOD
-  value: "5m"
-- name: CACHE_SYNC_TIMEOUT
-  value: "30s"
-```
+### 2. Caching and rate limiting
 
-### 3. Rate Limiting
+The informer cache and API client use controller-runtime defaults. There are
+**no** `CONTROLLER_RESYNC_PERIOD`, `CACHE_SYNC_TIMEOUT`, `QPS_LIMIT`, or
+`BURST_LIMIT` environment variables — the manager does not read them. The cache
+resync period (controller-runtime default 10h) and client QPS/burst are not
+currently exposed as configuration. To scope the cache to specific namespaces
+(which reduces memory and watch load on large clusters), use the
+`--watch-namespaces` flag — see [RBAC hardening](security/rbac-hardening.md).
 
-**API Rate Limiting:**
-```yaml
-# Configure rate limiting for API calls
-env:
-- name: QPS_LIMIT
-  value: "50"
-- name: BURST_LIMIT
-  value: "100"
-```
+`GOMAXPROCS` is wired to the CPU limit via the downward API in
+`config/manager/manager.yaml`, so Go's runtime parallelism tracks the
+container's CPU allocation automatically.
 
-This document provides comprehensive guidance for deploying Beskar7 in production environments. Regular review and updates of these practices ensure optimal security, performance, and reliability. 
+This document provides guidance for deploying Beskar7 in production
+environments. Regular review keeps these practices aligned with the shipped
+flags and behavior.


### PR DESCRIPTION
## Summary

Closes **#89**. `docs/deployment-best-practices.md`'s "Performance Optimization" section advertised eight knobs the manager doesn't implement.

| Type | Fictional | Reality |
|---|---|---|
| Flags | `--concurrent-reconciles`, `--max-concurrent-reconciles`, `--worker-count`, `--resync-period` | None exist. `MaxConcurrentReconciles = 1` (controller-runtime default); raising it is a code change. |
| Env vars | `CONTROLLER_RESYNC_PERIOD`, `CACHE_SYNC_TIMEOUT`, `QPS_LIMIT`, `BURST_LIMIT` | None read by the manager. Cache/client use controller-runtime defaults. |

Verified via grep that none appear in `cmd/manager/main.go` or `controllers/`. Two other docs (`resource-planning.md`, `troubleshooting.md`) already correctly stated `--max-concurrent-reconciles` doesn't exist — this section contradicted them.

## What changed

Rewrote the section to:
- Show only the **real** flags (leader-election timings + the new `--inspection-timeout` from #99), linking to `resource-planning.md#performance-tuning` for the full list.
- State plainly that concurrency is `MaxConcurrentReconciles=1` and raising it is a code change — matching the stance already documented elsewhere.
- State the cache/client use controller-runtime defaults and the listed env vars are not read; point at `--watch-namespaces` for cache scoping.
- Keep the accurate `GOMAXPROCS` note (it **is** wired via downward API in `config/manager/manager.yaml`).

## Scope note

The issue title is about `--max-concurrent-reconciles` specifically, but the honest scrub covers the whole fabricated section — it's all the same class of doc fiction. Doc-only change.

## Test plan

- [x] grep confirms no fictional flag/env-var is presented as real (only explicit "there is no X" negations remain)
- [x] Cross-links resolve: `resource-planning.md#performance-tuning` (section exists), `security/rbac-hardening.md` (exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)