### PR TITLE
config: migrate kustomize configs off deprecated v1 fields (#92)

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -8,23 +8,25 @@ resources:
 - bases/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_beskar7clusters.yaml
-- patches/webhook_in_beskar7machines.yaml
-- patches/webhook_in_beskar7machinetemplates.yaml
-- patches/webhook_in_physicalhosts.yaml
+- path: patches/webhook_in_beskar7clusters.yaml
+- path: patches/webhook_in_beskar7machines.yaml
+- path: patches/webhook_in_beskar7machinetemplates.yaml
+- path: patches/webhook_in_physicalhosts.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_beskar7clusters.yaml
-- patches/cainjection_in_beskar7machines.yaml
-- patches/cainjection_in_beskar7machinetemplates.yaml
-- patches/cainjection_in_physicalhosts.yaml
+- path: patches/cainjection_in_beskar7clusters.yaml
+- path: patches/cainjection_in_beskar7machines.yaml
+- path: patches/cainjection_in_beskar7machinetemplates.yaml
+- path: patches/cainjection_in_physicalhosts.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
-commonLabels:
-  cluster.x-k8s.io/contract: v1beta1
-  cluster.x-k8s.io/provider: beskar7 
+labels:
+- pairs:
+    cluster.x-k8s.io/contract: v1beta1
+    cluster.x-k8s.io/provider: beskar7
+  includeSelectors: true 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,12 +6,16 @@ namespace: beskar7-system
 # "controller-manager" becomes "my-deployment-controller-manager".
 # namePrefix: my-deployment-
 
-# Labels to add to all resources and selectors.
-commonLabels:
-  app.kubernetes.io/name: beskar7
-  app.kubernetes.io/version: v0.2.7
+# Labels to add to all resources and selectors. includeSelectors: true
+# preserves the v1 commonLabels behavior (the labels are injected into
+# Deployment/Service selectors too, not just metadata).
+labels:
+- pairs:
+    app.kubernetes.io/name: beskar7
+    app.kubernetes.io/version: v0.2.7
+  includeSelectors: true
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/config/overlays/extra-large/kustomization.yaml
+++ b/config/overlays/extra-large/kustomization.yaml
@@ -7,14 +7,14 @@ resources:
 - ../../default
 - pdb.yaml  # Keep the existing PDB
 
-patchesStrategicMerge:
-- manager_patch.yaml
+patches:
+- path: manager_patch.yaml
 
 namePrefix: extra-large-
 
-commonLabels:
-  deployment-size: extra-large
-
+# deployment-size is already covered by the labels block below (which also
+# carries includeSelectors: true), so the old commonLabels entry was redundant
+# and was dropped during the v1→v2 migration.
 labels:
 - includeSelectors: true
   pairs:

--- a/config/overlays/large/kustomization.yaml
+++ b/config/overlays/large/kustomization.yaml
@@ -6,14 +6,14 @@ namespace: beskar7-system
 resources:
 - ../../default
 
-patchesStrategicMerge:
-- manager_patch.yaml
+patches:
+- path: manager_patch.yaml
 
 namePrefix: large-
 
-commonLabels:
-  deployment-size: large
-
+# deployment-size is already covered by the labels block below (which also
+# carries includeSelectors: true), so the old commonLabels entry was redundant
+# and was dropped during the v1→v2 migration.
 labels:
 - includeSelectors: true
   pairs:

--- a/config/overlays/small/kustomization.yaml
+++ b/config/overlays/small/kustomization.yaml
@@ -6,10 +6,12 @@ namespace: beskar7-system
 resources:
 - ../../default
 
-patchesStrategicMerge:
-- manager_patch.yaml
+patches:
+- path: manager_patch.yaml
 
 namePrefix: small-
 
-commonLabels:
-  deployment-size: small 
+labels:
+- pairs:
+    deployment-size: small
+  includeSelectors: true 

--- a/config/rbac/namespace-scoped/kustomization.yaml
+++ b/config/rbac/namespace-scoped/kustomization.yaml
@@ -21,7 +21,7 @@
 #     metrics_*                     (Symlinks would also work; explicit
 #                                   refs are clearer.)
 #
-# To enable, point your own overlay's `bases:` at this dir instead of
+# To enable, point your own overlay's `resources:` at this dir instead of
 # ../rbac, AND set --watch-namespaces=<csv> on the manager Deployment so
 # the controller-runtime cache matches the RBAC.
 namespace: beskar7-system

--- a/config/security/kustomization.yaml
+++ b/config/security/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
 - network-policy.yaml
 
-commonLabels:
-  app.kubernetes.io/name: beskar7
-  app.kubernetes.io/component: security 
+labels:
+- pairs:
+    app.kubernetes.io/name: beskar7
+    app.kubernetes.io/component: security
+  includeSelectors: true 


### PR DESCRIPTION
## Summary

Closes **#92**. kustomize v5 warns on every `kustomize build` / `make release-manifests` for `bases:`, `commonLabels:`, `patchesStrategicMerge:`. Migrated all seven kustomization files to v2 equivalents.

| v1 (deprecated) | v2 |
|---|---|
| `bases:` | `resources:` |
| `patchesStrategicMerge: [f]` | `patches: [{path: f}]` |
| `commonLabels: {k: v}` | `labels: [{pairs: {k: v}, includeSelectors: true}]` |

## The load-bearing detail: `includeSelectors: true`

v1 `commonLabels` injected labels into Deployment/Service **selectors**, not just metadata. The manager Deployment's `selector.matchLabels` depends on `app.kubernetes.io/name` + `app.kubernetes.io/version` coming from `commonLabels`. Bare `labels:` defaults `includeSelectors` to **false** — which would drop those from the (immutable) selector and break `helm`/`kubectl apply` upgrades. Every migrated `commonLabels` carries `includeSelectors: true` to preserve exact v1 behavior.

`config/overlays/{large,extra-large}` already had a `labels:` block carrying `deployment-size` with `includeSelectors: true`, so their `commonLabels: {deployment-size: ...}` was fully redundant and was dropped.

## Files

- `config/default` (commonLabels + bases)
- `config/crd` (patchesStrategicMerge + commonLabels)
- `config/security` (commonLabels)
- `config/overlays/small` (patchesStrategicMerge + commonLabels)
- `config/overlays/large` (patchesStrategicMerge; redundant commonLabels dropped)
- `config/overlays/extra-large` (patchesStrategicMerge; redundant commonLabels dropped)
- `config/rbac/namespace-scoped` (comment-only: `bases:` → `resources:`)

## Why manual, not `kustomize edit fix`

`kustomize edit fix` also converts `vars:` → `replacements:` (out of scope) and self-warns that the result "may not produce the same output." Did the renames by hand for precision.

## Validation — behavior-preserving

Captured `kustomize build` for all 8 entry points before and after the migration. **All 8 render byte-identical:**

```
IDENTICAL: config/default
IDENTICAL: config/rbac
IDENTICAL: config/rbac/namespace-scoped
IDENTICAL: config/crd
IDENTICAL: config/security
IDENTICAL: config/overlays/small
IDENTICAL: config/overlays/large
IDENTICAL: config/overlays/extra-large
```

No deprecation warnings on any build path.

> ⚠️ Note for reviewers: don't validate via `make release-manifests` — that target ends with `git checkout config/default config/overlays/` to undo its own version-string sed edits, which also reverts these source changes. Use `kustomize build <dir>` directly.

## Test plan

- [x] No `bases:`/`commonLabels:`/`patchesStrategicMerge:` remain (verified via grep)
- [x] All 8 entry points render byte-identical before/after
- [x] Zero deprecation warnings from `kustomize build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)