### PR TITLE
controllers: wire PhysicalHost Recorder + guard nil (fixes #103)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -212,9 +212,10 @@ func main() {
 	}
 
 	if err = (&controllers.PhysicalHostReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("PhysicalHost"),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Log:      ctrl.Log.WithName("controllers").WithName("PhysicalHost"),
+		Recorder: mgr.GetEventRecorderFor("beskar7-physicalhost-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PhysicalHost")
 		os.Exit(1)

--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -512,11 +512,16 @@ func (r *PhysicalHostReconciler) applyInspectionResultAnnotation(ctx context.Con
 func (r *PhysicalHostReconciler) reconcileDelete(ctx context.Context, logger logr.Logger, physicalHost *infrastructurev1beta1.PhysicalHost) (ctrl.Result, error) {
 	logger.Info("Reconciling PhysicalHost deletion")
 
-	// If still claimed, log warning but allow deletion
+	// If still claimed, log warning but allow deletion. Guard the Recorder:
+	// it may be nil in tests (and historically was unset in main.go), and a
+	// nil dereference here would panic the delete reconcile *before* the
+	// finalizer is removed, stranding the host in Terminating forever.
 	if physicalHost.Spec.ConsumerRef != nil {
 		logger.Info("Warning: Deleting PhysicalHost that is still claimed", "consumer", physicalHost.Spec.ConsumerRef.Name)
-		r.Recorder.Event(physicalHost, corev1.EventTypeWarning, "DeletingClaimedHost",
-			fmt.Sprintf("Deleting host that is still claimed by %s", physicalHost.Spec.ConsumerRef.Name))
+		if r.Recorder != nil {
+			r.Recorder.Event(physicalHost, corev1.EventTypeWarning, "DeletingClaimedHost",
+				fmt.Sprintf("Deleting host that is still claimed by %s", physicalHost.Spec.ConsumerRef.Name))
+		}
 	}
 
 	// Remove finalizer; the deferred patch persists this.

--- a/controllers/physicalhost_reconciledelete_test.go
+++ b/controllers/physicalhost_reconciledelete_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	infrastructurev1beta1 "github.com/projectbeskar/beskar7/api/v1beta1"
+)
+
+// TestReconcileDelete_ClaimedHost_NilRecorder is a regression test for #103:
+// PhysicalHostReconciler was constructed in cmd/manager/main.go without a
+// Recorder, so deleting a still-claimed host (ConsumerRef != nil) dereferenced
+// a nil Recorder and panicked in reconcileDelete — before RemoveFinalizer ran,
+// leaving the host stranded in Terminating.
+//
+// reconcileDelete touches no API server (it only mutates the in-memory object
+// and emits an Event), so it can be exercised with a zero-value reconciler and
+// no envtest. The reconciler here deliberately leaves Recorder nil to assert
+// the guard added in the fix.
+func TestReconcileDelete_ClaimedHost_NilRecorder(t *testing.T) {
+	r := &PhysicalHostReconciler{} // Recorder intentionally nil
+
+	ph := &infrastructurev1beta1.PhysicalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "claimed-host",
+			Namespace:  "default",
+			Finalizers: []string{PhysicalHostFinalizer},
+		},
+		Spec: infrastructurev1beta1.PhysicalHostSpec{
+			// A non-nil ConsumerRef is the condition that drives the
+			// Recorder.Event call that used to panic.
+			ConsumerRef: &corev1.ObjectReference{
+				Kind:       "Beskar7Machine",
+				Name:       "some-machine",
+				Namespace:  "default",
+				APIVersion: InfrastructureAPIVersion,
+			},
+		},
+	}
+
+	// Must not panic even though Recorder is nil.
+	if _, err := r.reconcileDelete(context.Background(), log.Log, ph); err != nil {
+		t.Fatalf("reconcileDelete returned error: %v", err)
+	}
+
+	// The finalizer must be removed so the deferred patch can let the object
+	// finalize (the whole point — a panic here would strand it).
+	for _, f := range ph.Finalizers {
+		if f == PhysicalHostFinalizer {
+			t.Fatalf("finalizer %q was not removed; host would be stranded in Terminating", PhysicalHostFinalizer)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes **#103**. `cmd/manager/main.go` constructed `PhysicalHostReconciler` without a `Recorder`, so `r.Recorder` was nil at runtime. `reconcileDelete` dereferences it when the host is still claimed:

```go
if physicalHost.Spec.ConsumerRef != nil {
    r.Recorder.Event(...)   // nil panic
}
```

Deleting a claimed `PhysicalHost` (a normal decommission action) therefore panicked. controller-runtime recovers the panic so the manager survives — **but the panic happens before `RemoveFinalizer`**, so the host never sheds its finalizer and is stranded in `Terminating`, panic-looping each reconcile.

Surfaced in the PR #102 CI diagnostics dump (during the smoke teardown, which deletes still-claimed hosts).

## Fix (two parts)

1. **`main.go`**: `Recorder: mgr.GetEventRecorderFor("beskar7-physicalhost-controller")` — so the `DeletingClaimedHost` warning event is actually emitted.
2. **`reconcileDelete`**: guard the `Event` call with `if r.Recorder != nil` — a nil Recorder (tests, or any future miswiring) degrades to no-event instead of a panic that strands the object.

## Regression test

`controllers/physicalhost_reconciledelete_test.go`: constructs the reconciler with a **nil Recorder** and a claimed host, calls `reconcileDelete`, asserts no panic + finalizer removed.

Verified it genuinely guards the regression:
```
# guard removed:
--- FAIL: TestReconcileDelete_ClaimedHost_NilRecorder
panic: runtime error: invalid memory address or nil pointer dereference
# guard present:
ok  github.com/projectbeskar/beskar7/controllers
```

## Test plan

- [x] `go build` / `go vet` / `make lint` clean
- [x] New regression test panics without the guard, passes with it
- [x] Full envtest suite (`TestAPIs`) green (16.3s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)