### PR TITLE
controllers: release claimed host by ConsumerRef on delete (fixes #107)

### DIFF
--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -842,9 +842,16 @@ func (r *Beskar7MachineReconciler) findAndClaimOrGetAssociatedHost(ctx context.C
 }
 
 // reconcileDelete handles deletion. The sequence is:
-//  1. Best-effort Redfish cleanup (ClearBootSourceOverride + graceful power-off).
-//  2. Patch ConsumerRef = nil on the PhysicalHost spec.
-//  3. Remove the Beskar7Machine finalizer.
+//  1. Locate the PhysicalHost this machine claimed (by ConsumerRef ownership).
+//  2. Best-effort Redfish cleanup (ClearBootSourceOverride + graceful power-off).
+//  3. Patch ConsumerRef = nil on the PhysicalHost spec.
+//  4. Remove the Beskar7Machine finalizer.
+//
+// Release keys off ConsumerRef ownership, NOT ProviderID. ProviderID is only set
+// once inspection completes (handleReadyHost), but ConsumerRef is set much earlier
+// at claim time, so a machine deleted mid-inspection has a claimed host with no
+// ProviderID. Keying release off ProviderID would skip the release entirely in
+// that window and strand the host in InUse with a dangling ConsumerRef (#107).
 //
 // Redfish cleanup is skipped when the ForceReleaseAnnotation is "true" (BMC
 // permanently unreachable) or when the credentials Secret no longer exists.
@@ -853,46 +860,85 @@ func (r *Beskar7MachineReconciler) findAndClaimOrGetAssociatedHost(ctx context.C
 func (r *Beskar7MachineReconciler) reconcileDelete(ctx context.Context, logger logr.Logger, b7machine *infrastructurev1beta1.Beskar7Machine) (ctrl.Result, error) {
 	logger.Info("Reconciling deletion")
 
-	if b7machine.Spec.ProviderID != nil && *b7machine.Spec.ProviderID != "" {
-		ns, name, parseErr := parseProviderID(*b7machine.Spec.ProviderID)
-		if parseErr != nil {
-			// Malformed providerID — log and proceed; nothing useful we can do.
-			logger.V(1).Info("Cannot parse ProviderID during deletion; proceeding without host release", "err", parseErr)
+	host, err := r.findClaimedHostForRelease(ctx, logger, b7machine)
+	if err != nil {
+		logger.Error(err, "Failed to look up claimed host during deletion")
+		return ctrl.Result{}, err
+	}
+	if host != nil {
+		forceRelease := b7machine.Annotations[ForceReleaseAnnotation] == "true"
+		if forceRelease {
+			logger.Info("ForceReleaseAnnotation set; skipping Redfish power-off and boot-override clear")
 		} else {
-			host := &infrastructurev1beta1.PhysicalHost{}
-			if err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, host); err == nil {
-				if host.Spec.ConsumerRef != nil && host.Spec.ConsumerRef.Name == b7machine.Name {
-					forceRelease := b7machine.Annotations[ForceReleaseAnnotation] == "true"
-					if forceRelease {
-						logger.Info("ForceReleaseAnnotation set; skipping Redfish power-off and boot-override clear")
-					} else {
-						// Best-effort Redfish cleanup. Errors are logged but do not block release.
-						r.bestEffortReleaseRedfish(ctx, logger, host)
-					}
-					// Always clear ConsumerRef on the host spec.
-					base := host.DeepCopy()
-					host.Spec.ConsumerRef = nil
-					if err := r.Patch(ctx, host, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
-						if apierrors.IsConflict(err) {
-							return ctrl.Result{Requeue: true}, nil
-						}
-						logger.Error(err, "Failed to release host")
-						return ctrl.Result{}, err
-					}
-					logger.Info("Released PhysicalHost", "host", name)
-				}
-			} else if !apierrors.IsNotFound(err) {
-				// Real error fetching host — surface and requeue.
-				return ctrl.Result{}, err
-			}
-			// host NotFound → already gone; nothing to release.
+			// Best-effort Redfish cleanup. Errors are logged but do not block release.
+			r.bestEffortReleaseRedfish(ctx, logger, host)
 		}
+		// Always clear ConsumerRef on the host spec.
+		base := host.DeepCopy()
+		host.Spec.ConsumerRef = nil
+		if err := r.Patch(ctx, host, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			logger.Error(err, "Failed to release host")
+			return ctrl.Result{}, err
+		}
+		logger.Info("Released PhysicalHost", "host", host.Name)
 	}
 
 	if controllerutil.RemoveFinalizer(b7machine, Beskar7MachineFinalizer) {
 		logger.Info("Removing finalizer")
 	}
 	return ctrl.Result{}, nil
+}
+
+// findClaimedHostForRelease locates the PhysicalHost currently claimed by this
+// Beskar7Machine so reconcileDelete can release it. ConsumerRef ownership is the
+// source of truth: a machine deleted before inspection completes has a claimed
+// host (ConsumerRef set) but no ProviderID yet (#107), so a ProviderID-only
+// lookup would miss it and strand the host.
+//
+// ProviderID, when present and parseable, is used as a fast-path Get to avoid a
+// list in the common provisioned case. If it is unset, malformed, or points at a
+// host that is not (or no longer) claimed by us, we fall back to a namespace list
+// scan keyed on ConsumerRef.Name — the same lookup findAndClaimOrGetAssociatedHost
+// uses in the claim direction. Returns (nil, nil) when no host is claimed by us.
+func (r *Beskar7MachineReconciler) findClaimedHostForRelease(ctx context.Context, logger logr.Logger, b7machine *infrastructurev1beta1.Beskar7Machine) (*infrastructurev1beta1.PhysicalHost, error) {
+	// Fast path: ProviderID names the host directly.
+	if b7machine.Spec.ProviderID != nil && *b7machine.Spec.ProviderID != "" {
+		ns, name, parseErr := parseProviderID(*b7machine.Spec.ProviderID)
+		if parseErr != nil {
+			logger.V(1).Info("Cannot parse ProviderID during deletion; falling back to ConsumerRef scan", "err", parseErr)
+		} else {
+			host := &infrastructurev1beta1.PhysicalHost{}
+			err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, host)
+			switch {
+			case err == nil:
+				if host.Spec.ConsumerRef != nil && host.Spec.ConsumerRef.Name == b7machine.Name {
+					return host, nil
+				}
+				// ProviderID points at a host not claimed by us; fall through to scan.
+			case apierrors.IsNotFound(err):
+				// Named host already gone; fall through in case a different host is ours.
+			default:
+				return nil, err
+			}
+		}
+	}
+
+	// Fallback: scan the namespace for any host whose ConsumerRef names us. This
+	// covers the claimed-but-not-yet-provisioned window where ProviderID is unset.
+	allHosts := &infrastructurev1beta1.PhysicalHostList{}
+	if err := r.List(ctx, allHosts, client.InNamespace(b7machine.Namespace)); err != nil {
+		return nil, err
+	}
+	for i := range allHosts.Items {
+		h := &allHosts.Items[i]
+		if h.Spec.ConsumerRef != nil && h.Spec.ConsumerRef.Name == b7machine.Name {
+			return h, nil
+		}
+	}
+	return nil, nil
 }
 
 // bestEffortReleaseRedfish issues ClearBootSourceOverride and a graceful power-off

--- a/test/integration/provision_flow_test.go
+++ b/test/integration/provision_flow_test.go
@@ -255,16 +255,17 @@ var _ = Describe("Secret-rotation watch", func() {
 })
 
 var _ = Describe("Delete and release", func() {
-	// Regression test adjacent to the #103 nil-Recorder-on-delete fix. Verifies
-	// that deleting a provisioned Beskar7Machine causes:
+	// Regression tests adjacent to the #103 nil-Recorder-on-delete fix. Verify
+	// that deleting a Beskar7Machine causes:
 	//   1. The host's Spec.ConsumerRef to be cleared.
 	//   2. The host's Status.State to return to Available.
 	//
-	// We drive the machine to full Ready state (ProviderID set) before deleting
-	// because reconcileDelete only clears ConsumerRef when ProviderID is present
-	// on the Beskar7Machine. Deleting before ProviderID is set is a known
-	// production limitation: ConsumerRef is not cleared (the host strands in InUse).
-	// A separate issue tracks that path; this test covers the nominal delete case.
+	// Two cases are covered:
+	//   - Provisioned delete: machine driven to Ready (ProviderID set) before delete.
+	//   - Pre-Ready delete (#107 regression): machine deleted while the host is still
+	//     Inspecting, so ProviderID is nil. reconcileDelete must locate the claimed
+	//     host by ConsumerRef ownership (not ProviderID) and release it; otherwise
+	//     the host strands permanently in InUse with a dangling ConsumerRef.
 
 	var (
 		specCtx   context.Context
@@ -329,6 +330,46 @@ var _ = Describe("Delete and release", func() {
 			err := mgr.GetClient().Get(specCtx, b7mKey, &infrastructurev1beta1.Beskar7Machine{})
 			g.Expect(err).To(MatchError(ContainSubstring("not found")),
 				"Beskar7Machine must be fully deleted after finalizer removal")
+		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
+	})
+
+	It("should release the host when a Beskar7Machine is deleted before provisioning (ProviderID unset) (#107)", func() {
+		hostKey := client.ObjectKeyFromObject(host)
+		b7mKey := client.ObjectKeyFromObject(b7machine)
+
+		By("waiting for the host to be claimed and reach Inspecting (pre-Ready, ProviderID still unset)")
+		// We deliberately do NOT simulate the inspector here, so the machine never
+		// reaches Ready and ProviderID is never set. This is the #107 window.
+		Eventually(func(g Gomega) {
+			current := &infrastructurev1beta1.PhysicalHost{}
+			g.Expect(mgr.GetClient().Get(specCtx, hostKey, current)).To(Succeed())
+			g.Expect(current.Status.State).To(Equal(infrastructurev1beta1.StateInspecting))
+			g.Expect(current.Spec.ConsumerRef).NotTo(BeNil())
+		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
+
+		By("confirming ProviderID is unset on the Beskar7Machine (proves we are in the pre-Ready window)")
+		currentB7M := &infrastructurev1beta1.Beskar7Machine{}
+		Expect(mgr.GetClient().Get(specCtx, b7mKey, currentB7M)).To(Succeed())
+		Expect(currentB7M.Spec.ProviderID).To(BeNil(),
+			"ProviderID must be unset for this regression to exercise the ConsumerRef-based release path")
+
+		By("deleting the Beskar7Machine while the host is still Inspecting")
+		Expect(k8sClient.Delete(specCtx, b7machine)).To(Succeed())
+
+		By("waiting for host to be released (ConsumerRef cleared, state=Available) despite ProviderID never being set")
+		Eventually(func(g Gomega) {
+			current := &infrastructurev1beta1.PhysicalHost{}
+			g.Expect(mgr.GetClient().Get(specCtx, hostKey, current)).To(Succeed())
+			g.Expect(current.Spec.ConsumerRef).To(BeNil(),
+				"ConsumerRef must be cleared even when the machine was deleted before ProviderID was assigned (#107)")
+			g.Expect(current.Status.State).To(Equal(infrastructurev1beta1.StateAvailable),
+				"host must return to Available rather than stranding in InUse/Inspecting")
+		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
+
+		By("confirming the Beskar7Machine is fully gone")
+		Eventually(func(g Gomega) {
+			err := mgr.GetClient().Get(specCtx, b7mKey, &infrastructurev1beta1.Beskar7Machine{})
+			g.Expect(err).To(MatchError(ContainSubstring("not found")))
 		}, eventuallyTimeout, eventuallyInterval).Should(Succeed())
 	})
 })


### PR DESCRIPTION
## Summary

Fixes #107 — a permanent PhysicalHost leak when a `Beskar7Machine` is deleted before provisioning completes.

`reconcileDelete` only released the claimed host when `Spec.ProviderID` was set. But `ProviderID` is assigned late, in `handleReadyHost` (after inspection completes), whereas `ConsumerRef` is set much earlier at claim time. A `Beskar7Machine` deleted mid-inspection (claimed, host `InUse`/`Inspecting`, no `ProviderID` yet) therefore had its finalizer removed **without** clearing the host's `ConsumerRef` — stranding the host in `InUse` with a dangling `ConsumerRef` pointing at a now-deleted machine. No future `Beskar7Machine` could ever claim it (not `Available`, non-nil `ConsumerRef`), so the host leaked permanently.

## Fix

Key release off **`ConsumerRef` ownership**, not `ProviderID`. New `findClaimedHostForRelease` helper:
- `ProviderID`, when present and parseable, stays a fast-path `Get` — no behavior change for the common provisioned-then-deleted case.
- When `ProviderID` is unset, malformed, or points at a host not (or no longer) claimed by us, fall back to a namespace list scan keyed on `ConsumerRef.Name` — the same lookup `findAndClaimOrGetAssociatedHost` already uses in the claim direction.

The release logic itself (force-release annotation, best-effort Redfish cleanup, optimistic-lock patch, conflict→requeue) is unchanged — just moved out of the `ProviderID`-gated block.

## Regression test

Adds a spec to the manager-level integration suite (`test/integration/`, from #94) that deletes a `Beskar7Machine` while the host is still `Inspecting` (asserts `ProviderID == nil` first to prove it's in the pre-Ready window), then asserts the host returns to `Available` with `ConsumerRef` cleared. Also fixes the now-stale "known limitation" comment in the existing post-Ready delete spec.

**Verified the regression test catches the bug**: it times out (fails) against the pre-fix controller and passes with the fix.

## Test plan
- [x] `make test` — pass (controllers re-ran, 63.9%)
- [x] `make lint` (golangci-lint v2.12.2) — 0 issues
- [x] `go build` / `go vet` with and without `-tags=integration` — clean
- [x] `go test -tags=integration ./test/integration/...` — 4 specs, 3 independent runs, no flake
- [x] Negative check: new spec fails (60s timeout) against pre-fix code, passes with fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)