### PR TITLE
release: cut v0.4.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 *No unreleased work — see the per-tag entries below. Going forward, each released tag gets its own entry; this section stays empty between tags.*
 
+## [v0.4.0-alpha.6] - 2026-05-29
+
+The "post-alpha.5 hardening arc": closed the last correctness bug surfaced after alpha.5 (a host that leaked permanently when a machine was deleted mid-provision), stood up a real manager-level integration test tier to catch that class of bug at PR speed, brought the tooling/config onto current schemas (kustomize v2, golangci-lint v2), and landed the CAPI pause-conformance + webhook + flag work that had been queued. Also fixes the release workflow itself, which broke on the alpha.5 tag run.
+
+### Added
+- **Manager-level integration test suite** (#94, PR #106) — replaces the hollow `test/integration` placeholder (a single `t.Skip` that asserted nothing) with a real suite that boots envtest, starts one shared controller-runtime manager wiring all three reconcilers exactly as `cmd/manager/main.go` does, and drives cross-controller scenarios under real watch/informer timing. Three specs: full provision flow (claim → inspect → `Ready`/ProviderID, with the inspector callback simulated via the inspection-result ConfigMap + annotation handoff), credentials-Secret rotation re-trigger via `SecretToPhysicalHosts`, and delete-and-release. Build-tagged `integration`; the existing `integration-test` CI job already runs it, so no workflow change. Catches the watch-wiring / concurrent-reconcile bug class that the manual-`Reconcile` unit tier cannot and that was previously only covered by the slow kind smoke.
+- **`--inspection-timeout` manager flag** (#91, PR #99) — exposes the previously-hardcoded inspection timeout (`DefaultInspectionTimeout`, 10m) as a `Beskar7MachineReconciler` field resolved via `inspectionTimeout()`, wired through `cmd/manager/main.go`. Lets operators tune how long a host may sit in `Inspecting` before the machine is marked terminally failed.
+- **Self-signed webhook certificate path** (GAP-2, #88, PR #98) — the Helm chart can now serve the `Beskar7Cluster` admission webhook without cert-manager. When `certManager.enabled=false`, a memoized `beskar7.webhookCerts` template helper generates a CA + serving cert (Sprig `genCA`/`genSignedCert`), renders a `kubernetes.io/tls` Secret, and injects the CA bundle into the webhook configuration. `certManager.enabled=true` (default) keeps the cert-manager-issued path unchanged.
+- **Smoke watch-namespaces isolation layer + CI gate** (#95, PR #102) — adds layer 6 to `hack/smoke/run.sh` (env/flag-gated `SMOKE_NS_ISOLATION` / `--with-isolation`) that proves a watch-namespaces-scoped operator ignores resources outside its watched set, plus a `make smoke-watch-namespaces` target and a CI phase. Self-skips when the operator was installed cluster-wide.
+
+### Fixed
+- **#107**: `Beskar7MachineReconciler.reconcileDelete` only released the claimed `PhysicalHost` when `Spec.ProviderID` was set, but `ProviderID` is assigned late (after inspection, in `handleReadyHost`) while `ConsumerRef` is set at claim time. A machine deleted mid-inspection thus had its finalizer removed without clearing the host's `ConsumerRef`, stranding the host in `InUse` with a dangling reference — a permanent, unclaimable leak. Release now keys off `ConsumerRef` ownership (new `findClaimedHostForRelease` helper; `ProviderID` kept as a fast-path `Get`, with a namespace list-scan fallback) (PR #108).
+- **#103**: `PhysicalHostReconciler.reconcileDelete` panicked on a nil `Recorder` (`r.Recorder.Event(...)`) because the manager wiring never set `Recorder`. Wired `mgr.GetEventRecorderFor(...)` in `cmd/manager/main.go` and added a nil-guard, with a regression test that panics without the guard (PR #104).
+- **GAP-1 / #87**: `PhysicalHostReconciler` now honours the CAPI pause signal (`cluster.x-k8s.io/paused` annotation), matching the other reconcilers and the provider contract. Reconcile returns early without mutating the host while paused (PR #97).
+- **Release workflow kustomize install** (#86) — the `Generate Release Artifacts` step used the upstream `install_kustomize.sh` script, whose asset glob changed at kustomize-master and started failing with `tar: ... No such file or directory` (this broke the v0.4.0-alpha.5 release artifacts). Replaced with a pinned `go install sigs.k8s.io/kustomize/kustomize/v5@v5.4.3`, matching the controller-gen / golangci-lint pattern.
+
+### Changed
+- **golangci-lint migrated to v2** (#93, PR #105) — `.golangci.yml` rewritten to the v2 schema (`version: "2"`, `linters.default: standard`, `formatters` section); `make lint` and CI pinned to the matching v2 binary (`v2.12.2`, module path `.../v2/cmd/golangci-lint`). Seven surfaced staticcheck quick-fix findings resolved behavior-preservingly (tagged `switch`, De Morgan simplification, `time.Time` method shortcuts).
+- **kustomize configs migrated off deprecated v1 fields** (#92, PR #101) — `bases:` → `resources:`, `commonLabels:` → `labels: [{pairs, includeSelectors: true}]` (the `includeSelectors` is load-bearing for the Deployment selector), `patchesStrategicMerge:` → `patches: [{path}]` across seven `kustomization.yaml` files. All eight `kustomize build` entry points verified byte-identical before/after.
+
+### Docs
+- **Scrubbed fictional performance-tuning flags and env vars** (#89, PR #100) from the docs — removed references to manager flags and environment variables that `cmd/manager/main.go` never accepted, so the documented surface matches the real one.
+
+### Internal
+- **`test/emulation/hardware_emulation_test.go` deleted** (PR #106) — orphaned dead test code (`//go:build integration`, package `emulation`) that no CI job or `make` target ever ran; its mock-Redfish assertions are already covered by `internal/redfishmock/server_test.go`.
+- **`charts/beskar7/Chart.yaml`** `version` and `appVersion` bumped to v0.4.0-alpha.6 (this release).
+- **`Makefile` `VERSION`** bumped to v0.4.0-alpha.6 — image-tag default for `make docker-build`, `make release-manifests`, etc.
+
 ## [v0.4.0-alpha.5] - 2026-05-24
 
 The "backlog cleanup arc": tightened RBAC to per-namespace scope as an opt-in, brought the Prometheus metric surface in line with reality (delete what was dead, wire what should emit), and closed every correctness bug + hygiene item that had been carried since the v0.4-alpha review.
@@ -712,7 +740,8 @@ For detailed implementation information, see the examples directory and document
 - CI: lint, tests, container build, CRD generation, Kind sanity checks.
 - Core controllers and CRDs for `PhysicalHost`, `Beskar7Machine`, `Beskar7Cluster`.
 
-[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.5...HEAD
+[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.6...HEAD
+[v0.4.0-alpha.6]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.5...v0.4.0-alpha.6
 [v0.4.0-alpha.5]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.4...v0.4.0-alpha.5
 [v0.4.0-alpha.4]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha...v0.4.0-alpha.4
 [v0.4.0-alpha]: https://github.com/projectbeskar/beskar7/compare/v0.3.4-alpha...v0.4.0-alpha

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.0-alpha.5
+VERSION ?= v0.4.0-alpha.6
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.0-alpha.5  
+**Version:** v0.4.0-alpha.6  
 **Status:** Alpha - Under active development. API may still change before v0.4.0 GA.  
 **Breaking Changes:** v0.4.0 is NOT compatible with v0.3.x ([see CHANGELOG](CHANGELOG.md))
 
@@ -51,12 +51,12 @@ helm install --devel beskar7 beskar7/beskar7 \
   --namespace beskar7-system --create-namespace
 ```
 
-The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.5`); drop it once a non-prerelease tag is cut.
+The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.6`); drop it once a non-prerelease tag is cut.
 
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.5/beskar7-manifests-v0.4.0-alpha.5.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.6/beskar7-manifests-v0.4.0-alpha.6.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0-alpha.5
-appVersion: "v0.4.0-alpha.5"
+version: 0.4.0-alpha.6
+appVersion: "v0.4.0-alpha.6"
 keywords:
   - cluster-api
   - infrastructure

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -273,8 +273,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.0-alpha.N`; bump N for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.0-alpha.5
-   git push origin v0.4.0-alpha.5
+   git tag v0.4.0-alpha.6
+   git push origin v0.4.0-alpha.6
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.5`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.6`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ The `bootstrap.urlBase` value is rendered into `PhysicalHost.Status.Bootstrap.UR
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.5/beskar7-manifests-v0.4.0-alpha.5.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.6/beskar7-manifests-v0.4.0-alpha.6.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -171,7 +171,7 @@ Memory Limit = (Host Count × 0.5MB) + (Webhook Concurrency × 10MB) + 100MB (ba
 Configure reconciliation intervals based on your needs:
 
 ```yaml
-# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.5.
+# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.6.
 args:
 - --leader-elect=true
 - --metrics-bind-address=:8443

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Operators
 
-This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.5. Each item is anchored to source code so you can verify the claim.
+This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.6. Each item is anchored to source code so you can verify the claim.
 
 If you are looking for hardening recommendations, see [Configuration](configuration.md). For RBAC details, see [RBAC Hardening](rbac-hardening.md). For incident debugging, see [Troubleshooting](troubleshooting.md).
 

--- a/examples/complete-cluster.md
+++ b/examples/complete-cluster.md
@@ -1,6 +1,6 @@
 # Complete Cluster Deployment Example
 
-This walkthrough deploys a 1-control-plane + 2-worker Kubernetes cluster on bare metal using Beskar7 v0.4.0-alpha.5. The accompanying YAML is [`complete-cluster.yaml`](complete-cluster.yaml).
+This walkthrough deploys a 1-control-plane + 2-worker Kubernetes cluster on bare metal using Beskar7 v0.4.0-alpha.6. The accompanying YAML is [`complete-cluster.yaml`](complete-cluster.yaml).
 
 ## Prerequisites
 

--- a/examples/complete-cluster.yaml
+++ b/examples/complete-cluster.yaml
@@ -1,5 +1,5 @@
 # Complete Beskar7 Cluster Example
-# Deploys a 1 control-plane + 2 worker cluster using Beskar7 v0.4.0-alpha.5.
+# Deploys a 1 control-plane + 2 worker cluster using Beskar7 v0.4.0-alpha.6.
 #
 # Prerequisites:
 #   1. Beskar7 controller is installed (Helm or release manifests).

--- a/examples/minimal-test-cluster.yaml
+++ b/examples/minimal-test-cluster.yaml
@@ -1,6 +1,6 @@
 # Minimal Test Cluster Example
 #
-# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.5
+# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.6
 # inspection workflow. NOT a working cluster — bring this up first to verify the
 # inspection round-trip, then graduate to examples/complete-cluster.yaml.
 #

--- a/examples/security/README.md
+++ b/examples/security/README.md
@@ -1,6 +1,6 @@
 # Beskar7 Security Examples
 
-Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.5 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
+Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.6 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
 
 ## What's actually enforced
 

--- a/examples/security/development.yaml
+++ b/examples/security/development.yaml
@@ -1,4 +1,4 @@
-# Development-style security configuration for Beskar7 v0.4.0-alpha.5.
+# Development-style security configuration for Beskar7 v0.4.0-alpha.6.
 #
 # Loosens TLS verification for self-signed BMC certs typical in lab setups.
 # Do NOT use this configuration in production.

--- a/examples/security/production.yaml
+++ b/examples/security/production.yaml
@@ -1,4 +1,4 @@
-# Production-style security configuration for Beskar7 v0.4.0-alpha.5.
+# Production-style security configuration for Beskar7 v0.4.0-alpha.6.
 #
 # This file demonstrates the enforced security knobs only — the
 # beskar7-security-policy ConfigMap and the various "security framework"


### PR DESCRIPTION
## Summary

Cuts **v0.4.0-alpha.6**, bundling the 11 commits merged since the `v0.4.0-alpha.5` tag — 3 correctness fixes, the new integration test tier, CAPI/webhook/flag work, tooling migrations, and the release-workflow fix.

- Bumps `VERSION` (Makefile) and chart `version` + `appVersion` (Chart.yaml) to `v0.4.0-alpha.6`.
- Bumps current-version references across README, `docs/`, and `examples/`.
- Adds the CHANGELOG entry.

The historical reference in `.github/workflows/release.yml` (which records that the kustomize bug broke the *alpha.5* release) is intentionally left unchanged.

## What's in alpha.6

| Theme | Items |
|---|---|
| Fixed | #107 host-release leak on pre-Ready delete (PR #108) · #103 nil-Recorder panic (PR #104) · #87 PhysicalHost pause conformance (PR #97) · #86 release-workflow kustomize install |
| Added | #94 manager-level integration suite (PR #106) · #91 `--inspection-timeout` flag (PR #99) · #88 self-signed webhook cert path (PR #98) · #95 smoke watch-namespaces isolation (PR #102) |
| Changed | #93 golangci-lint v2 (PR #105) · #92 kustomize v2 (PR #101) |
| Docs | #89 scrub fictional perf-tuning flags/env vars (PR #100) |

## Test plan
- [x] `helm lint charts/beskar7` — clean (only the benign "icon recommended" info)
- [x] `helm template` renders the manager image as `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.6`
- [x] Verified no stray `0.4.0-alpha.5` references remain except the intended historical ones (CHANGELOG entries + the release.yml comment)
- [x] CHANGELOG compare links updated (`Unreleased` → `alpha.6...HEAD`, new `alpha.6` link)

## After merge
Tag `v0.4.0-alpha.6` and push it to trigger the release workflow (now fixed by #86 — this will be the first clean end-to-end run since the alpha.5 break). Awaiting explicit go-ahead before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)