### PR TITLE
controllers: add per-host iPXE /boot endpoint (D-009/D-010)

### DIFF
--- a/api/v1beta1/beskar7machine_types.go
+++ b/api/v1beta1/beskar7machine_types.go
@@ -69,13 +69,13 @@ type Beskar7MachineSpec struct {
 	// InspectionImageURL is the iPXE boot script URL that boots the inspection image.
 	// The inspection image will collect hardware information and report back to Beskar7.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern="^https?://.*"
+	// +kubebuilder:validation:Pattern="^https?://[^\\s]+$"
 	InspectionImageURL string `json:"inspectionImageURL"`
 
 	// TargetImageURL is the URL of the final OS image to boot via kexec after inspection.
 	// This should be a kernel+initrd or complete bootable image.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern="^https?://.*"
+	// +kubebuilder:validation:Pattern="^https?://[^\\s]+$"
 	TargetImageURL string `json:"targetImageURL"`
 
 	// ConfigurationURL is an optional URL for OS-specific configuration.

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -64,12 +64,12 @@ spec:
                     type: integer
                 type: object
               inspectionImageURL:
-                pattern: ^https?://.*
+                pattern: ^https?://[^\s]+$
                 type: string
               providerID:
                 type: string
               targetImageURL:
-                pattern: ^https?://.*
+                pattern: ^https?://[^\s]+$
                 type: string
             required:
             - inspectionImageURL

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -53,12 +53,12 @@ spec:
                             type: integer
                         type: object
                       inspectionImageURL:
-                        pattern: ^https?://.*
+                        pattern: ^https?://[^\s]+$
                         type: string
                       providerID:
                         type: string
                       targetImageURL:
-                        pattern: ^https?://.*
+                        pattern: ^https?://[^\s]+$
                         type: string
                     required:
                     - inspectionImageURL

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"os"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -137,6 +138,20 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	// H-1: Warn if --bootstrap-url-base is a cluster-internal .svc address.
+	// Bare-metal hosts boot outside the cluster and cannot resolve cluster DNS;
+	// a .svc URL forces operators toward InsecureSkipVerify and the inspector's
+	// TLS verification will fail (contract §8). Operators MUST override
+	// --bootstrap-url-base with an externally-reachable address whose serving
+	// cert has a matching SAN.
+	if strings.Contains(bootstrapURLBase, ".svc") {
+		setupLog.Info("WARNING: --bootstrap-url-base contains a cluster-internal .svc address; "+
+			"bare-metal hosts cannot reach cluster DNS and the inspector's TLS verification will fail. "+
+			"Override --bootstrap-url-base with an externally-reachable address (LoadBalancer/NodePort/Ingress) "+
+			"whose TLS certificate has a matching SAN (contract §8).",
+			"bootstrapURLBase", bootstrapURLBase)
+	}
+
 	// Setup metrics registry
 	internalmetrics.Init()
 
@@ -221,12 +236,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setup the host-callback HTTPS server. Hosts both the inspection POST and
-	// the bootstrap GET on the same port (default :8082), gated by the same
-	// per-host bearer-token middleware. TLS is mandatory and the cert dir
-	// defaults to the webhook cert dir (same Pod, same DNS name, one
+	// Setup the host-callback HTTPS server. Hosts the inspection POST, bootstrap
+	// GET, and the /boot iPXE endpoint on the same port (default :8082). The
+	// /boot endpoint is NOT bearer-gated; it uses the single-use boot nonce
+	// (D-009) and is rate-limited per source IP. TLS is mandatory and the cert
+	// dir defaults to the webhook cert dir (same Pod, same DNS name, one
 	// Certificate via cert-manager).
-	if err := controllers.SetupCallbackServer(mgr, inspectionPort, inspectionCertDir); err != nil {
+	// bootstrapURLBase is passed so the /boot handler can render beskar7.api=
+	// into the iPXE cmdline (§5). It must be externally reachable from bare metal.
+	if err := controllers.SetupCallbackServer(mgr, inspectionPort, inspectionCertDir, bootstrapURLBase); err != nil {
 		setupLog.Error(err, "unable to setup callback server")
 		os.Exit(1)
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -64,12 +64,12 @@ spec:
                     type: integer
                 type: object
               inspectionImageURL:
-                pattern: ^https?://.*
+                pattern: ^https?://[^\s]+$
                 type: string
               providerID:
                 type: string
               targetImageURL:
-                pattern: ^https?://.*
+                pattern: ^https?://[^\s]+$
                 type: string
             required:
             - inspectionImageURL

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -53,12 +53,12 @@ spec:
                             type: integer
                         type: object
                       inspectionImageURL:
-                        pattern: ^https?://.*
+                        pattern: ^https?://[^\s]+$
                         type: string
                       providerID:
                         type: string
                       targetImageURL:
-                        pattern: ^https?://.*
+                        pattern: ^https?://[^\s]+$
                         type: string
                     required:
                     - inspectionImageURL

--- a/controllers/boot_handler.go
+++ b/controllers/boot_handler.go
@@ -1,0 +1,460 @@
+/*
+Copyright 2024 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/time/rate"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrastructurev1beta1 "github.com/projectbeskar/beskar7/api/v1beta1"
+	"github.com/projectbeskar/beskar7/internal/auth"
+)
+
+const (
+	// bootHandlerOpaqueFailureStatus is the HTTP status returned for every /boot
+	// failure regardless of cause. Per contract §4.1, callers must not be able to
+	// distinguish "host not found", "wrong nonce", "nonce expired", or
+	// "nonce consumed" from the response.
+	bootHandlerOpaqueFailureStatus = http.StatusNotFound
+
+	// bootHandlerOpaqueFailureBody is the fixed body for all /boot failures.
+	bootHandlerOpaqueFailureBody = "not found"
+
+	// bootNonceConsumeMaxRetries is the maximum number of optimistic-lock retries
+	// in the consume path. Under normal load a single retry suffices; 3 bounds
+	// pathological concurrency without spinning forever.
+	bootNonceConsumeMaxRetries = 3
+
+	// bootIPRateLimitRPS is the sustained per-IP request rate allowed on /boot.
+	// A single NIC retry fires once per boot; 1 r/s per IP is generous for
+	// legitimate retries and blocks scanning.
+	bootIPRateLimitRPS = 1.0
+
+	// bootIPRateLimitBurst is the burst capacity per IP. iPXE may retry a
+	// chainload a few times on a flaky network; 5 lets a slow NIC burst without
+	// triggering the limiter under normal operation.
+	bootIPRateLimitBurst = 5
+
+	// bootIPRateLimiterTTL is how long an idle per-IP entry stays in the map
+	// before eviction. Prevents unbounded map growth on networks that rotate
+	// IP assignments frequently.
+	bootIPRateLimiterTTL = 5 * time.Minute
+
+	// bootScriptMaxBytes is the upper bound on the rendered iPXE boot script.
+	// The Linux kernel cmdline cap is ~2–4 KiB depending on arch; 4096 bytes is
+	// the safe ceiling. A script that exceeds this is operator misconfig (e.g. an
+	// over-large beskar7.ca chain) and would silently truncate the cmdline on real
+	// hardware. We surface it as an operator-visible Info log and an opaque failure
+	// rather than delivering a broken script. (SEC-10)
+	bootScriptMaxBytes = 4096
+)
+
+// BootHandlerConfig carries the operator-supplied configuration needed to
+// render the iPXE cmdline. Populated once at SetupCallbackServer time and
+// shared (read-only) across all handler invocations.
+type BootHandlerConfig struct {
+	// APIBase is the externally-reachable HTTPS base URL of the callback server,
+	// e.g. "https://beskar7.example.com:8082". Rendered into beskar7.api=.
+	APIBase string
+
+	// CABytes is the PEM-encoded CA certificate the inspector uses to verify the
+	// callback TLS certificate. Base64-encoded into beskar7.ca=. Sourced from
+	// the callback cert dir (ca.crt if present, else tls.crt).
+	CABytes []byte
+}
+
+// ipEntry pairs a rate limiter with the time it was last seen. Used by
+// BootHandler to evict stale per-IP entries from the limiter map.
+type ipEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// BootHandler serves the per-host iPXE boot script.
+//
+// Auth: the {nonce} path segment is verified constant-time against
+// Status.Bootstrap.BootNonceHash, within TTL, and not yet consumed. NOT
+// bearer-gated — the booting host has no bearer token yet; that token is
+// delivered by this endpoint in the rendered cmdline.
+//
+// On success: marks the nonce consumed (D-010, single-use) and returns the
+// rendered iPXE script. A second fetch for the same host (race loser or NIC
+// retry) returns identical content (§4.1).
+//
+// Every failure returns the same opaque response so callers cannot distinguish
+// "host not found" from "wrong nonce" from "expired" from "consumed" (§4.1).
+//
+// Status ownership exception: this handler writes exactly one field,
+// PhysicalHost.Status.Bootstrap.BootNonceConsumedAt, via an optimistic-locked
+// Status().Patch. This is the sole audited exception to the D-005 invariant.
+// See D-010 in PROJECT_CONTEXT.md for the rationale.
+//
+// INVARIANT (D-005 amendment): grep "client.Status().Update" controllers/*_handler.go
+// must remain empty. Only the single audited Status().Patch below is permitted.
+type BootHandler struct {
+	Client client.Client
+	Log    logr.Logger
+	Config BootHandlerConfig
+
+	// ipLimiters holds per-source-IP rate limiters. Protected by ipLimitersMu.
+	// Entries are evicted after bootIPRateLimiterTTL of inactivity.
+	ipLimitersMu sync.Mutex
+	ipLimiters   map[string]*ipEntry
+}
+
+// ServeHTTP handles GET /api/v1/boot/{namespace}/{hostName}/{nonce}.
+func (h *BootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	namespace := r.PathValue("namespace")
+	hostName := r.PathValue("hostName")
+	// nonce is the capability token; never logged (§4.1).
+	nonce := r.PathValue("nonce")
+
+	// Log namespace + host + remote IP + outcome. Never the nonce, token,
+	// CA bytes, or rendered script.
+	log := h.Log.WithValues("namespace", namespace, "host", hostName, "remote", r.RemoteAddr)
+
+	// Rate-limit per source IP before touching the API server. The /boot route is
+	// ungated (no bearer token), so rate limiting is the first line of defence
+	// against credential-stuffing on the nonce space.
+	clientIP := remoteAddrToIP(r.RemoteAddr)
+	if !h.allowIP(clientIP) {
+		log.V(1).Info("boot GET: rate-limited", "ip", clientIP)
+		// 429 so operators can distinguish rate-limit events from opaque 404s.
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	// Empty path values are an opaque failure. The route pattern requires all
+	// three segments; this guards against a misconfigured mux.
+	if namespace == "" || hostName == "" || nonce == "" {
+		log.V(1).Info("boot GET: missing path values")
+		h.opaqueFailure(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	// 1. Get the PhysicalHost. NotFound and other errors are both opaque.
+	ph := &infrastructurev1beta1.PhysicalHost{}
+	if err := h.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: hostName}, ph); err != nil {
+		log.V(1).Info("boot GET: PhysicalHost lookup failed", "err", err.Error())
+		h.opaqueFailure(w)
+		return
+	}
+
+	// 2. Verify the nonce. All three conditions must hold: BootNonceHash non-empty,
+	// BootNonceExpiresAt in the future, and auth.Verify constant-time match.
+	// Any failure is opaque — no oracle for "bad hash" vs "expired" vs "consumed".
+	if !verifyBootNonce(nonce, ph) {
+		log.V(1).Info("boot GET: nonce verification failed")
+		h.opaqueFailure(w)
+		return
+	}
+
+	// 3. Consume the nonce (D-010 — atomic single-use under optimistic lock).
+	//
+	// If already consumed (BootNonceConsumedAt != nil), this is a race loser or
+	// a legitimate NIC retry. Skip the patch and fall through to render identical
+	// content (§4.1 guarantees same response for same host regardless of order).
+	//
+	// D-010: this Status().Patch is the sole audited exception to D-005.
+	// The field written (BootNonceConsumedAt) is owned exclusively by this
+	// handler; no reconciler writes it, so the BUG-1 last-write-wins hazard
+	// does not apply. A Conflict is the desired outcome (the winner consumed;
+	// the loser confirms it and renders identically).
+	if ph.Status.Bootstrap.BootNonceConsumedAt == nil {
+		var consumeOK bool
+		for attempt := 0; attempt < bootNonceConsumeMaxRetries; attempt++ {
+			base := ph.DeepCopy()
+			now := metav1.NewTime(time.Now())
+			ph.Status.Bootstrap.BootNonceConsumedAt = &now
+
+			// Status().Update is FORBIDDEN in handler files (D-005).
+			// This single Status().Patch is the audited D-010 exception.
+			patchErr := h.Client.Status().Patch(ctx, ph,
+				client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{}))
+			if patchErr == nil {
+				consumeOK = true
+				break
+			}
+			if !apierrors.IsConflict(patchErr) {
+				log.V(1).Info("boot GET: consume patch failed", "err", patchErr.Error())
+				h.opaqueFailure(w)
+				return
+			}
+			// Conflict: the object was mutated between our Get and our Patch.
+			// Re-Get and re-evaluate.
+			fresh := &infrastructurev1beta1.PhysicalHost{}
+			if getErr := h.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: hostName}, fresh); getErr != nil {
+				log.V(1).Info("boot GET: re-get after conflict failed", "err", getErr.Error())
+				h.opaqueFailure(w)
+				return
+			}
+			ph = fresh
+
+			// If the fresh object is already consumed, we lost the race; render
+			// identical content below.
+			if ph.Status.Bootstrap != nil && ph.Status.Bootstrap.BootNonceConsumedAt != nil {
+				consumeOK = true
+				break
+			}
+			// If the nonce is no longer valid in the fresh copy (e.g. the
+			// PhysicalHost reconciler cleared the hash), treat as opaque failure.
+			if !verifyBootNonce(nonce, ph) {
+				log.V(1).Info("boot GET: nonce no longer valid after conflict re-get")
+				h.opaqueFailure(w)
+				return
+			}
+		}
+		if !consumeOK {
+			// Exhausted retries without a durable consume or a confirmed
+			// already-consumed state.
+			log.V(1).Info("boot GET: consume retries exhausted")
+			h.opaqueFailure(w)
+			return
+		}
+	}
+
+	// 4. Render — ONLY after consume is durable (or already-consumed confirmed).
+	// renderBootScript is a pure function of (ph, machine, secret, config) so
+	// the response is byte-identical on the fresh-consume and already-consumed
+	// paths.
+	script, err := h.renderBootScript(ctx, log, ph)
+	if err != nil {
+		log.V(1).Info("boot GET: render failed", "err", err.Error())
+		h.opaqueFailure(w)
+		return
+	}
+
+	log.Info("boot GET: served iPXE script")
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(script)); err != nil {
+		log.V(1).Info("boot GET: response write failed", "err", err.Error())
+	}
+}
+
+// verifyBootNonce reports whether the nonce is valid for the given host.
+// All three conditions must hold: BootNonceHash non-empty, BootNonceExpiresAt
+// in the future, and auth.Verify constant-time match. Pulled out so it can be
+// re-evaluated after an optimistic-lock conflict without duplicating logic.
+//
+// Deliberately does NOT check BootNonceConsumedAt — that check belongs in the
+// consume path so the already-consumed branch can render identical content.
+func verifyBootNonce(nonce string, ph *infrastructurev1beta1.PhysicalHost) bool {
+	bs := ph.Status.Bootstrap
+	if bs == nil || bs.BootNonceHash == "" {
+		return false
+	}
+	if bs.BootNonceExpiresAt == nil || !time.Now().Before(bs.BootNonceExpiresAt.Time) {
+		return false
+	}
+	return auth.Verify(nonce, bs.BootNonceHash)
+}
+
+// validateBootURL rejects values that could break out of a single
+// space-delimited kernel cmdline parameter. Closes the cmdline-injection vector
+// (SEC-7): a value with whitespace/control chars or a non-http(s) scheme could
+// inject or override beskar7.* params rendered into the /boot iPXE script.
+func validateBootURL(field, raw string) error {
+	if strings.ContainsFunc(raw, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	}) {
+		return fmt.Errorf("%s contains whitespace or control characters", field)
+	}
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("%s is not a valid http(s) URL", field)
+	}
+	return nil
+}
+
+// renderBootScript resolves the consuming Beskar7Machine, reads the bearer-token
+// plaintext from the per-host Secret, and renders the §4.1 iPXE script.
+//
+// Pure function of (host, machine, secret, config): the rendered output is
+// byte-identical on fresh-consume and already-consumed paths for the same host.
+// No secret material is logged here; the caller logs only namespace + host +
+// outcome.
+func (h *BootHandler) renderBootScript(
+	ctx context.Context,
+	log logr.Logger,
+	ph *infrastructurev1beta1.PhysicalHost,
+) (string, error) {
+	// Walk to the consuming Beskar7Machine via Spec.ConsumerRef.
+	cr := ph.Spec.ConsumerRef
+	if cr == nil || cr.Kind != "Beskar7Machine" || cr.APIVersion != InfrastructureAPIVersion {
+		return "", fmt.Errorf("PhysicalHost %s/%s has no Beskar7Machine consumer", ph.Namespace, ph.Name)
+	}
+	b7m := &infrastructurev1beta1.Beskar7Machine{}
+	if err := h.Client.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name}, b7m); err != nil {
+		return "", fmt.Errorf("get Beskar7Machine %s/%s: %w", cr.Namespace, cr.Name, err)
+	}
+
+	// InspectionImageURL is the base URL for vmlinuz + initrd.img (contract v1
+	// re-purposes this previously-unused field as the inspector image base).
+	if b7m.Spec.InspectionImageURL == "" {
+		return "", fmt.Errorf("Beskar7Machine %s/%s has empty InspectionImageURL", b7m.Namespace, b7m.Name)
+	}
+
+	// Validate both URL fields before rendering (SEC-7 / C-1a). A space or control
+	// character in either value would break out of its cmdline parameter and allow
+	// the tenant to inject or override subsequent beskar7.* parameters. This check
+	// is defence-in-depth on top of the CRD pattern (C-1b); it is the airtight
+	// fix because it operates on the value actually rendered, not the value admitted.
+	if err := validateBootURL("InspectionImageURL", b7m.Spec.InspectionImageURL); err != nil {
+		return "", err
+	}
+	if err := validateBootURL("TargetImageURL", b7m.Spec.TargetImageURL); err != nil {
+		return "", err
+	}
+
+	// Read the bearer-token plaintext from the per-host bootstrap-token Secret.
+	// The handler received the {nonce} in the URL; it hands back the bearer token
+	// in the rendered cmdline — these are two distinct secrets (§3, D-009).
+	secret := &corev1.Secret{}
+	secretKey := types.NamespacedName{Namespace: ph.Namespace, Name: bootstrapTokenSecretName(ph.Name)}
+	if err := h.Client.Get(ctx, secretKey, secret); err != nil {
+		return "", fmt.Errorf("get bootstrap-token Secret %s: %w", secretKey.Name, err)
+	}
+	tokenBytes, ok := secret.Data["plaintext-token"]
+	if !ok || len(tokenBytes) == 0 {
+		return "", fmt.Errorf("bootstrap-token Secret %s has no plaintext-token key", secretKey.Name)
+	}
+
+	// base64-encode the CA PEM for inline delivery via beskar7.ca=.
+	caB64 := base64.StdEncoding.EncodeToString(h.Config.CABytes)
+
+	script := buildBootIPXEScript(
+		b7m.Spec.InspectionImageURL,
+		h.Config.APIBase,
+		ph.Namespace,
+		ph.Name,
+		string(tokenBytes),
+		b7m.Spec.TargetImageURL,
+		caB64,
+	)
+
+	// Cap the rendered script length (SEC-10). The Linux kernel cmdline cap is
+	// ~2–4 KiB; a script that exceeds bootScriptMaxBytes would silently truncate
+	// on real hardware. This is operator misconfig (e.g. an over-large CA chain);
+	// log at Info so it is operator-visible, then return an opaque failure.
+	if len(script) > bootScriptMaxBytes {
+		log.Info("boot GET: rendered script exceeds maximum allowed size; operator must shorten CA or URL fields",
+			"scriptBytes", len(script), "maxBytes", bootScriptMaxBytes)
+		return "", fmt.Errorf("rendered boot script (%d bytes) exceeds bootScriptMaxBytes (%d)", len(script), bootScriptMaxBytes)
+	}
+
+	_ = log // outcome is logged by the caller; no script or secret content logged here.
+
+	return script, nil
+}
+
+// buildBootIPXEScript is a pure function that renders the §4.1 iPXE boot
+// script. All inputs are caller-resolved; this function performs no I/O.
+// Package-level so tests can call it directly for golden-string assertions.
+//
+// Optional parameters (beskar7.timeout, beskar7.debug) are omitted in
+// contract v1 — no operator UI to supply them yet.
+func buildBootIPXEScript(
+	inspectionImageURL string,
+	apiBase string,
+	namespace string,
+	hostName string,
+	token string,
+	targetImageURL string,
+	caB64 string,
+) string {
+	return fmt.Sprintf(
+		"#!ipxe\nkernel %s/vmlinuz beskar7.api=%s beskar7.namespace=%s beskar7.host=%s beskar7.token=%s beskar7.target=%s beskar7.ca=%s\ninitrd %s/initrd.img\nboot\n",
+		inspectionImageURL,
+		apiBase,
+		namespace,
+		hostName,
+		token,
+		targetImageURL,
+		caB64,
+		inspectionImageURL,
+	)
+}
+
+// opaqueFailure writes the canonical §4.1 failure response. Every failure
+// path calls this so the response is byte-identical regardless of cause.
+// Mirrors the bootstrap_handler.go opaque-404 discipline.
+func (h *BootHandler) opaqueFailure(w http.ResponseWriter) {
+	http.Error(w, bootHandlerOpaqueFailureBody, bootHandlerOpaqueFailureStatus)
+}
+
+// allowIP returns true if the given client IP is within its rate-limit budget.
+// Uses golang.org/x/time/rate (already an indirect dep via client-go), keyed
+// by IP in a bounded sync.Map-style map. Stale entries are opportunistically
+// evicted after bootIPRateLimiterTTL to bound memory growth.
+func (h *BootHandler) allowIP(ip string) bool {
+	h.ipLimitersMu.Lock()
+	defer h.ipLimitersMu.Unlock()
+
+	if h.ipLimiters == nil {
+		h.ipLimiters = make(map[string]*ipEntry)
+	}
+
+	entry, ok := h.ipLimiters[ip]
+	if !ok {
+		entry = &ipEntry{
+			limiter: rate.NewLimiter(bootIPRateLimitRPS, bootIPRateLimitBurst),
+		}
+		h.ipLimiters[ip] = entry
+	}
+	entry.lastSeen = time.Now()
+
+	// Opportunistic eviction: scan for entries idle beyond TTL. Amortised O(n)
+	// where n is the number of active IPs on the provisioning network; typically
+	// small (one entry per host being booted concurrently).
+	for k, e := range h.ipLimiters {
+		if k != ip && time.Since(e.lastSeen) > bootIPRateLimiterTTL {
+			delete(h.ipLimiters, k)
+		}
+	}
+
+	return entry.limiter.Allow()
+}
+
+// remoteAddrToIP extracts the IP portion from an "ip:port" RemoteAddr.
+// Falls back to the full string on parse failure so rate limiting still
+// operates (the key is stable per connection either way).
+func remoteAddrToIP(remoteAddr string) string {
+	for i := len(remoteAddr) - 1; i >= 0; i-- {
+		if remoteAddr[i] == ':' {
+			return remoteAddr[:i]
+		}
+	}
+	return remoteAddr
+}

--- a/controllers/boot_handler_test.go
+++ b/controllers/boot_handler_test.go
@@ -1,0 +1,865 @@
+/*
+Copyright 2024 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrastructurev1beta1 "github.com/projectbeskar/beskar7/api/v1beta1"
+	"github.com/projectbeskar/beskar7/internal/auth"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const (
+	bootTestAPIBase = "https://beskar7.example.com:8082"
+	bootTestCABytes = "FAKE-CA-PEM-DATA"
+)
+
+// buildBootMux wires a BootHandler onto a ServeMux using the same route pattern
+// as SetupCallbackServer. Tests drive it via httptest.Server.
+func buildBootMux(cfg BootHandlerConfig) *http.ServeMux {
+	log := ctrl.Log.WithName("boot-handler-test")
+	handler := &BootHandler{
+		Client: k8sClient,
+		Log:    log,
+		Config: cfg,
+	}
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/boot/{namespace}/{hostName}/{nonce}", handler)
+	return mux
+}
+
+// bootTestConfig returns a BootHandlerConfig suitable for tests.
+func bootTestConfig() BootHandlerConfig {
+	return BootHandlerConfig{
+		APIBase: bootTestAPIBase,
+		CABytes: []byte(bootTestCABytes),
+	}
+}
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+// bootTestFixture creates the full set of Kubernetes objects needed for a
+// happy-path /boot test:
+//   - PhysicalHost in testNs
+//   - Beskar7Machine (consumer) in testNs with InspectionImageURL + TargetImageURL set
+//   - ConsumerRef linking the host to the machine
+//   - bootstrap-token Secret holding plaintext-token
+//
+// Returns (physicalHost, b7machine, bearerTokenPlaintext, noncePlaintext).
+// The caller is responsible for minting and storing the boot nonce on the host's
+// Status.Bootstrap (use setHostBootNonce).
+func bootTestFixture(testNs string) (
+	*infrastructurev1beta1.PhysicalHost,
+	*infrastructurev1beta1.Beskar7Machine,
+	string, /* bearerToken plaintext */
+	string, /* nonce plaintext */
+) {
+	By("creating PhysicalHost")
+	ph := &infrastructurev1beta1.PhysicalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "boot-handler-host",
+			Namespace: testNs,
+		},
+		Spec: infrastructurev1beta1.PhysicalHostSpec{
+			RedfishConnection: infrastructurev1beta1.RedfishConnection{
+				Address:              "https://192.168.99.1",
+				CredentialsSecretRef: "irrelevant",
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, ph)).To(Succeed())
+
+	By("creating Beskar7Machine (consumer)")
+	b7m := &infrastructurev1beta1.Beskar7Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "boot-handler-b7m",
+			Namespace: testNs,
+		},
+		Spec: infrastructurev1beta1.Beskar7MachineSpec{
+			InspectionImageURL: "https://boot.example.com/inspect",
+			TargetImageURL:     "https://boot.example.com/kairos.tar.gz",
+		},
+	}
+	Expect(k8sClient.Create(ctx, b7m)).To(Succeed())
+
+	By("linking ConsumerRef on PhysicalHost")
+	freshPH := &infrastructurev1beta1.PhysicalHost{}
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs}, freshPH)).To(Succeed())
+	base := freshPH.DeepCopy()
+	freshPH.Spec.ConsumerRef = &corev1.ObjectReference{
+		Kind:       "Beskar7Machine",
+		APIVersion: InfrastructureAPIVersion,
+		Name:       b7m.Name,
+		Namespace:  b7m.Namespace,
+		UID:        b7m.UID,
+	}
+	Expect(k8sClient.Patch(ctx, freshPH, client.MergeFrom(base))).To(Succeed())
+
+	By("minting bearer token and creating bootstrap-token Secret")
+	bearerPlaintext, bearerHash, err := auth.MintToken()
+	Expect(err).NotTo(HaveOccurred())
+
+	noncePlaintext, nonceHash, err := auth.MintToken()
+	Expect(err).NotTo(HaveOccurred())
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bootstrapTokenSecretName(ph.Name),
+			Namespace: testNs,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"plaintext-token":      []byte(bearerPlaintext),
+			"plaintext-boot-nonce": []byte(noncePlaintext),
+		},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+	By("writing BootNonceHash + BootNonceExpiresAt to PhysicalHost Status.Bootstrap")
+	setHostBootNonce(freshPH.Name, testNs, nonceHash, bearerHash, 10*time.Minute)
+
+	// Return fresh copies so callers hold the latest resourceVersion.
+	gotPH := &infrastructurev1beta1.PhysicalHost{}
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs}, gotPH)).To(Succeed())
+
+	return gotPH, b7m, bearerPlaintext, noncePlaintext
+}
+
+// setHostBootNonce writes BootNonceHash, BootNonceExpiresAt, and TokenHash to
+// the host's Status.Bootstrap via Status().Update. Call after the host exists.
+func setHostBootNonce(hostName, ns, nonceHash, tokenHash string, ttl time.Duration) {
+	ph := &infrastructurev1beta1.PhysicalHost{}
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: hostName, Namespace: ns}, ph)).To(Succeed())
+	expiresAt := metav1.NewTime(time.Now().Add(ttl))
+	issuedAt := metav1.NewTime(time.Now())
+	tokenExpiresAt := metav1.NewTime(time.Now().Add(30 * time.Minute))
+	ph.Status.Bootstrap = &infrastructurev1beta1.BootstrapStatus{
+		TokenHash:          tokenHash,
+		IssuedAt:           &issuedAt,
+		ExpiresAt:          &tokenExpiresAt,
+		BootNonceHash:      nonceHash,
+		BootNonceExpiresAt: &expiresAt,
+	}
+	Expect(k8sClient.Status().Update(ctx, ph)).To(Succeed())
+}
+
+// doBoot issues GET /api/v1/boot/{namespace}/{host}/{nonce} against server.
+func doBoot(serverURL, namespace, hostName, nonce string) *http.Response {
+	url := fmt.Sprintf("%s/api/v1/boot/%s/%s/%s", serverURL, namespace, hostName, nonce)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, bytes.NewReader(nil))
+	Expect(err).NotTo(HaveOccurred())
+	resp, err := http.DefaultClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	return resp
+}
+
+// readBody reads and closes the response body, returning a string.
+func readBody(resp *http.Response) string {
+	defer func() { _ = resp.Body.Close() }()
+	b, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	return string(b)
+}
+
+// ── specs ─────────────────────────────────────────────────────────────────────
+
+var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
+	const (
+		Timeout  = 10 * time.Second
+		Interval = 250 * time.Millisecond
+	)
+
+	var (
+		testNs *corev1.Namespace
+		server *httptest.Server
+	)
+
+	BeforeEach(func() {
+		testNs = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "boot-handler-test-"},
+		}
+		Expect(k8sClient.Create(ctx, testNs)).To(Succeed())
+
+		server = httptest.NewServer(buildBootMux(bootTestConfig()))
+	})
+
+	AfterEach(func() {
+		server.Close()
+		Expect(k8sClient.Delete(ctx, testNs)).To(Succeed())
+	})
+
+	// ── 1. Happy path ──────────────────────────────────────────────────────
+
+	It("happy path: valid fresh nonce → 200 with correct iPXE script, ConsumedAt set", func() {
+		ph, b7m, _, nonce := bootTestFixture(testNs.Name)
+
+		resp := doBoot(server.URL, testNs.Name, ph.Name, nonce)
+		body := readBody(resp)
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(resp.Header.Get("Content-Type")).To(Equal("text/plain"))
+
+		By("asserting iPXE script structure")
+		Expect(body).To(HavePrefix("#!ipxe\n"))
+		Expect(body).To(ContainSubstring(b7m.Spec.InspectionImageURL+"/vmlinuz"))
+		Expect(body).To(ContainSubstring("beskar7.api="+bootTestAPIBase))
+		Expect(body).To(ContainSubstring("beskar7.namespace="+testNs.Name))
+		Expect(body).To(ContainSubstring("beskar7.host="+ph.Name))
+		Expect(body).To(ContainSubstring("beskar7.token="))
+		Expect(body).To(ContainSubstring("beskar7.target="+b7m.Spec.TargetImageURL))
+		Expect(body).To(ContainSubstring("beskar7.ca="))
+		Expect(body).To(ContainSubstring("initrd "+b7m.Spec.InspectionImageURL+"/initrd.img"))
+		Expect(body).To(ContainSubstring("\nboot\n"))
+
+		By("asserting BootNonceConsumedAt is set")
+		Eventually(func(g Gomega) {
+			got := &infrastructurev1beta1.PhysicalHost{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, got)).To(Succeed())
+			g.Expect(got.Status.Bootstrap).NotTo(BeNil())
+			g.Expect(got.Status.Bootstrap.BootNonceConsumedAt).NotTo(BeNil(),
+				"BootNonceConsumedAt must be set after first /boot fetch")
+		}, Timeout, Interval).Should(Succeed())
+	})
+
+	// ── 2. Single-use under concurrency (load-bearing) ────────────────────
+
+	It("single-use under concurrency: two goroutines, both 200, identical body, ConsumedAt set once", func() {
+		ph, _, _, nonce := bootTestFixture(testNs.Name)
+
+		const workers = 2
+		results := make([]struct {
+			status int
+			body   string
+		}, workers)
+
+		var wg sync.WaitGroup
+		for i := 0; i < workers; i++ {
+			i := i
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer GinkgoRecover()
+				resp := doBoot(server.URL, testNs.Name, ph.Name, nonce)
+				b := readBody(resp)
+				results[i].status = resp.StatusCode
+				results[i].body = b
+			}()
+		}
+		wg.Wait()
+
+		By("both fetches must succeed with 200")
+		for i, r := range results {
+			Expect(r.status).To(Equal(http.StatusOK),
+				fmt.Sprintf("goroutine %d: expected 200, got %d (body: %q)", i, r.status, r.body))
+		}
+
+		By("byte-identical bodies (§4.1 idempotency guarantee)")
+		Expect(results[0].body).To(Equal(results[1].body),
+			"both fetches must return byte-identical iPXE scripts")
+
+		By("BootNonceConsumedAt set exactly once — value stable after second fetch")
+		var firstConsumedAt *metav1.Time
+		Eventually(func(g Gomega) {
+			got := &infrastructurev1beta1.PhysicalHost{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, got)).To(Succeed())
+			g.Expect(got.Status.Bootstrap).NotTo(BeNil())
+			g.Expect(got.Status.Bootstrap.BootNonceConsumedAt).NotTo(BeNil())
+			firstConsumedAt = got.Status.Bootstrap.BootNonceConsumedAt
+		}, Timeout, Interval).Should(Succeed())
+
+		// A brief pause then a third fetch confirms value stability.
+		time.Sleep(50 * time.Millisecond)
+		got := &infrastructurev1beta1.PhysicalHost{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, got)).To(Succeed())
+		Expect(got.Status.Bootstrap.BootNonceConsumedAt.Time).To(BeTemporally("==", firstConsumedAt.Time),
+			"BootNonceConsumedAt must not be advanced by subsequent fetches")
+	})
+
+	// ── 3. Already-consumed retry ──────────────────────────────────────────
+
+	It("already-consumed: identical render, no second patch, ConsumedAt value unchanged", func() {
+		ph, b7m, _, nonce := bootTestFixture(testNs.Name)
+
+		By("pre-consuming the nonce")
+		consumedAt := metav1.NewTime(time.Now().Add(-1 * time.Second))
+		freshPH := &infrastructurev1beta1.PhysicalHost{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, freshPH)).To(Succeed())
+		freshPH.Status.Bootstrap.BootNonceConsumedAt = &consumedAt
+		Expect(k8sClient.Status().Update(ctx, freshPH)).To(Succeed())
+
+		By("issuing a /boot fetch against an already-consumed nonce")
+		resp := doBoot(server.URL, testNs.Name, ph.Name, nonce)
+		body := readBody(resp)
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		By("body is the correct iPXE script")
+		Expect(body).To(ContainSubstring(b7m.Spec.InspectionImageURL+"/vmlinuz"))
+		Expect(body).To(ContainSubstring("beskar7.token="))
+
+		By("ConsumedAt is unchanged — same second as the pre-set value")
+		got := &infrastructurev1beta1.PhysicalHost{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, got)).To(Succeed())
+		Expect(got.Status.Bootstrap.BootNonceConsumedAt).NotTo(BeNil())
+		// metav1.Time serializes to second-precision RFC3339; compare truncated.
+		Expect(got.Status.Bootstrap.BootNonceConsumedAt.Truncate(time.Second)).To(
+			BeTemporally("==", consumedAt.Truncate(time.Second)),
+			"ConsumedAt must not be advanced by a second /boot fetch")
+	})
+
+	// ── 4. Opaque failures ─────────────────────────────────────────────────
+
+	It("opaque 404: expired nonce", func() {
+		ph, _, _, nonce := bootTestFixture(testNs.Name)
+
+		By("overwriting the expiry to the past")
+		freshPH := &infrastructurev1beta1.PhysicalHost{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, freshPH)).To(Succeed())
+		expiredAt := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+		freshPH.Status.Bootstrap.BootNonceExpiresAt = &expiredAt
+		Expect(k8sClient.Status().Update(ctx, freshPH)).To(Succeed())
+
+		resp := doBoot(server.URL, testNs.Name, ph.Name, nonce)
+		body := readBody(resp)
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		Expect(body).To(ContainSubstring(bootHandlerOpaqueFailureBody))
+	})
+
+	It("opaque 404: wrong nonce", func() {
+		ph, _, _, _ := bootTestFixture(testNs.Name)
+		// Use a freshly minted token as the "wrong nonce" — 256-bit entropy makes
+		// collisions impossible.
+		wrongNonce, _, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+
+		resp := doBoot(server.URL, testNs.Name, ph.Name, wrongNonce)
+		body := readBody(resp)
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		Expect(body).To(ContainSubstring(bootHandlerOpaqueFailureBody))
+	})
+
+	It("opaque 404: unknown host", func() {
+		resp := doBoot(server.URL, testNs.Name, "no-such-host", "some-nonce")
+		body := readBody(resp)
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		Expect(body).To(ContainSubstring(bootHandlerOpaqueFailureBody))
+	})
+
+	It("opaque 404: no Beskar7Machine consumer (ConsumerRef nil)", func() {
+		By("creating a host with no ConsumerRef")
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "boot-no-consumer",
+				Namespace: testNs.Name,
+			},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address:              "https://192.168.99.2",
+					CredentialsSecretRef: "irrelevant",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ph)).To(Succeed())
+
+		noncePlaintext, nonceHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		_, tokenHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		setHostBootNonce(ph.Name, testNs.Name, nonceHash, tokenHash, 10*time.Minute)
+
+		// Create the token secret (the handler reads it after resolving the
+		// consumer, but we still create it to isolate the "no consumer" branch).
+		Expect(k8sClient.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bootstrapTokenSecretName(ph.Name),
+				Namespace: testNs.Name,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{"plaintext-token": []byte("irrelevant")},
+		})).To(Succeed())
+
+		resp := doBoot(server.URL, testNs.Name, ph.Name, noncePlaintext)
+		body := readBody(resp)
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		Expect(body).To(ContainSubstring(bootHandlerOpaqueFailureBody))
+	})
+
+	// Empty InspectionImageURL: CRD validation forbids an empty string at
+	// admission time, so we use a fake client (which skips API validation) to
+	// stage the object. Same technique as the oversize-bootstrap test.
+	It("opaque 404: empty InspectionImageURL on Beskar7Machine (fake client)", func() {
+		noncePlaintext, nonceHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		_, tokenHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+
+		nonceExpiresAt := metav1.NewTime(time.Now().Add(10 * time.Minute))
+		issuedAt := metav1.NewTime(time.Now())
+		tokenExpiresAt := metav1.NewTime(time.Now().Add(30 * time.Minute))
+
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "h-empty-inspect", Namespace: "n"},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address: "https://192.168.1.1", CredentialsSecretRef: "x",
+				},
+				ConsumerRef: &corev1.ObjectReference{
+					Kind:       "Beskar7Machine",
+					APIVersion: InfrastructureAPIVersion,
+					Name:       "b7m-empty",
+					Namespace:  "n",
+				},
+			},
+			Status: infrastructurev1beta1.PhysicalHostStatus{
+				Bootstrap: &infrastructurev1beta1.BootstrapStatus{
+					TokenHash:          tokenHash,
+					IssuedAt:           &issuedAt,
+					ExpiresAt:          &tokenExpiresAt,
+					BootNonceHash:      nonceHash,
+					BootNonceExpiresAt: &nonceExpiresAt,
+				},
+			},
+		}
+		// Beskar7Machine with empty InspectionImageURL (bypassing CRD validation
+		// via fake client — testing the handler's own guard, not the CRD schema).
+		b7mEmpty := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "b7m-empty", Namespace: "n"},
+			Spec: infrastructurev1beta1.Beskar7MachineSpec{
+				InspectionImageURL: "", // empty — triggers the handler's guard
+				TargetImageURL:     "https://boot.example.com/target.tar.gz",
+			},
+		}
+		tokenSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenSecretName("h-empty-inspect"), Namespace: "n"},
+			Type:       corev1.SecretTypeOpaque,
+			Data:       map[string][]byte{"plaintext-token": []byte("fake-token")},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(k8sClient.Scheme()).
+			WithObjects(b7mEmpty, tokenSecret).
+			WithStatusSubresource(ph).
+			WithObjects(ph).
+			Build()
+		// Set status directly (fake client allows this without Status().Update).
+		// Re-Get to apply the Status.Bootstrap we set in the object literal above.
+		// Fake client populates status from WithObjects when WithStatusSubresource is set.
+
+		handler := &BootHandler{
+			Client: fakeClient,
+			Log:    ctrl.Log.WithName("boot-empty-inspect-test"),
+			Config: bootTestConfig(),
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/boot/n/h-empty-inspect/"+noncePlaintext, nil)
+		req.SetPathValue("namespace", "n")
+		req.SetPathValue("hostName", "h-empty-inspect")
+		req.SetPathValue("nonce", noncePlaintext)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusNotFound),
+			"empty InspectionImageURL must be an opaque 404, not a 200")
+		Expect(w.Body.String()).To(ContainSubstring(bootHandlerOpaqueFailureBody))
+	})
+
+	It("opaque 404: missing bootstrap-token Secret", func() {
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "boot-no-secret",
+				Namespace: testNs.Name,
+			},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address:              "https://192.168.99.4",
+					CredentialsSecretRef: "irrelevant",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ph)).To(Succeed())
+
+		b7m := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "boot-b7m-no-secret",
+				Namespace: testNs.Name,
+			},
+			Spec: infrastructurev1beta1.Beskar7MachineSpec{
+				InspectionImageURL: "https://boot.example.com/inspect",
+				TargetImageURL:     "https://boot.example.com/target.tar.gz",
+			},
+		}
+		Expect(k8sClient.Create(ctx, b7m)).To(Succeed())
+
+		freshPH := &infrastructurev1beta1.PhysicalHost{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, freshPH)).To(Succeed())
+		base := freshPH.DeepCopy()
+		freshPH.Spec.ConsumerRef = &corev1.ObjectReference{
+			Kind:       "Beskar7Machine",
+			APIVersion: InfrastructureAPIVersion,
+			Name:       b7m.Name,
+			Namespace:  b7m.Namespace,
+		}
+		Expect(k8sClient.Patch(ctx, freshPH, client.MergeFrom(base))).To(Succeed())
+
+		noncePlaintext, nonceHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		_, tokenHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		setHostBootNonce(ph.Name, testNs.Name, nonceHash, tokenHash, 10*time.Minute)
+		// Deliberately do NOT create the bootstrap-token Secret.
+
+		resp := doBoot(server.URL, testNs.Name, ph.Name, noncePlaintext)
+		body := readBody(resp)
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		Expect(body).To(ContainSubstring(bootHandlerOpaqueFailureBody))
+	})
+
+	// ── 5. Injection rejection (C-1a / SEC-7) ────────────────────────────
+
+	// buildInjectionFakeHandler creates a BootHandler backed by a fake client
+	// containing a PhysicalHost with a valid boot nonce and a Beskar7Machine whose
+	// spec fields are set by the caller. Used to test injection rejection without
+	// round-tripping through CRD admission validation (which would reject the
+	// malicious value before it reaches the handler).
+	//
+	// We define it as a local closure rather than a top-level helper so it can
+	// capture the test namespace's context cleanly.
+	buildInjectionFakeHandler := func(inspectionURL, targetURL string) (*BootHandler, string) {
+		noncePlaintext, nonceHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		_, tokenHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+
+		nonceExpiresAt := metav1.NewTime(time.Now().Add(10 * time.Minute))
+		issuedAt := metav1.NewTime(time.Now())
+		tokenExpiresAt := metav1.NewTime(time.Now().Add(30 * time.Minute))
+
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "h-inject", Namespace: "n"},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address: "https://192.168.1.1", CredentialsSecretRef: "x",
+				},
+				ConsumerRef: &corev1.ObjectReference{
+					Kind:       "Beskar7Machine",
+					APIVersion: InfrastructureAPIVersion,
+					Name:       "b7m-inject",
+					Namespace:  "n",
+				},
+			},
+			Status: infrastructurev1beta1.PhysicalHostStatus{
+				Bootstrap: &infrastructurev1beta1.BootstrapStatus{
+					TokenHash:          tokenHash,
+					IssuedAt:           &issuedAt,
+					ExpiresAt:          &tokenExpiresAt,
+					BootNonceHash:      nonceHash,
+					BootNonceExpiresAt: &nonceExpiresAt,
+				},
+			},
+		}
+		b7m := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "b7m-inject", Namespace: "n"},
+			Spec: infrastructurev1beta1.Beskar7MachineSpec{
+				InspectionImageURL: inspectionURL,
+				TargetImageURL:     targetURL,
+			},
+		}
+		tokenSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenSecretName("h-inject"), Namespace: "n"},
+			Type:       corev1.SecretTypeOpaque,
+			Data:       map[string][]byte{"plaintext-token": []byte("fake-token")},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(k8sClient.Scheme()).
+			WithObjects(b7m, tokenSecret).
+			WithStatusSubresource(ph).
+			WithObjects(ph).
+			Build()
+
+		handler := &BootHandler{
+			Client: fakeClient,
+			Log:    ctrl.Log.WithName("boot-inject-test"),
+			Config: bootTestConfig(),
+		}
+		return handler, noncePlaintext
+	}
+
+	// doBootDirect issues ServeHTTP directly against a handler using path values
+	// set via SetPathValue, bypassing the mux routing.
+	doBootDirect := func(handler *BootHandler, namespace, hostName, nonce string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/boot/"+namespace+"/"+hostName+"/"+nonce, nil)
+		req.SetPathValue("namespace", namespace)
+		req.SetPathValue("hostName", hostName)
+		req.SetPathValue("nonce", nonce)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w
+	}
+
+	// Table-driven injection tests — one row per injection vector.
+	// Each case mutates exactly one of the two URL fields; the other is kept valid.
+	type injectionCase struct {
+		name           string
+		inspectionURL  string
+		targetURL      string
+	}
+	injectionCases := []injectionCase{
+		// InspectionImageURL injection vectors
+		{name: "InspectionImageURL with space", inspectionURL: "http://x/ beskar7.token=ATTACKER", targetURL: "https://ok.example.com/target"},
+		{name: "InspectionImageURL with newline", inspectionURL: "http://x/\nbeskar7.token=ATTACKER", targetURL: "https://ok.example.com/target"},
+		{name: "InspectionImageURL with tab", inspectionURL: "http://x/\tbeskar7.token=ATTACKER", targetURL: "https://ok.example.com/target"},
+		{name: "InspectionImageURL with control char", inspectionURL: "http://x/\x01evil", targetURL: "https://ok.example.com/target"},
+		{name: "InspectionImageURL with non-http scheme", inspectionURL: "file:///etc/passwd", targetURL: "https://ok.example.com/target"},
+		// TargetImageURL injection vectors
+		{name: "TargetImageURL with space", inspectionURL: "https://ok.example.com/inspect", targetURL: "http://x/ beskar7.api=ATTACKER"},
+		{name: "TargetImageURL with newline", inspectionURL: "https://ok.example.com/inspect", targetURL: "http://x/\nbeskar7.api=ATTACKER"},
+		{name: "TargetImageURL with tab", inspectionURL: "https://ok.example.com/inspect", targetURL: "http://x/\tbeskar7.api=ATTACKER"},
+		{name: "TargetImageURL with control char", inspectionURL: "https://ok.example.com/inspect", targetURL: "http://x/\x01evil"},
+		{name: "TargetImageURL with non-http scheme", inspectionURL: "https://ok.example.com/inspect", targetURL: "file:///etc/passwd"},
+	}
+
+	for _, tc := range injectionCases {
+		tc := tc // capture range variable
+		It("injection rejection (SEC-7): "+tc.name+" → opaque 404", func() {
+			handler, nonce := buildInjectionFakeHandler(tc.inspectionURL, tc.targetURL)
+			w := doBootDirect(handler, "n", "h-inject", nonce)
+
+			Expect(w.Code).To(Equal(http.StatusNotFound),
+				"injection attempt must yield opaque 404, not a 200 with injected script")
+			Expect(w.Body.String()).To(ContainSubstring(bootHandlerOpaqueFailureBody))
+			// Confirm the injected payload does not appear in the response body.
+			Expect(w.Body.String()).NotTo(ContainSubstring("ATTACKER"),
+				"injected payload must not appear in response body")
+		})
+	}
+
+	// ── 6. Script length cap (SEC-10) ──────────────────────────────────────
+
+	It("length cap (SEC-10): oversized CA → opaque 404", func() {
+		// Construct a BootHandlerConfig with a CA large enough to push the
+		// rendered script over bootScriptMaxBytes. The base script without the
+		// CA is around 200 bytes; 4096 bytes of CA ensures we exceed the cap.
+		oversizedCA := make([]byte, bootScriptMaxBytes)
+		for i := range oversizedCA {
+			oversizedCA[i] = 'A' // not a real PEM, but the cap check fires before parsing
+		}
+		largeCfg := BootHandlerConfig{
+			APIBase: bootTestAPIBase,
+			CABytes: oversizedCA,
+		}
+
+		noncePlaintext, nonceHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		_, tokenHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+
+		nonceExpiresAt := metav1.NewTime(time.Now().Add(10 * time.Minute))
+		issuedAt := metav1.NewTime(time.Now())
+		tokenExpiresAt := metav1.NewTime(time.Now().Add(30 * time.Minute))
+
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "h-large-ca", Namespace: "n"},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address: "https://192.168.1.1", CredentialsSecretRef: "x",
+				},
+				ConsumerRef: &corev1.ObjectReference{
+					Kind:       "Beskar7Machine",
+					APIVersion: InfrastructureAPIVersion,
+					Name:       "b7m-large-ca",
+					Namespace:  "n",
+				},
+			},
+			Status: infrastructurev1beta1.PhysicalHostStatus{
+				Bootstrap: &infrastructurev1beta1.BootstrapStatus{
+					TokenHash:          tokenHash,
+					IssuedAt:           &issuedAt,
+					ExpiresAt:          &tokenExpiresAt,
+					BootNonceHash:      nonceHash,
+					BootNonceExpiresAt: &nonceExpiresAt,
+				},
+			},
+		}
+		b7m := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "b7m-large-ca", Namespace: "n"},
+			Spec: infrastructurev1beta1.Beskar7MachineSpec{
+				InspectionImageURL: "https://boot.example.com/inspect",
+				TargetImageURL:     "https://boot.example.com/target.tar.gz",
+			},
+		}
+		tokenSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenSecretName("h-large-ca"), Namespace: "n"},
+			Type:       corev1.SecretTypeOpaque,
+			Data:       map[string][]byte{"plaintext-token": []byte("fake-token")},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(k8sClient.Scheme()).
+			WithObjects(b7m, tokenSecret).
+			WithStatusSubresource(ph).
+			WithObjects(ph).
+			Build()
+
+		handler := &BootHandler{
+			Client: fakeClient,
+			Log:    ctrl.Log.WithName("boot-large-ca-test"),
+			Config: largeCfg,
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/boot/n/h-large-ca/"+noncePlaintext, nil)
+		req.SetPathValue("namespace", "n")
+		req.SetPathValue("hostName", "h-large-ca")
+		req.SetPathValue("nonce", noncePlaintext)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusNotFound),
+			"oversized script must be an opaque 404, not a 200 with a truncated script")
+		Expect(w.Body.String()).To(ContainSubstring(bootHandlerOpaqueFailureBody))
+	})
+
+	// ── 8. Rate limiting ───────────────────────────────────────────────────
+
+	It("rate limiting: burst exceeded from one IP → 429; different IP unaffected", func() {
+		// Drive the handler directly via httptest.ResponseRecorder so we control
+		// RemoteAddr precisely without touching the API server (the rate-limiter
+		// fires before the nonce verification).
+		bootLog := ctrl.Log.WithName("boot-rate-limit-test")
+		handler := &BootHandler{
+			Client: k8sClient,
+			Log:    bootLog,
+			Config: bootTestConfig(),
+		}
+
+		const ip1 = "10.0.0.1"
+		const ip2 = "10.0.0.2"
+
+		// Exhaust the burst from ip1. Each call to allow() burns 1 token from
+		// the bucket (burst=5). The burst+1-th call must be rejected.
+		for i := 0; i < bootIPRateLimitBurst; i++ {
+			Expect(handler.allowIP(ip1)).To(BeTrue(),
+				fmt.Sprintf("call %d (within burst) must be allowed", i+1))
+		}
+		Expect(handler.allowIP(ip1)).To(BeFalse(),
+			"call burst+1 from ip1 must be rate-limited")
+
+		By("different IP is unaffected by ip1's exhausted bucket")
+		Expect(handler.allowIP(ip2)).To(BeTrue(),
+			"ip2 has an independent bucket and must not be limited")
+	})
+
+	// ── 9. No secret leakage ───────────────────────────────────────────────
+
+	It("no secret leakage: nonce/token/script never appear in log sink", func() {
+		// Wire a log sink that captures every keyed value.
+		sink := &logCaptureSink{}
+		capLog := logWithSink(sink)
+
+		bootHandler := &BootHandler{
+			Client: k8sClient,
+			Log:    capLog,
+			Config: bootTestConfig(),
+		}
+		mux := http.NewServeMux()
+		mux.Handle("GET /api/v1/boot/{namespace}/{hostName}/{nonce}", bootHandler)
+		logServer := httptest.NewServer(mux)
+		defer logServer.Close()
+
+		ph, _, bearerToken, nonce := bootTestFixture(testNs.Name)
+
+		resp := doBoot(logServer.URL, testNs.Name, ph.Name, nonce)
+		body := readBody(resp)
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		By("assert the nonce does not appear in any log key/value")
+		for _, entry := range sink.entries {
+			Expect(entry).NotTo(ContainSubstring(nonce),
+				"nonce must never appear in logs")
+			Expect(entry).NotTo(ContainSubstring(bearerToken),
+				"bearer token must never appear in logs")
+			// The rendered script contains the bearer token; assert it's not logged.
+			Expect(entry).NotTo(ContainSubstring(body),
+				"rendered iPXE script must never appear in logs")
+		}
+	})
+})
+
+// ── log capture helpers ───────────────────────────────────────────────────────
+
+// logCaptureSink implements logr.LogSink, recording every log entry as a
+// flat string so tests can scan for forbidden material (nonce, token, script).
+type logCaptureSink struct {
+	mu      sync.Mutex
+	entries []string
+}
+
+func (s *logCaptureSink) append(msg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, msg)
+}
+
+func (s *logCaptureSink) Init(_ logr.RuntimeInfo)                      {}
+func (s *logCaptureSink) Enabled(_ int) bool                           { return true }
+func (s *logCaptureSink) Info(_ int, msg string, kv ...interface{}) {
+	s.append(fmt.Sprint(append([]interface{}{msg}, kv...)...))
+}
+func (s *logCaptureSink) Error(err error, msg string, kv ...interface{}) {
+	s.append(fmt.Sprint(append([]interface{}{msg, err}, kv...)...))
+}
+func (s *logCaptureSink) WithValues(kv ...interface{}) logr.LogSink {
+	// Return a child that shares the same entry slice.
+	return &logCaptureSinkChild{parent: s, static: fmt.Sprint(kv...)}
+}
+func (s *logCaptureSink) WithName(_ string) logr.LogSink { return s }
+
+// logCaptureSinkChild is returned by WithValues so that static key-value
+// pairs set by WithValues are also scanned for forbidden material.
+type logCaptureSinkChild struct {
+	parent *logCaptureSink
+	static string
+}
+
+func (c *logCaptureSinkChild) Init(_ logr.RuntimeInfo)                          {}
+func (c *logCaptureSinkChild) Enabled(_ int) bool                              { return true }
+func (c *logCaptureSinkChild) Info(_ int, msg string, kv ...interface{}) {
+	c.parent.append(fmt.Sprint(append([]interface{}{c.static, msg}, kv...)...))
+}
+func (c *logCaptureSinkChild) Error(err error, msg string, kv ...interface{}) {
+	c.parent.append(fmt.Sprint(append([]interface{}{c.static, msg, err}, kv...)...))
+}
+func (c *logCaptureSinkChild) WithValues(kv ...interface{}) logr.LogSink {
+	return &logCaptureSinkChild{parent: c.parent, static: c.static + fmt.Sprint(kv...)}
+}
+func (c *logCaptureSinkChild) WithName(_ string) logr.LogSink { return c }
+
+// logWithSink constructs a logr.Logger backed by the given sink.
+func logWithSink(s logr.LogSink) logr.Logger {
+	return logr.New(s)
+}

--- a/controllers/boot_handler_test.go
+++ b/controllers/boot_handler_test.go
@@ -232,14 +232,14 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 
 		By("asserting iPXE script structure")
 		Expect(body).To(HavePrefix("#!ipxe\n"))
-		Expect(body).To(ContainSubstring(b7m.Spec.InspectionImageURL+"/vmlinuz"))
-		Expect(body).To(ContainSubstring("beskar7.api="+bootTestAPIBase))
-		Expect(body).To(ContainSubstring("beskar7.namespace="+testNs.Name))
-		Expect(body).To(ContainSubstring("beskar7.host="+ph.Name))
+		Expect(body).To(ContainSubstring(b7m.Spec.InspectionImageURL + "/vmlinuz"))
+		Expect(body).To(ContainSubstring("beskar7.api=" + bootTestAPIBase))
+		Expect(body).To(ContainSubstring("beskar7.namespace=" + testNs.Name))
+		Expect(body).To(ContainSubstring("beskar7.host=" + ph.Name))
 		Expect(body).To(ContainSubstring("beskar7.token="))
-		Expect(body).To(ContainSubstring("beskar7.target="+b7m.Spec.TargetImageURL))
+		Expect(body).To(ContainSubstring("beskar7.target=" + b7m.Spec.TargetImageURL))
 		Expect(body).To(ContainSubstring("beskar7.ca="))
-		Expect(body).To(ContainSubstring("initrd "+b7m.Spec.InspectionImageURL+"/initrd.img"))
+		Expect(body).To(ContainSubstring("initrd " + b7m.Spec.InspectionImageURL + "/initrd.img"))
 		Expect(body).To(ContainSubstring("\nboot\n"))
 
 		By("asserting BootNonceConsumedAt is set")
@@ -324,7 +324,7 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 		By("body is the correct iPXE script")
-		Expect(body).To(ContainSubstring(b7m.Spec.InspectionImageURL+"/vmlinuz"))
+		Expect(body).To(ContainSubstring(b7m.Spec.InspectionImageURL + "/vmlinuz"))
 		Expect(body).To(ContainSubstring("beskar7.token="))
 
 		By("ConsumedAt is unchanged — same second as the pre-set value")
@@ -627,9 +627,9 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 	// Table-driven injection tests — one row per injection vector.
 	// Each case mutates exactly one of the two URL fields; the other is kept valid.
 	type injectionCase struct {
-		name           string
-		inspectionURL  string
-		targetURL      string
+		name          string
+		inspectionURL string
+		targetURL     string
 	}
 	injectionCases := []injectionCase{
 		// InspectionImageURL injection vectors
@@ -825,8 +825,8 @@ func (s *logCaptureSink) append(msg string) {
 	s.entries = append(s.entries, msg)
 }
 
-func (s *logCaptureSink) Init(_ logr.RuntimeInfo)                      {}
-func (s *logCaptureSink) Enabled(_ int) bool                           { return true }
+func (s *logCaptureSink) Init(_ logr.RuntimeInfo) {}
+func (s *logCaptureSink) Enabled(_ int) bool      { return true }
 func (s *logCaptureSink) Info(_ int, msg string, kv ...interface{}) {
 	s.append(fmt.Sprint(append([]interface{}{msg}, kv...)...))
 }
@@ -846,8 +846,8 @@ type logCaptureSinkChild struct {
 	static string
 }
 
-func (c *logCaptureSinkChild) Init(_ logr.RuntimeInfo)                          {}
-func (c *logCaptureSinkChild) Enabled(_ int) bool                              { return true }
+func (c *logCaptureSinkChild) Init(_ logr.RuntimeInfo) {}
+func (c *logCaptureSinkChild) Enabled(_ int) bool      { return true }
 func (c *logCaptureSinkChild) Info(_ int, msg string, kv ...interface{}) {
 	c.parent.append(fmt.Sprint(append([]interface{}{c.static, msg}, kv...)...))
 }

--- a/controllers/inspection_handler.go
+++ b/controllers/inspection_handler.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -370,22 +371,65 @@ func (h *InspectionHandler) setInspectionResultAnnotation(
 	return nil
 }
 
+// readCallbackCA reads the PEM CA bytes from certDir to populate the
+// BootHandler's BootHandlerConfig.CABytes (beskar7.ca= in the iPXE cmdline).
+//
+// The inspector uses this CA to verify the callback's TLS certificate on the
+// subsequent inspection POST and bootstrap GET (§8). Preference order:
+//  1. ca.crt — written by cert-manager and the chart's self-signed path;
+//     a dedicated CA cert is the best choice.
+//  2. tls.crt — self-signed certificates are their own CA; fall back to it
+//     when ca.crt is absent.
+//
+// Returns the raw PEM bytes. An error here blocks manager startup so
+// misconfiguration is loud (fail at setup, not at first /boot request).
+func readCallbackCA(certDir string) ([]byte, error) {
+	candidates := []string{
+		filepath.Join(certDir, "ca.crt"),
+		filepath.Join(certDir, "tls.crt"),
+	}
+	for _, p := range candidates {
+		f, err := os.Open(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("open %q: %w", p, err)
+		}
+		b, err := io.ReadAll(f)
+		_ = f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read %q: %w", p, err)
+		}
+		if len(b) > 0 {
+			return b, nil
+		}
+	}
+	return nil, fmt.Errorf("no readable CA file found in cert dir %q (tried ca.crt, tls.crt)", certDir)
+}
+
 // SetupCallbackServer wires the host-callback HTTPS server into the manager.
 //
-// The server hosts two host-scoped endpoints, both gated by the same
-// per-PhysicalHost bearer-token middleware (auth.RequireBearer +
-// newBearerTokenVerifier):
+// The server hosts three host-scoped endpoints:
 //
 //   - POST /api/v1/inspection/{namespace}/{hostName}: receives inspection
 //     reports from the inspection image (handled by InspectionHandler).
+//     Bearer-gated.
 //   - GET  /api/v1/bootstrap/{namespace}/{hostName}: serves the bootstrap data
 //     Secret bytes for the Beskar7Machine that consumes the targeted host
-//     (handled by BootstrapHandler).
+//     (handled by BootstrapHandler). Bearer-gated.
+//   - GET  /api/v1/boot/{namespace}/{hostName}/{nonce}: serves the per-host
+//     iPXE boot script (handled by BootHandler). NOT bearer-gated — gated by
+//     the single-use boot nonce (D-009). Rate-limited per source IP.
 //
-// All authentication failures return an opaque 401 — the verifier's specific
-// error is logged at V(1) only. TLS is mandatory; the cert dir defaults to the
-// webhook cert dir (same Pod, same DNS name, one cert via cert-manager).
-func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string) error {
+// All bearer-auth failures return an opaque 401. All /boot nonce failures return
+// an opaque 404. TLS is mandatory; the cert dir defaults to the webhook cert dir
+// (same Pod, same DNS name, one cert via cert-manager).
+//
+// bootstrapURLBase is the externally-reachable HTTPS base URL of this server
+// (e.g. "https://beskar7.example.com:8082"). It is rendered into the
+// beskar7.api= kernel cmdline parameter by the /boot handler. Must be non-empty.
+func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string, bootstrapURLBase string) error {
 	if certDir == "" {
 		return fmt.Errorf("callback server cert dir is empty; set --inspection-cert-dir")
 	}
@@ -397,6 +441,17 @@ func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string) error {
 	}
 	if _, err := os.Stat(keyPath); err != nil {
 		return fmt.Errorf("callback server key %q not readable: %w", keyPath, err)
+	}
+
+	// Read the CA bytes for the /boot handler's beskar7.ca= cmdline parameter.
+	// The inspector uses this CA to verify the callback TLS certificate on
+	// the subsequent inspection POST and bootstrap GET (§8).
+	// Preference: ca.crt (cert-manager and the chart's self-signed path both
+	// write a dedicated ca.crt alongside tls.crt/tls.key). Fallback: tls.crt
+	// itself (self-signed certificates are their own CA).
+	caBytes, err := readCallbackCA(certDir)
+	if err != nil {
+		return fmt.Errorf("read callback CA for /boot handler: %w", err)
 	}
 
 	// Pre-warm the ConfigMap informer. The inspection handler writes a
@@ -426,10 +481,20 @@ func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string) error {
 		Log:    bootstrapLog,
 	}
 
-	// Same verifier flavour for both endpoints: the bearer token authorises
-	// requests for a specific PhysicalHost, regardless of which host-scoped
-	// endpoint is being called. We construct one verifier per route so the
-	// V(1) log handle reflects the route.
+	bootLog := ctrl.Log.WithName("boot-handler")
+	bootHandler := &BootHandler{
+		Client: mgr.GetClient(),
+		Log:    bootLog,
+		Config: BootHandlerConfig{
+			APIBase: bootstrapURLBase,
+			CABytes: caBytes,
+		},
+	}
+
+	// Same verifier flavour for the bearer-gated endpoints: the bearer token
+	// authorises requests for a specific PhysicalHost, regardless of which
+	// host-scoped endpoint is being called. We construct one verifier per route
+	// so the V(1) log handle reflects the route.
 	inspectionVerifier := newBearerTokenVerifier(mgr.GetClient(), inspectionLog)
 	bootstrapVerifier := newBearerTokenVerifier(mgr.GetClient(), bootstrapLog)
 
@@ -439,6 +504,8 @@ func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string) error {
 		auth.RequireBearer(inspectionLog, inspectionVerifier, inspectionHandler))
 	mux.Handle("GET /api/v1/bootstrap/{namespace}/{hostName}",
 		auth.RequireBearer(bootstrapLog, bootstrapVerifier, bootstrapHandler))
+	// /boot is NOT bearer-gated. Rate limiting is applied inside BootHandler.ServeHTTP.
+	mux.Handle("GET /api/v1/boot/{namespace}/{hostName}/{nonce}", bootHandler)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write([]byte("ok")); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.31.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
-	golang.org/x/time v0.11.0 // indirect
+	golang.org/x/time v0.11.0
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect


### PR DESCRIPTION
## Summary

Phase A, PR 2 of the per-host iPXE boot feature. Adds the **ungated, nonce-gated `GET /api/v1/boot/{namespace}/{hostName}/{nonce}`** endpoint on the callback server — the piece that hands a freshly-booted bare-metal host its per-host bearer token + boot params on the kernel cmdline. Builds on the boot-nonce lifecycle (#111) and the frozen contract (#110).

## What it does
- **`controllers/boot_handler.go`** (new): verifies the `{nonce}` constant-time (`auth.Verify`) against `Status.Bootstrap.BootNonceHash` + TTL; **single-use consumes** it via an optimistic-locked `Status().Patch` of `BootNonceConsumedAt` (**D-010** — the sole audited handler→status write; conflict → re-Get + re-eval; already-consumed → render identical). Renders the contract §4.1 iPXE script: `{InspectionImageURL}/vmlinuz` + `beskar7.api/namespace/host/token/target/ca` + `initrd`. Bearer token read from the per-host Secret (`plaintext-token`); CA delivered inline (base64) from the callback cert dir (`ca.crt`, else self-signed `tls.crt`). Per-source-IP rate limiting. Uniform opaque 404 on every failure (no oracle); never logs the nonce/token/CA/script.
- **`inspection_handler.go`**: `SetupCallbackServer` wires the `/boot` route (NOT bearer-gated) + `readCallbackCA`; gains a `bootstrapURLBase` param.
- **`main.go`**: passes `--bootstrap-url-base` through; **warns at startup if it's a `.svc` address** (unreachable from bare metal, forces insecure downstream — H-1).

## Security (this PR was gated on a security review)
A review found a **CRITICAL** finding, now **closed**:
- **SEC-7 — kernel cmdline injection** via `InspectionImageURL`/`TargetImageURL` (CRD pattern `^https?://.*` permitted spaces/newlines, so a namespace tenant could inject/override `beskar7.api`/`beskar7.token`/`beskar7.target` → redirect the bootstrap GET that returns cluster join secrets, or MITM the OS image). Fixed airtight: `validateBootURL` rejects whitespace/control chars + non-http(s) schemes before render; CRD pattern tightened to `^https?://[^\s]+$` (defence-in-depth). 10 injection-rejection tests added.
- **SEC-10** — render length cap (`bootScriptMaxBytes=4096`) so an oversized CA can't silently truncate the kernel cmdline.

Review-confirmed correct and preserved: the D-010 consume (atomic single-use, no spin, render-after-durable), secret non-leakage, constant-time verify, and the TOFU-on-`/boot` trust model.

**Tracked follow-ups (NOT in this PR):** a `Beskar7Machine` validating webhook (defence-in-depth layer for SEC-7), per-host rate-limit keying (SEC-9), host-existence timing-oracle equalization (SEC-11), CA hot-reload (SEC-12), https-only enforcement (SEC-6/M-1). Plus a minor note: URL validation currently runs *after* the nonce consume, so a misconfigured spec burns the nonce then opaque-fails (self-heals on re-trigger).

## Test plan
- [x] `make test` — all pass; `go test -race ./controllers/...` race-clean
- [x] `make manifests` + `make sync-chart-crds` — CRD pattern regenerated (machines + machinetemplates, base + chart)
- [x] `make lint` (golangci-lint v2) — 0 issues; `go build`/`go vet` clean
- [x] Boot specs: happy path, concurrent single-use (identical bodies, consumed once, conflict-retry exercised), already-consumed retry, opaque failures (expired/wrong-nonce/unknown-host/no-consumer/empty-image/missing-token), **10 injection-rejection cases**, length cap, rate-limit isolation, no-secret-leakage log scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)