### PR TITLE
chart: external callback reachability + serving-cert SAN (H-1)

### DIFF
--- a/charts/beskar7/templates/NOTES.txt
+++ b/charts/beskar7/templates/NOTES.txt
@@ -21,4 +21,24 @@
 7. Monitoring is enabled - metrics are available at https://localhost:8443/metrics (HTTPS, requires auth)
 {{- end }}
 
+{{- if eq (.Values.callback.service.type | default "ClusterIP") "ClusterIP" }}
+
+NOTE: bootstrap.urlBase is "{{ .Values.bootstrap.urlBase }}".
+   Bare-metal hosts must reach the callback server (:8082) DURING PXE boot, before
+   they join the cluster network — a cluster-internal .svc address is NOT reachable
+   from real hardware. Expose the callback Service externally (set
+   callback.service.type=LoadBalancer or NodePort, or front it with an Ingress),
+   set bootstrap.urlBase to that external address, and list the external name(s)/IP(s)
+   in callback.externalNames / callback.externalIPs so the serving-cert SAN covers
+   them. See docs/installation.md (External reachability) and docs/inspector-contract.md.
+{{- else }}
+
+8. Callback Service is exposed as type {{ .Values.callback.service.type }}. Confirm
+   bootstrap.urlBase ({{ .Values.bootstrap.urlBase }}) resolves to that address and is
+   listed in callback.externalNames / callback.externalIPs (serving-cert SAN), or the
+   inspector will reject the callback TLS handshake.
+   SECURITY: scope this exposure to the provisioning network — do NOT publish :8082
+   to the public internet. Use loadBalancerSourceRanges / a NetworkPolicy / firewall.
+{{- end }}
+
 For more information, visit: https://github.com/projectbeskar/beskar7

--- a/charts/beskar7/templates/_helpers.tpl
+++ b/charts/beskar7/templates/_helpers.tpl
@@ -124,7 +124,14 @@ install/upgrade path hits the cluster and is stable.
     {{- $certs = dict "crt" (index $data "tls.crt") "key" (index $data "tls.key") "ca" $ca -}}
   {{- else -}}
     {{- $caCert := genCA (printf "%s-ca" $svc) 3650 -}}
-    {{- $cert := genSignedCert $cn nil (list $cn) 3650 $caCert -}}
+    {{- /*
+      SAN list: the in-cluster .svc name (webhook server) plus any external
+      callback names/IPs so the SAME cert validates for bare-metal hosts hitting
+      :8082. genSignedCert signature is (CN, ipAddresses, dnsNames, days, ca).
+    */ -}}
+    {{- $dnsNames := concat (list $cn) (.Values.callback.externalNames | default (list)) -}}
+    {{- $ipAddrs := .Values.callback.externalIPs | default (list) -}}
+    {{- $cert := genSignedCert $cn $ipAddrs $dnsNames 3650 $caCert -}}
     {{- $certs = dict "crt" (b64enc $cert.Cert) "key" (b64enc $cert.Key) "ca" (b64enc $caCert.Cert) -}}
   {{- end -}}
   {{- $_ := set . "_beskar7WebhookCerts" $certs -}}

--- a/charts/beskar7/templates/certificate.yaml
+++ b/charts/beskar7/templates/certificate.yaml
@@ -15,7 +15,18 @@ spec:
     - beskar7
   commonName: {{ .Values.webhook.service.name }}.{{ include "beskar7.namespace" . }}.svc
   dnsNames:
+  # In-cluster SAN for the webhook server (apiserver verifies against this).
   - {{ .Values.webhook.service.name }}.{{ include "beskar7.namespace" . }}.svc
+  {{- /* External SANs for the callback server, reachable by bare-metal hosts. */}}
+  {{- range .Values.callback.externalNames }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- with .Values.callback.externalIPs }}
+  ipAddresses:
+    {{- range . }}
+  - {{ . | quote }}
+    {{- end }}
+  {{- end }}
   issuerRef:
     name: {{ .Values.certManager.issuer.name }}
     kind: {{ .Values.certManager.issuer.kind }}

--- a/charts/beskar7/templates/deployment.yaml
+++ b/charts/beskar7/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        - containerPort: 8082
+          name: callback
+          protocol: TCP
         - containerPort: 8081
           name: healthz
           protocol: TCP

--- a/charts/beskar7/templates/service-callback.yaml
+++ b/charts/beskar7/templates/service-callback.yaml
@@ -16,12 +16,23 @@ metadata:
     {{- include "beskar7.labels" . | nindent 4 }}
     app.kubernetes.io/component: callback-server
     cluster.x-k8s.io/provider: beskar7
+  {{- with .Values.callback.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  type: {{ .Values.callback.service.type | default "ClusterIP" }}
+  {{- if and (eq .Values.callback.service.type "LoadBalancer") .Values.callback.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.callback.service.loadBalancerIP | quote }}
+  {{- end }}
   ports:
   - name: callback
     port: 8082
     targetPort: 8082
     protocol: TCP
+    {{- if and (ne (.Values.callback.service.type | default "ClusterIP") "ClusterIP") .Values.callback.service.nodePort }}
+    nodePort: {{ .Values.callback.service.nodePort | int }}
+    {{- end }}
   selector:
     {{- include "beskar7.selectorLabels" . | nindent 4 }}
     control-plane: controller-manager

--- a/charts/beskar7/values.yaml
+++ b/charts/beskar7/values.yaml
@@ -169,11 +169,64 @@ readinessProbe:
 
 bootstrap:
   # Base URL operators expose for the bootstrap and inspection callback endpoints.
-  # Beskar7 computes per-machine bootstrap URLs from this base. Set to whatever
-  # FQDN+port your hosts can reach the manager on (typically the in-cluster
-  # service DNS, but may be a Service of type LoadBalancer or an external Ingress
-  # for hosts that boot before joining the cluster network).
+  # Beskar7 renders this into beskar7.api= on the inspector kernel cmdline and
+  # into PhysicalHost.Status.Bootstrap.URL. Bare-metal hosts must reach it DURING
+  # PXE boot — before they have joined the cluster network — so the default
+  # cluster-internal .svc address below is unreachable from real hardware and the
+  # manager logs a startup warning when it sees a .svc name.
+  #
+  # For a real deployment set this to the external address the host can reach
+  # (a Service of type LoadBalancer/NodePort or an Ingress; see callback.* below),
+  # and make sure that address is covered by the serving-cert SAN via
+  # callback.externalNames / callback.externalIPs. The inspector verifies the
+  # callback cert against the CA delivered on its cmdline and has no
+  # insecure-skip path, so a SAN mismatch is a hard failure.
   urlBase: "https://beskar7-controller-manager.beskar7-system.svc:8082"
+
+# Callback server (inspection POST + bootstrap GET + per-host /boot) exposure.
+#
+# These endpoints run on :8082 (HTTPS) in the manager Pod and must be reachable
+# by bare-metal hosts that are still PXE-booting — i.e. over an externally
+# routable address, NOT cluster DNS. Two things have to line up for that to work:
+#   1. Expose the callback Service externally (service.type below, or front it
+#      with your own Ingress and leave the type ClusterIP).
+#   2. Put the external DNS name(s)/IP(s) in externalNames / externalIPs so the
+#      serving certificate's SAN covers them. bootstrap.urlBase's host MUST be one
+#      of these — the inspector rejects a hostname mismatch with no skip option.
+#
+# Defaults preserve the historical cluster-internal behavior (ClusterIP, no extra
+# SANs); the knobs below are opt-in.
+callback:
+  service:
+    # ClusterIP (default) keeps the Service cluster-internal. Set to LoadBalancer
+    # or NodePort to reach the callback endpoints from the provisioning network.
+    # For Ingress, leave this ClusterIP and route :8082 through your controller.
+    #
+    # SECURITY: scope the exposure to the provisioning subnet — do NOT publish it
+    # to the public internet. The /boot endpoint is gated only by an unguessable
+    # single-use nonce (rate-limited), and POST/GET carry per-host bearer tokens;
+    # a private provisioning network is the intended deployment. Use
+    # loadBalancerSourceRanges / cloud LB source restrictions (via .annotations) or
+    # a NetworkPolicy/firewall to keep it off the open internet.
+    type: ClusterIP
+    # Static load-balancer IP (LoadBalancer type only; ignored otherwise).
+    loadBalancerIP: ""
+    # Fixed node port in 30000-32767 (NodePort/LoadBalancer only; auto if empty).
+    nodePort: ""
+    # Extra annotations on the callback Service (e.g. cloud load-balancer hints).
+    annotations: {}
+  # External DNS name(s) the serving-cert SAN must cover. Include the host portion
+  # of bootstrap.urlBase here when it is a name. Added to both the cert-manager
+  # Certificate dnsNames and the self-signed cert SAN list.
+  externalNames: []
+  # External IP(s) the serving-cert SAN must cover. Use when bootstrap.urlBase is
+  # an IP (e.g. a fixed LoadBalancer IP). Added as IP SANs in both cert paths.
+  #
+  # NOTE (self-signed mode, certManager.enabled=false): the serving cert is
+  # generated once and reused across upgrades. Adding/removing names or IPs here
+  # after the first install does NOT rotate the cert — delete the Secret named in
+  # certManager.certificate.secretName to force regeneration with the new SANs.
+  externalIPs: []
 
 # Additional labels
 labels: {}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,6 +48,25 @@ helm install --devel my-release beskar7/beskar7 \
 
 The `bootstrap.urlBase` value is rendered into `PhysicalHost.Status.Bootstrap.URL`. Bare-metal hosts must be able to reach it during PXE boot.
 
+### External reachability
+
+The callback server (inspection POST, bootstrap GET, and the per-host `/boot` endpoint) listens on `:8082` over HTTPS. Bare-metal hosts reach it **while they are still PXE-booting** — before they have joined the cluster network — so the default cluster-internal `…svc:8082` address is not reachable from real hardware, and the manager logs a startup warning when `bootstrap.urlBase` is a `.svc` name.
+
+For a real deployment, two things must line up:
+
+1. **Expose the callback Service externally.** Either set `callback.service.type` to `LoadBalancer` or `NodePort`, or leave it `ClusterIP` and front `:8082` with your own Ingress controller. **Scope this to the provisioning network — do not publish it to the public internet.** The `/boot` endpoint is gated only by an unguessable single-use nonce (rate-limited), so restrict reachability with `loadBalancerSourceRanges` / cloud source-range annotations, a `NetworkPolicy`, or an upstream firewall.
+2. **Cover the external address in the serving-cert SAN.** List the external DNS name(s) and/or IP(s) in `callback.externalNames` / `callback.externalIPs`. The host portion of `bootstrap.urlBase` **must** be one of these — the inspector verifies the callback certificate against the CA it is handed on the kernel cmdline and has no insecure-skip path, so a SAN mismatch is a hard failure.
+
+```bash
+helm install --devel beskar7 beskar7/beskar7 \
+  --namespace beskar7-system --create-namespace \
+  --set callback.service.type=LoadBalancer \
+  --set bootstrap.urlBase=https://beskar7.example.com:8082 \
+  --set 'callback.externalNames={beskar7.example.com}'
+```
+
+The external SAN is added to both certificate paths: the cert-manager `Certificate` (`certManager.enabled=true`) and the chart's self-signed cert (`certManager.enabled=false`). In self-signed mode the cert is generated once and reused across upgrades — changing `callback.externalNames` / `callback.externalIPs` after the first install does not rotate it; delete the Secret named in `certManager.certificate.secretName` to force regeneration with the new SANs.
+
 ## Install via release manifests
 
 ```bash


### PR DESCRIPTION
## Summary

Phase A PR 3 (external reachability) — the chart half of H-1. Bare-metal hosts reach the callback server (`:8082`: inspection POST, bootstrap GET, per-host `/boot`) **while they are still PXE-booting**, before they join the cluster network. So the cluster-internal `…svc:8082` default is unreachable from real hardware, and a `.svc`-only serving cert would force operators toward insecure-skip — which the inspector deliberately has **no** path for (it verifies the callback cert against the CA delivered on its kernel cmdline, per the contract spec §8).

The manager-side `.svc` startup warning already shipped in #112. This PR adds the chart knobs to expose the Service externally and to size the serving cert SAN to match.

## Changes

- **`values.yaml`** — new opt-in `callback.*` block:
  - `callback.service.type` (`ClusterIP` default; `LoadBalancer`/`NodePort`) plus `loadBalancerIP` / `nodePort` / `annotations` passthrough.
  - `callback.externalNames` / `callback.externalIPs` — external DNS/IP SANs.
  - `bootstrap.urlBase` comment tightened to state the host **must** be a cert SAN.
- **`service-callback.yaml`** — renders `type`, optional `loadBalancerIP`, `nodePort` (`| int`), and `annotations`.
- **`certificate.yaml`** (cert-manager path) — appends `externalNames` to `dnsNames` and `externalIPs` to `ipAddresses`.
- **`_helpers.tpl`** (self-signed path) — widens the `genSignedCert` SAN list with the external DNS names + IPs (the shared webhook+callback cert keeps its `.svc` SAN, so the apiserver webhook trust path is unchanged — external SANs are purely additive).
- **`deployment.yaml`** — declares `containerPort: 8082` (callback).
- **`NOTES.txt` + `docs/installation.md`** — operator guidance: expose externally, keep `urlBase` host in the SAN, and **scope the LB/NodePort to the provisioning network, not the public internet** (`loadBalancerSourceRanges` / NetworkPolicy / firewall). Documents the self-signed cert-reuse caveat (changing SANs requires deleting the cert Secret).

Defaults are unchanged (ClusterIP, `.svc`-only SAN). Kustomize `config/` ships no callback Service (chart-only resource) and remains the in-cluster reference path, so no kustomize parity edit is warranted.

## Validation

- `helm lint` clean.
- Rendered four combinations: default (unchanged), cert-manager + LoadBalancer + external SANs, self-signed + NodePort + external SANs. Decoded the self-signed cert with `openssl x509 -ext subjectAltName` and confirmed the SAN carries `.svc` + external DNS + both IPs; default self-signed SAN is `.svc`-only.
- CI kind-smoke installs with default values → exercises the backward-compatible path.
- **Security-reviewed** (security-engineer): no blockers. Shared-cert SAN widening does not weaken the webhook trust path; private key never leaves the pod (the `/boot` handler emits only the CA). Folded in the SHOULD-FIX (public-internet-scoping caveat) and the NIT (`nodePort | int`).

## Test plan

- [ ] CI lint + kind-smoke (default-values install/upgrade) green
- [ ] `helm template` with `callback.service.type=LoadBalancer` + `callback.externalNames` produces a Certificate with the external SAN
- [ ] `certManager.enabled=false` + external names → self-signed cert SAN covers them (openssl-verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)