### PR TITLE
test: golden-fixture contract test for the inspector report schema

### DIFF
--- a/controllers/inspection_contract_test.go
+++ b/controllers/inspection_contract_test.go
@@ -1,0 +1,211 @@
+package controllers
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// goldenInspectionReportPath is the canonical contract fixture shared with the
+// beskar7-inspector repo. The inspector emits this exact wire format and asserts
+// it round-trips through its Rust serde types; this test asserts the same bytes
+// decode losslessly into the controller's InspectionReportRequest and convert
+// faithfully into the InspectionReport API type. If the two repos drift, one of
+// these tests goes red. See test/contract/README.md (contract: v1).
+const goldenInspectionReportPath = "../test/contract/golden_inspection_report.json"
+
+// Expected aggregates for the golden host. These are the numbers the controller's
+// hardware-requirements validation computes from the fixture; they are part of
+// the contract because the inspector must emit capacity strings the controller
+// can parse. Note the IEC convention: each "32GiB" DIMM is 32*2^30 bytes, which
+// divided by 1e9 (decimal GB) truncates to 34 — so four DIMMs total 136 GB, not
+// 128. parseMemoryCapacityGB documents this; the inspector author must expect it.
+const (
+	goldenTotalCPUCores  = 64   // 2 sockets * 32 cores
+	goldenMemPerDIMMGB   = 34   // "32GiB" -> 34 decimal GB (32*2^30/1e9, truncated)
+	goldenTotalMemoryGB  = 136  // 4 * 34
+	goldenTotalDiskGB    = 1920 // 2 * 960
+	goldenNumCPUSockets  = 2
+	goldenNumDIMMs       = 4
+	goldenNumDisks       = 2
+	goldenNumNICs        = 2
+	goldenFirstNICNumIPs = 2
+)
+
+func readGoldenReport(t *testing.T) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Clean(goldenInspectionReportPath))
+	if err != nil {
+		t.Fatalf("read golden inspection report at %s: %v", goldenInspectionReportPath, err)
+	}
+	return b
+}
+
+// TestInspectorReportContract is the anti-drift guardrail between Beskar7 and the
+// beskar7-inspector. It exercises the full server-side path the inspector's POST
+// body takes: decode -> buildInspectionReport -> hardware-sum validation.
+func TestInspectorReportContract(t *testing.T) {
+	golden := readGoldenReport(t)
+
+	// 1. Lenient decode — exactly what controllers/inspection_handler.go does in
+	//    production (json.Decoder without DisallowUnknownFields). Proves the
+	//    fixture is accepted by the live handler.
+	t.Run("decodes leniently (production parity)", func(t *testing.T) {
+		var req InspectionReportRequest
+		if err := json.Unmarshal(golden, &req); err != nil {
+			t.Fatalf("lenient decode failed: %v", err)
+		}
+		if req.Manufacturer == "" || req.Model == "" || req.SerialNumber == "" {
+			t.Errorf("system identity fields not populated: %+v", req)
+		}
+		if len(req.CPUs) != goldenNumCPUSockets {
+			t.Errorf("CPUs: got %d, want %d", len(req.CPUs), goldenNumCPUSockets)
+		}
+		if len(req.Memory) != goldenNumDIMMs {
+			t.Errorf("Memory: got %d, want %d", len(req.Memory), goldenNumDIMMs)
+		}
+		if len(req.Disks) != goldenNumDisks {
+			t.Errorf("Disks: got %d, want %d", len(req.Disks), goldenNumDisks)
+		}
+		if len(req.NICs) != goldenNumNICs {
+			t.Errorf("NICs: got %d, want %d", len(req.NICs), goldenNumNICs)
+		}
+		if len(req.NICs) > 0 && len(req.NICs[0].IPAddresses) != goldenFirstNICNumIPs {
+			t.Errorf("first NIC IP count: got %d, want %d (ipAddresses must be a JSON array)",
+				len(req.NICs[0].IPAddresses), goldenFirstNICNumIPs)
+		}
+		if req.BootModeDetected == "" || req.FirmwareVersion == "" {
+			t.Errorf("bootModeDetected/firmwareVersion not populated: %+v", req)
+		}
+	})
+
+	// 2. Strict decode — DisallowUnknownFields fails if the inspector emits a
+	//    field the controller does not model. This is the forward-drift catch:
+	//    a new key in the inspector's output that Beskar7 would silently drop in
+	//    production turns this test red instead.
+	t.Run("decodes strictly (no unknown fields)", func(t *testing.T) {
+		dec := json.NewDecoder(bytes.NewReader(golden))
+		dec.DisallowUnknownFields()
+		var req InspectionReportRequest
+		if err := dec.Decode(&req); err != nil {
+			t.Fatalf("strict decode failed — the golden fixture carries a field "+
+				"InspectionReportRequest does not model (schema drift): %v", err)
+		}
+	})
+
+	// 3. Round-trip — decode then re-encode, and compare the JSON object graphs.
+	//    Catches the reverse drift: a struct field renamed or dropped so that a
+	//    key present in the golden is no longer emitted. (omitempty means we rely
+	//    on the fixture populating every modelled field with a non-zero value.)
+	t.Run("round-trips losslessly", func(t *testing.T) {
+		var req InspectionReportRequest
+		if err := json.Unmarshal(golden, &req); err != nil {
+			t.Fatalf("decode for round-trip failed: %v", err)
+		}
+		reEncoded, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("re-encode failed: %v", err)
+		}
+
+		var goldenObj, rtObj map[string]any
+		if err := json.Unmarshal(golden, &goldenObj); err != nil {
+			t.Fatalf("decode golden to map: %v", err)
+		}
+		if err := json.Unmarshal(reEncoded, &rtObj); err != nil {
+			t.Fatalf("decode round-trip to map: %v", err)
+		}
+		if !reflect.DeepEqual(goldenObj, rtObj) {
+			t.Errorf("round-trip object graph differs from golden — a modelled field "+
+				"was renamed, dropped, or retyped.\n golden: %s\n re-enc: %s", golden, reEncoded)
+		}
+	})
+
+	// 4. Conversion fidelity — buildInspectionReport is the DTO -> API-type hop
+	//    consumed by every downstream reconcile. Assert each collection and a few
+	//    representative scalars survive the conversion.
+	t.Run("buildInspectionReport conversion is faithful", func(t *testing.T) {
+		var req InspectionReportRequest
+		if err := json.Unmarshal(golden, &req); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		report := buildInspectionReport(req)
+
+		if report.Manufacturer != req.Manufacturer ||
+			report.Model != req.Model ||
+			report.SerialNumber != req.SerialNumber ||
+			report.BootModeDetected != req.BootModeDetected ||
+			report.FirmwareVersion != req.FirmwareVersion {
+			t.Errorf("scalar identity fields not carried through conversion: %+v", report)
+		}
+		if len(report.CPUs) != len(req.CPUs) ||
+			len(report.Memory) != len(req.Memory) ||
+			len(report.Disks) != len(req.Disks) ||
+			len(report.NICs) != len(req.NICs) {
+			t.Fatalf("collection lengths changed in conversion: cpus %d/%d mem %d/%d disk %d/%d nic %d/%d",
+				len(report.CPUs), len(req.CPUs), len(report.Memory), len(req.Memory),
+				len(report.Disks), len(req.Disks), len(report.NICs), len(req.NICs))
+		}
+		if report.CPUs[0].Cores != req.CPUs[0].Cores || report.CPUs[0].Threads != req.CPUs[0].Threads {
+			t.Errorf("CPU core/thread counts not carried through: %+v", report.CPUs[0])
+		}
+		if report.Memory[0].Capacity != req.Memory[0].Capacity {
+			t.Errorf("memory capacity string not carried through: %q != %q",
+				report.Memory[0].Capacity, req.Memory[0].Capacity)
+		}
+		if report.Disks[0].SizeGB != req.Disks[0].SizeGB {
+			t.Errorf("disk sizeGB not carried through: %d != %d", report.Disks[0].SizeGB, req.Disks[0].SizeGB)
+		}
+		if !reflect.DeepEqual(report.NICs[0].IPAddresses, req.NICs[0].IPAddresses) {
+			t.Errorf("NIC IP list not carried through: %v != %v",
+				report.NICs[0].IPAddresses, req.NICs[0].IPAddresses)
+		}
+	})
+
+	// 5. Hardware-requirement aggregates — the controller validates by summing
+	//    cpu.Cores, parseMemoryCapacityGB(capacity), and disk.SizeGB. Running the
+	//    REAL parseMemoryCapacityGB over the fixture locks the memory-suffix
+	//    contract (the field the inspector most easily gets wrong) and the IEC
+	//    truncation semantics documented above.
+	t.Run("hardware aggregates match documented totals", func(t *testing.T) {
+		var req InspectionReportRequest
+		if err := json.Unmarshal(golden, &req); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		report := buildInspectionReport(req)
+
+		totalCores := 0
+		for _, c := range report.CPUs {
+			totalCores += c.Cores
+		}
+		if totalCores != goldenTotalCPUCores {
+			t.Errorf("total CPU cores: got %d, want %d", totalCores, goldenTotalCPUCores)
+		}
+
+		totalMem := 0
+		for _, m := range report.Memory {
+			gb, err := parseMemoryCapacityGB(m.Capacity)
+			if err != nil {
+				t.Fatalf("parseMemoryCapacityGB(%q) failed — the inspector emitted a "+
+					"capacity the controller cannot parse (contract violation): %v", m.Capacity, err)
+			}
+			if gb != goldenMemPerDIMMGB {
+				t.Errorf("per-DIMM parse of %q: got %d GB, want %d GB", m.Capacity, gb, goldenMemPerDIMMGB)
+			}
+			totalMem += gb
+		}
+		if totalMem != goldenTotalMemoryGB {
+			t.Errorf("total memory: got %d GB, want %d GB", totalMem, goldenTotalMemoryGB)
+		}
+
+		totalDisk := 0
+		for _, d := range report.Disks {
+			totalDisk += d.SizeGB
+		}
+		if totalDisk != goldenTotalDiskGB {
+			t.Errorf("total disk: got %d GB, want %d GB", totalDisk, goldenTotalDiskGB)
+		}
+	})
+}

--- a/docs/inspector-contract.md
+++ b/docs/inspector-contract.md
@@ -298,10 +298,15 @@ The inspector MUST:
 - This document carries a **contract version** (top of file). Both repos record
   the version they implement.
 - A **golden report fixture** (a canonical §6 JSON document) lives in both repos.
-  The controller has a test that decodes it into `InspectionReportRequest`, runs
-  `buildInspectionReport` + hardware-requirements validation, and asserts success.
-  The inspector has a serde round-trip test asserting it produces byte-equivalent
-  JSON. A schema change fails one or both, forcing a coordinated contract bump.
+  The canonical copy is [`test/contract/golden_inspection_report.json`](../test/contract/golden_inspection_report.json)
+  (see [`test/contract/README.md`](../test/contract/README.md)). The controller test
+  `controllers/inspection_contract_test.go` decodes it into `InspectionReportRequest`
+  — both leniently (production parity) and strictly (`DisallowUnknownFields`, the
+  forward-drift catch) — round-trips it to prove the struct is lossless, runs
+  `buildInspectionReport`, and runs the real `parseMemoryCapacityGB` over its memory
+  entries to lock the hardware-aggregate math. The inspector mirrors the same bytes
+  in a serde round-trip test asserting byte-equivalent JSON. A schema change on
+  either side fails one or both tests, forcing a coordinated contract bump.
 
 ---
 

--- a/test/contract/README.md
+++ b/test/contract/README.md
@@ -1,0 +1,49 @@
+# Inspector contract fixtures (contract: v1)
+
+This directory holds the **canonical golden fixture** for the controller ↔
+inspector wire contract. It is the anti-drift guardrail between this repo and
+[`beskar7-inspector`](https://github.com/projectbeskar/beskar7-inspector).
+
+The authoritative prose spec is [`docs/inspector-contract.md`](../../docs/inspector-contract.md);
+this fixture is the machine-checked half of it.
+
+## `golden_inspection_report.json`
+
+The exact JSON body a `beskar7-inspector` run POSTs to
+`POST {callbackBase}/api/v1/inspection/{namespace}/{hostName}`
+(`namespace`/`hostName` are path parameters, not body fields, so they do **not**
+appear here). It models one representative dual-socket host.
+
+Both repos assert against the **same bytes**:
+
+- **Beskar7** — `controllers/inspection_contract_test.go` (`go test ./controllers/...`)
+  decodes it into `InspectionReportRequest`, both leniently (production parity)
+  and strictly (`DisallowUnknownFields`, forward-drift catch), round-trips it to
+  prove the struct is lossless, runs `buildInspectionReport`, and runs the real
+  `parseMemoryCapacityGB` over the memory entries to lock the hardware-aggregate
+  math.
+- **beskar7-inspector** — a Rust serde round-trip test deserializes the same file
+  into its `Report` type and re-serializes it, asserting byte-equality.
+
+If the inspector adds, renames, or retypes a field, one side's test goes red.
+**Keep the two copies identical.** When the contract changes, bump the version in
+`docs/inspector-contract.md`, update this fixture, and update both repos in lockstep.
+
+## Documented aggregates
+
+The controller's hardware-requirements validation sums these from the fixture
+(kept in sync with the constants in `inspection_contract_test.go`):
+
+| Aggregate | Value | Derivation |
+|---|---|---|
+| Total CPU cores | 64 | 2 sockets × 32 cores |
+| Memory per DIMM | 34 GB | `"32GiB"` → 32 × 2³⁰ bytes ÷ 1e9, **truncated** |
+| Total memory | 136 GB | 4 × 34 |
+| Total disk | 1920 GB | 2 × 960 |
+
+> **IEC vs decimal:** `parseMemoryCapacityGB` treats `GiB`/`MiB`/`TiB` as binary
+> (×1024) and `GB`/`MB`/`TB` as SI (×1000), then converts to **decimal GB**
+> (÷1e9) and truncates. So a `"32GiB"` DIMM counts as **34** GB toward
+> `MinMemoryGB`, not 32. Inspector authors emitting capacity strings must expect
+> this. Accepted suffixes: `GB`, `GiB`, `MB`, `MiB`, `TB`, `TiB` — a bare number
+> with no unit is rejected.

--- a/test/contract/golden_inspection_report.json
+++ b/test/contract/golden_inspection_report.json
@@ -1,0 +1,63 @@
+{
+  "manufacturer": "Dell Inc.",
+  "model": "PowerEdge R650",
+  "serialNumber": "ABCD123",
+  "cpus": [
+    {
+      "id": "CPU.Socket.1",
+      "vendor": "Intel",
+      "model": "Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz",
+      "cores": 32,
+      "threads": 64,
+      "frequency": "2.0GHz"
+    },
+    {
+      "id": "CPU.Socket.2",
+      "vendor": "Intel",
+      "model": "Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz",
+      "cores": 32,
+      "threads": 64,
+      "frequency": "2.0GHz"
+    }
+  ],
+  "memory": [
+    { "id": "DIMM.Socket.A1", "type": "DDR4", "capacity": "32GiB", "speed": "3200MHz" },
+    { "id": "DIMM.Socket.A2", "type": "DDR4", "capacity": "32GiB", "speed": "3200MHz" },
+    { "id": "DIMM.Socket.B1", "type": "DDR4", "capacity": "32GiB", "speed": "3200MHz" },
+    { "id": "DIMM.Socket.B2", "type": "DDR4", "capacity": "32GiB", "speed": "3200MHz" }
+  ],
+  "disks": [
+    {
+      "name": "/dev/nvme0n1",
+      "model": "Dell Ent NVMe AGN MU U.2 960GB",
+      "sizeGB": 960,
+      "type": "NVMe",
+      "serialNumber": "S64XNE0R301234"
+    },
+    {
+      "name": "/dev/nvme1n1",
+      "model": "Dell Ent NVMe AGN MU U.2 960GB",
+      "sizeGB": 960,
+      "type": "NVMe",
+      "serialNumber": "S64XNE0R305678"
+    }
+  ],
+  "nics": [
+    {
+      "name": "eno1",
+      "macAddress": "aa:bb:cc:dd:ee:01",
+      "driver": "ixgbe",
+      "speed": "10Gbps",
+      "ipAddresses": ["192.0.2.10", "fe80::a8bb:ccff:fedd:ee01"]
+    },
+    {
+      "name": "eno2",
+      "macAddress": "aa:bb:cc:dd:ee:02",
+      "driver": "ixgbe",
+      "speed": "10Gbps",
+      "ipAddresses": ["192.0.2.11"]
+    }
+  ],
+  "bootModeDetected": "UEFI",
+  "firmwareVersion": "2.10.2"
+}


### PR DESCRIPTION
## Summary

Phase A wrap-up: an anti-drift contract test that pins the controller↔inspector inspection-report wire schema to a committed golden fixture. This is the guardrail the Rust inspector (Phase B, sibling repo) will mirror so the two repos fail loudly if the schema ever diverges.

- **`test/contract/golden_inspection_report.json`** — canonical `InspectionReportRequest` fixture (dual-socket Dell R650; 2 CPUs, 4×`32GiB` DDR4, 2×960GB NVMe, 2 NICs incl. an IPv6 address). Every modelled field is non-zero so the round-trip is lossless under `omitempty`.
- **`controllers/inspection_contract_test.go`** — `TestInspectorReportContract`, a pure `testing.T` test (no envtest) in `package controllers` so it can exercise the unexported `buildInspectionReport` and `parseMemoryCapacityGB`. Five subtests:
  1. lenient decode (production parity with `ServeHTTP`),
  2. strict decode with `DisallowUnknownFields` (catches **forward** drift — a field the fixture doesn't model),
  3. object-graph round-trip `reflect.DeepEqual` via `map[string]any` (catches **reverse** drift — a struct field the fixture doesn't carry),
  4. `buildInspectionReport` conversion fidelity,
  5. hardware aggregates through the real `parseMemoryCapacityGB`, locking the accepted-suffix contract and the IEC-vs-decimal truncation (`32GiB` → 34 GB).
- **`test/contract/README.md`** — documents the dual-repo contract (`contract: v1`), the aggregate table, and the truncation gotcha; instructs keeping the two repo copies byte-identical with coordinated version bumps.
- **`docs/inspector-contract.md`** §10 — points at the concrete fixture/test paths instead of the prior abstract reference.

## Test plan

- [x] `go test ./controllers/ -run TestInspectorReportContract` — 5/5 subtests green
- [x] Negative drift-injection check: adding a `gpus` field to the fixture fails the strict-decode subtest; removing it restores green (guardrail bites)
- [x] `gofmt -l` clean, `go vet` clean, `make lint` 0 issues, `go mod tidy` no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)