### PR TITLE
feat: require TargetImageDigest + render beskar7.target-digest (D-011)

### DIFF
--- a/api/v1beta1/beskar7machine_types.go
+++ b/api/v1beta1/beskar7machine_types.go
@@ -72,11 +72,26 @@ type Beskar7MachineSpec struct {
 	// +kubebuilder:validation:Pattern="^https?://[^\\s]+$"
 	InspectionImageURL string `json:"inspectionImageURL"`
 
-	// TargetImageURL is the URL of the final OS image to boot via kexec after inspection.
-	// This should be a kernel+initrd or complete bootable image.
+	// TargetImageURL is the URL of the Kairos whole-disk raw image the inspector
+	// writes to the target disk during provisioning. The image is served over
+	// http(s); integrity is verified by the inspector against TargetImageDigest
+	// (digest pinning, not TLS — see contract §8.1). Plain HTTP is permitted
+	// because the digest is the sole integrity and authenticity anchor for the
+	// OS image.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern="^https?://[^\\s]+$"
 	TargetImageURL string `json:"targetImageURL"`
+
+	// TargetImageDigest is the expected SHA-256 digest of the bytes at
+	// TargetImageURL, formatted as "sha256:<64-lowercase-hex>". The inspector
+	// verifies the written image against this digest and refuses to proceed to
+	// mount, inject user-data, or reboot on a mismatch (contract §8.1). It is
+	// the sole integrity and authenticity anchor for the OS image — the image
+	// is fetched over plain HTTP and there is no signature; the operator must
+	// compute this digest over the exact, pinned artifact served at TargetImageURL.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern="^sha256:[a-f0-9]{64}$"
+	TargetImageDigest string `json:"targetImageDigest"`
 
 	// ConfigurationURL is an optional URL for OS-specific configuration.
 	// The inspection image will pass this to the target OS during kexec.

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -68,11 +68,15 @@ spec:
                 type: string
               providerID:
                 type: string
+              targetImageDigest:
+                pattern: ^sha256:[a-f0-9]{64}$
+                type: string
               targetImageURL:
                 pattern: ^https?://[^\s]+$
                 type: string
             required:
             - inspectionImageURL
+            - targetImageDigest
             - targetImageURL
             type: object
           status:

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -57,11 +57,15 @@ spec:
                         type: string
                       providerID:
                         type: string
+                      targetImageDigest:
+                        pattern: ^sha256:[a-f0-9]{64}$
+                        type: string
                       targetImageURL:
                         pattern: ^https?://[^\s]+$
                         type: string
                     required:
                     - inspectionImageURL
+                    - targetImageDigest
                     - targetImageURL
                     type: object
                 required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -68,11 +68,15 @@ spec:
                 type: string
               providerID:
                 type: string
+              targetImageDigest:
+                pattern: ^sha256:[a-f0-9]{64}$
+                type: string
               targetImageURL:
                 pattern: ^https?://[^\s]+$
                 type: string
             required:
             - inspectionImageURL
+            - targetImageDigest
             - targetImageURL
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -57,11 +57,15 @@ spec:
                         type: string
                       providerID:
                         type: string
+                      targetImageDigest:
+                        pattern: ^sha256:[a-f0-9]{64}$
+                        type: string
                       targetImageURL:
                         pattern: ^https?://[^\s]+$
                         type: string
                     required:
                     - inspectionImageURL
+                    - targetImageDigest
                     - targetImageURL
                     type: object
                 required:

--- a/controllers/beskar7machine_controller_test.go
+++ b/controllers/beskar7machine_controller_test.go
@@ -591,7 +591,7 @@ var _ = Describe("Beskar7Machine Controller", func() {
 					Spec: infrastructurev1beta1.Beskar7MachineSpec{
 						InspectionImageURL:   "http://boot-server/ipxe/inspect.ipxe",
 						TargetImageURL:       "http://boot-server/images/kairos.tar.gz",
-						TargetImageDigest:  bootTestDigest,
+						TargetImageDigest:    bootTestDigest,
 						HardwareRequirements: reqs,
 					},
 				}

--- a/controllers/beskar7machine_controller_test.go
+++ b/controllers/beskar7machine_controller_test.go
@@ -123,6 +123,7 @@ var _ = Describe("Beskar7Machine Controller", func() {
 				Spec: infrastructurev1beta1.Beskar7MachineSpec{
 					InspectionImageURL: "http://boot-server/ipxe/inspect.ipxe",
 					TargetImageURL:     "http://boot-server/images/kairos.tar.gz",
+					TargetImageDigest:  bootTestDigest,
 				},
 			}
 
@@ -355,6 +356,7 @@ var _ = Describe("Beskar7Machine Controller", func() {
 				Spec: infrastructurev1beta1.Beskar7MachineSpec{
 					InspectionImageURL: "http://boot-server/inspect.ipxe",
 					TargetImageURL:     "http://boot-server/kairos.tar.gz",
+					TargetImageDigest:  bootTestDigest,
 					ProviderID:         &provID,
 				},
 			}
@@ -422,6 +424,7 @@ var _ = Describe("Beskar7Machine Controller", func() {
 				Spec: infrastructurev1beta1.Beskar7MachineSpec{
 					InspectionImageURL: "http://boot-server/inspect.ipxe",
 					TargetImageURL:     "http://boot-server/kairos.tar.gz",
+					TargetImageDigest:  bootTestDigest,
 					ProviderID:         &provID,
 				},
 			}
@@ -472,6 +475,7 @@ var _ = Describe("Beskar7Machine Controller", func() {
 				Spec: infrastructurev1beta1.Beskar7MachineSpec{
 					InspectionImageURL: "http://boot-server/inspect.ipxe",
 					TargetImageURL:     "http://boot-server/kairos.tar.gz",
+					TargetImageDigest:  bootTestDigest,
 					ProviderID:         &provID,
 				},
 			}
@@ -523,6 +527,7 @@ var _ = Describe("Beskar7Machine Controller", func() {
 				Spec: infrastructurev1beta1.Beskar7MachineSpec{
 					InspectionImageURL: "http://boot-server/inspect.ipxe",
 					TargetImageURL:     "http://boot-server/kairos.tar.gz",
+					TargetImageDigest:  bootTestDigest,
 					ProviderID:         &provID,
 				},
 			}
@@ -586,6 +591,7 @@ var _ = Describe("Beskar7Machine Controller", func() {
 					Spec: infrastructurev1beta1.Beskar7MachineSpec{
 						InspectionImageURL:   "http://boot-server/ipxe/inspect.ipxe",
 						TargetImageURL:       "http://boot-server/images/kairos.tar.gz",
+						TargetImageDigest:  bootTestDigest,
 						HardwareRequirements: reqs,
 					},
 				}
@@ -696,6 +702,7 @@ var _ = Describe("Beskar7Machine Controller", func() {
 					Spec: infrastructurev1beta1.Beskar7MachineSpec{
 						InspectionImageURL: "http://boot-server/ipxe/inspect.ipxe",
 						TargetImageURL:     "http://boot-server/images/kairos.tar.gz",
+						TargetImageDigest:  bootTestDigest,
 					},
 				}
 				// Build a host with an InspectionTimestamp older than DefaultInspectionTimeout.
@@ -834,6 +841,7 @@ var _ = Describe("When two Beskar7Machines race for the same available host", fu
 			Spec: infrastructurev1beta1.Beskar7MachineSpec{
 				InspectionImageURL: "http://boot-server/inspect.ipxe",
 				TargetImageURL:     "http://boot-server/kairos.tar.gz",
+				TargetImageDigest:  bootTestDigest,
 			},
 		}
 		machineB := &infrastructurev1beta1.Beskar7Machine{
@@ -841,6 +849,7 @@ var _ = Describe("When two Beskar7Machines race for the same available host", fu
 			Spec: infrastructurev1beta1.Beskar7MachineSpec{
 				InspectionImageURL: "http://boot-server/inspect.ipxe",
 				TargetImageURL:     "http://boot-server/kairos.tar.gz",
+				TargetImageDigest:  bootTestDigest,
 			},
 		}
 		Expect(k8sClient.Create(ctx, machineA)).To(Succeed())
@@ -952,6 +961,7 @@ var _ = Describe("findAndClaimOrGetAssociatedHost with no Available hosts", func
 			Spec: infrastructurev1beta1.Beskar7MachineSpec{
 				InspectionImageURL: "http://boot/inspect.ipxe",
 				TargetImageURL:     "http://boot/kairos.tar.gz",
+				TargetImageDigest:  bootTestDigest,
 			},
 		}
 
@@ -1033,6 +1043,7 @@ var _ = Describe("Beskar7Machine bootstrap data secret handling", func() {
 			Spec: infrastructurev1beta1.Beskar7MachineSpec{
 				InspectionImageURL: "http://boot-server/inspect.ipxe",
 				TargetImageURL:     "http://boot-server/kairos.tar.gz",
+				TargetImageDigest:  bootTestDigest,
 			},
 		}
 		Expect(k8sClient.Create(ctx, b7machine)).To(Succeed())

--- a/controllers/boot_handler.go
+++ b/controllers/boot_handler.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -298,6 +299,23 @@ func validateBootURL(field, raw string) error {
 	return nil
 }
 
+// bootDigestPattern is compiled once at init time. It accepts only the
+// canonical contract §5/§8.1 form: "sha256:" followed by exactly 64
+// lowercase-hex characters. A value matching this pattern contains no
+// whitespace or control characters, so the pattern match alone is a
+// sufficient and stronger guard against cmdline injection (SEC-7 posture).
+var bootDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// validateBootDigest rejects a digest that does not match the contract §5/§8.1
+// canonical form. Defence-in-depth (SEC-7) on top of the CRD pattern: operates
+// on the value actually rendered, not the value admitted.
+func validateBootDigest(raw string) error {
+	if !bootDigestPattern.MatchString(raw) {
+		return fmt.Errorf("TargetImageDigest is not a valid sha256 digest (must match ^sha256:[0-9a-f]{64}$)")
+	}
+	return nil
+}
+
 // renderBootScript resolves the consuming Beskar7Machine, reads the bearer-token
 // plaintext from the per-host Secret, and renders the §4.1 iPXE script.
 //
@@ -320,21 +338,26 @@ func (h *BootHandler) renderBootScript(
 		return "", fmt.Errorf("get Beskar7Machine %s/%s: %w", cr.Namespace, cr.Name, err)
 	}
 
-	// InspectionImageURL is the base URL for vmlinuz + initrd.img (contract v1
-	// re-purposes this previously-unused field as the inspector image base).
+	// InspectionImageURL is the base URL for vmlinuz + initrd.img (contract v2:
+	// this field is the HTTPS base URL of a location serving the inspector
+	// vmlinuz and initrd.img).
 	if b7m.Spec.InspectionImageURL == "" {
 		return "", fmt.Errorf("Beskar7Machine %s/%s has empty InspectionImageURL", b7m.Namespace, b7m.Name)
 	}
 
-	// Validate both URL fields before rendering (SEC-7 / C-1a). A space or control
-	// character in either value would break out of its cmdline parameter and allow
-	// the tenant to inject or override subsequent beskar7.* parameters. This check
-	// is defence-in-depth on top of the CRD pattern (C-1b); it is the airtight
-	// fix because it operates on the value actually rendered, not the value admitted.
+	// Validate URL fields and the digest before rendering (SEC-7 / C-1a). A space
+	// or control character in any value would break out of its cmdline parameter
+	// and allow injection or override of subsequent beskar7.* parameters. This
+	// check is defence-in-depth on top of the CRD pattern (C-1b); it is the
+	// airtight fix because it operates on the value actually rendered, not the
+	// value admitted.
 	if err := validateBootURL("InspectionImageURL", b7m.Spec.InspectionImageURL); err != nil {
 		return "", err
 	}
 	if err := validateBootURL("TargetImageURL", b7m.Spec.TargetImageURL); err != nil {
+		return "", err
+	}
+	if err := validateBootDigest(b7m.Spec.TargetImageDigest); err != nil {
 		return "", err
 	}
 
@@ -361,6 +384,7 @@ func (h *BootHandler) renderBootScript(
 		ph.Name,
 		string(tokenBytes),
 		b7m.Spec.TargetImageURL,
+		b7m.Spec.TargetImageDigest,
 		caB64,
 	)
 
@@ -383,8 +407,12 @@ func (h *BootHandler) renderBootScript(
 // script. All inputs are caller-resolved; this function performs no I/O.
 // Package-level so tests can call it directly for golden-string assertions.
 //
+// The parameter order on the kernel cmdline follows contract v2 §4.1 exactly:
+// beskar7.api, beskar7.namespace, beskar7.host, beskar7.token, beskar7.target,
+// beskar7.target-digest, beskar7.ca.
+//
 // Optional parameters (beskar7.timeout, beskar7.debug) are omitted in
-// contract v1 — no operator UI to supply them yet.
+// contract v2 — no operator UI to supply them yet.
 func buildBootIPXEScript(
 	inspectionImageURL string,
 	apiBase string,
@@ -392,16 +420,18 @@ func buildBootIPXEScript(
 	hostName string,
 	token string,
 	targetImageURL string,
+	targetDigest string,
 	caB64 string,
 ) string {
 	return fmt.Sprintf(
-		"#!ipxe\nkernel %s/vmlinuz beskar7.api=%s beskar7.namespace=%s beskar7.host=%s beskar7.token=%s beskar7.target=%s beskar7.ca=%s\ninitrd %s/initrd.img\nboot\n",
+		"#!ipxe\nkernel %s/vmlinuz beskar7.api=%s beskar7.namespace=%s beskar7.host=%s beskar7.token=%s beskar7.target=%s beskar7.target-digest=%s beskar7.ca=%s\ninitrd %s/initrd.img\nboot\n",
 		inspectionImageURL,
 		apiBase,
 		namespace,
 		hostName,
 		token,
 		targetImageURL,
+		targetDigest,
 		caB64,
 		inspectionImageURL,
 	)

--- a/controllers/boot_handler_test.go
+++ b/controllers/boot_handler_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"time"
 
@@ -44,6 +45,10 @@ import (
 const (
 	bootTestAPIBase = "https://beskar7.example.com:8082"
 	bootTestCABytes = "FAKE-CA-PEM-DATA"
+
+	// bootTestDigest is a realistic sha256 digest used in fixtures.
+	// The 64-char hex string below is arbitrary but correctly formed.
+	bootTestDigest = "sha256:a3b4c5d6e7f80102030405060708090a0b0c0d0e0f101112131415161718191a"
 )
 
 // buildBootMux wires a BootHandler onto a ServeMux using the same route pattern
@@ -110,6 +115,7 @@ func bootTestFixture(testNs string) (
 		Spec: infrastructurev1beta1.Beskar7MachineSpec{
 			InspectionImageURL: "https://boot.example.com/inspect",
 			TargetImageURL:     "https://boot.example.com/kairos.tar.gz",
+			TargetImageDigest:  bootTestDigest,
 		},
 	}
 	Expect(k8sClient.Create(ctx, b7m)).To(Succeed())
@@ -238,9 +244,19 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 		Expect(body).To(ContainSubstring("beskar7.host=" + ph.Name))
 		Expect(body).To(ContainSubstring("beskar7.token="))
 		Expect(body).To(ContainSubstring("beskar7.target=" + b7m.Spec.TargetImageURL))
+		Expect(body).To(ContainSubstring("beskar7.target-digest=" + b7m.Spec.TargetImageDigest))
 		Expect(body).To(ContainSubstring("beskar7.ca="))
 		Expect(body).To(ContainSubstring("initrd " + b7m.Spec.InspectionImageURL + "/initrd.img"))
 		Expect(body).To(ContainSubstring("\nboot\n"))
+
+		By("asserting beskar7.target-digest appears between beskar7.target and beskar7.ca (contract §4.1 ordering)")
+		targetIdx := strings.Index(body, "beskar7.target=")
+		digestIdx := strings.Index(body, "beskar7.target-digest=")
+		caIdx := strings.Index(body, "beskar7.ca=")
+		Expect(targetIdx).To(BeNumerically("<", digestIdx),
+			"beskar7.target must precede beskar7.target-digest")
+		Expect(digestIdx).To(BeNumerically("<", caIdx),
+			"beskar7.target-digest must precede beskar7.ca")
 
 		By("asserting BootNonceConsumedAt is set")
 		Eventually(func(g Gomega) {
@@ -514,6 +530,7 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 			Spec: infrastructurev1beta1.Beskar7MachineSpec{
 				InspectionImageURL: "https://boot.example.com/inspect",
 				TargetImageURL:     "https://boot.example.com/target.tar.gz",
+				TargetImageDigest:  bootTestDigest,
 			},
 		}
 		Expect(k8sClient.Create(ctx, b7m)).To(Succeed())
@@ -590,6 +607,7 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 			Spec: infrastructurev1beta1.Beskar7MachineSpec{
 				InspectionImageURL: inspectionURL,
 				TargetImageURL:     targetURL,
+				TargetImageDigest:  bootTestDigest,
 			},
 		}
 		tokenSecret := &corev1.Secret{
@@ -661,7 +679,172 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 		})
 	}
 
-	// ── 6. Script length cap (SEC-10) ──────────────────────────────────────
+	// ── 6. Digest validation (contract §5 / §8.1 / SEC-7) ───────────────────
+	//
+	// validateBootDigest unit tests exercise the helper directly. Each case is
+	// also an implicit integration test because renderBootScript calls it before
+	// rendering; an invalid digest would yield an opaque 404 on the live handler.
+
+	type digestCase struct {
+		name    string
+		digest  string
+		wantErr bool
+	}
+	digestCases := []digestCase{
+		// ── accept ──
+		{
+			name:    "valid lowercase sha256",
+			digest:  "sha256:a3b4c5d6e7f80102030405060708090a0b0c0d0e0f101112131415161718191a",
+			wantErr: false,
+		},
+		{
+			name:    "valid sha256 all-zeros",
+			digest:  "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			wantErr: false,
+		},
+		// ── reject ──
+		{
+			name:    "empty string",
+			digest:  "",
+			wantErr: true,
+		},
+		{
+			name:    "missing sha256: prefix",
+			digest:  "a3b4c5d6e7f80102030405060708090a0b0c0d0e0f101112131415161718191a",
+			wantErr: true,
+		},
+		{
+			name:    "wrong algorithm prefix (sha512:)",
+			digest:  "sha512:a3b4c5d6e7f80102030405060708090a0b0c0d0e0f101112131415161718191a",
+			wantErr: true,
+		},
+		{
+			name:    "too short (63 hex chars)",
+			digest:  "sha256:a3b4c5d6e7f80102030405060708090a0b0c0d0e0f10111213141516171819",
+			wantErr: true,
+		},
+		{
+			name:    "too long (65 hex chars)",
+			digest:  "sha256:a3b4c5d6e7f80102030405060708090a0b0c0d0e0f101112131415161718191a1b",
+			wantErr: true,
+		},
+		{
+			name:    "uppercase hex (non-canonical per contract §5/§8.1)",
+			digest:  "sha256:A3B4C5D6E7F80102030405060708090A0B0C0D0E0F101112131415161718191A",
+			wantErr: true,
+		},
+		{
+			name:    "mixed case hex",
+			digest:  "sha256:A3b4c5d6e7f80102030405060708090a0b0c0d0e0f101112131415161718191a",
+			wantErr: true,
+		},
+		{
+			name:    "embedded space (cmdline injection vector)",
+			digest:  "sha256:a3b4c5d6e7f80102030405060708 beskar7.token=ATTACKER00000000000000000",
+			wantErr: true,
+		},
+		{
+			name:    "embedded newline (cmdline injection vector)",
+			digest:  "sha256:a3b4c5d6e7f80102030405060708\nbeskar7.token=ATTACKER0000000000000000",
+			wantErr: true,
+		},
+		{
+			name:    "non-hex chars in digest body",
+			digest:  "sha256:z3b4c5d6e7f80102030405060708090a0b0c0d0e0f101112131415161718191a",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range digestCases {
+		tc := tc // capture range variable
+		It("validateBootDigest: "+tc.name, func() {
+			err := validateBootDigest(tc.digest)
+			if tc.wantErr {
+				Expect(err).To(HaveOccurred(),
+					"expected validateBootDigest to reject %q but it accepted it", tc.digest)
+			} else {
+				Expect(err).NotTo(HaveOccurred(),
+					"expected validateBootDigest to accept %q but it rejected: %v", tc.digest, err)
+			}
+		})
+	}
+
+	// ── 6b. Digest handler integration: invalid digest on Beskar7Machine → opaque 404
+
+	It("opaque 404: invalid TargetImageDigest on Beskar7Machine (fake client)", func() {
+		noncePlaintext, nonceHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		_, tokenHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+
+		nonceExpiresAt := metav1.NewTime(time.Now().Add(10 * time.Minute))
+		issuedAt := metav1.NewTime(time.Now())
+		tokenExpiresAt := metav1.NewTime(time.Now().Add(30 * time.Minute))
+
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "h-bad-digest", Namespace: "n"},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address: "https://192.168.1.1", CredentialsSecretRef: "x",
+				},
+				ConsumerRef: &corev1.ObjectReference{
+					Kind:       "Beskar7Machine",
+					APIVersion: InfrastructureAPIVersion,
+					Name:       "b7m-bad-digest",
+					Namespace:  "n",
+				},
+			},
+			Status: infrastructurev1beta1.PhysicalHostStatus{
+				Bootstrap: &infrastructurev1beta1.BootstrapStatus{
+					TokenHash:          tokenHash,
+					IssuedAt:           &issuedAt,
+					ExpiresAt:          &tokenExpiresAt,
+					BootNonceHash:      nonceHash,
+					BootNonceExpiresAt: &nonceExpiresAt,
+				},
+			},
+		}
+		// TargetImageDigest is intentionally malformed — uppercase hex, rejected
+		// by validateBootDigest (contract §5/§8.1, SEC-7). Bypasses CRD validation
+		// via fake client to test the handler's own guard.
+		b7mBadDigest := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "b7m-bad-digest", Namespace: "n"},
+			Spec: infrastructurev1beta1.Beskar7MachineSpec{
+				InspectionImageURL: "https://boot.example.com/inspect",
+				TargetImageURL:     "https://boot.example.com/target.tar.gz",
+				TargetImageDigest:  "sha256:A3B4C5D6E7F80102030405060708090A0B0C0D0E0F101112131415161718191A",
+			},
+		}
+		tokenSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenSecretName("h-bad-digest"), Namespace: "n"},
+			Type:       corev1.SecretTypeOpaque,
+			Data:       map[string][]byte{"plaintext-token": []byte("fake-token")},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(k8sClient.Scheme()).
+			WithObjects(b7mBadDigest, tokenSecret).
+			WithStatusSubresource(ph).
+			WithObjects(ph).
+			Build()
+
+		handler := &BootHandler{
+			Client: fakeClient,
+			Log:    ctrl.Log.WithName("boot-bad-digest-test"),
+			Config: bootTestConfig(),
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/boot/n/h-bad-digest/"+noncePlaintext, nil)
+		req.SetPathValue("namespace", "n")
+		req.SetPathValue("hostName", "h-bad-digest")
+		req.SetPathValue("nonce", noncePlaintext)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		Expect(w.Code).To(Equal(http.StatusNotFound),
+			"invalid TargetImageDigest must yield an opaque 404, not a 200 with a broken script")
+		Expect(w.Body.String()).To(ContainSubstring(bootHandlerOpaqueFailureBody))
+	})
+
+	// ── 7. Script length cap (SEC-10) ──────────────────────────────────────
 
 	It("length cap (SEC-10): oversized CA → opaque 404", func() {
 		// Construct a BootHandlerConfig with a CA large enough to push the
@@ -713,6 +896,7 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 			Spec: infrastructurev1beta1.Beskar7MachineSpec{
 				InspectionImageURL: "https://boot.example.com/inspect",
 				TargetImageURL:     "https://boot.example.com/target.tar.gz",
+				TargetImageDigest:  bootTestDigest,
 			},
 		}
 		tokenSecret := &corev1.Secret{

--- a/controllers/bootstrap_handler_test.go
+++ b/controllers/bootstrap_handler_test.go
@@ -147,6 +147,7 @@ var _ = Describe("Bootstrap GET handler (PR-5.3)", func() {
 			Spec: infrastructurev1beta1.Beskar7MachineSpec{
 				InspectionImageURL: "http://boot-server/inspect.ipxe",
 				TargetImageURL:     "http://boot-server/kairos.tar.gz",
+				TargetImageDigest:  bootTestDigest,
 			},
 		}
 		Expect(k8sClient.Create(ctx, b7machine)).To(Succeed())

--- a/examples/complete-cluster.yaml
+++ b/examples/complete-cluster.yaml
@@ -116,6 +116,7 @@ spec:
     spec:
       inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
       targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+      targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
       configurationURL:   "http://boot-server.local/configs/control-plane.yaml"
       hardwareRequirements:
         minCPUCores: 4
@@ -163,6 +164,7 @@ spec:
     spec:
       inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
       targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+      targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
       configurationURL:   "http://boot-server.local/configs/worker.yaml"
       hardwareRequirements:
         minCPUCores: 4

--- a/examples/minimal-test-cluster.yaml
+++ b/examples/minimal-test-cluster.yaml
@@ -66,4 +66,5 @@ metadata:
 spec:
   inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
   targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
   configurationURL:   "http://boot-server.local/configs/test.yaml"

--- a/examples/minimal-test.yaml
+++ b/examples/minimal-test.yaml
@@ -38,6 +38,7 @@ metadata:
 spec:
   inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
   targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
   configurationURL: "http://boot-server.local/configs/test-config.yaml"
 
 ---

--- a/examples/simple-cluster.yaml
+++ b/examples/simple-cluster.yaml
@@ -124,6 +124,7 @@ spec:
   
   # Final OS (Kairos example)
   targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
   
   # OS configuration
   configurationURL: "http://boot-server.local/configs/control-plane-config.yaml"
@@ -147,6 +148,7 @@ metadata:
 spec:
   inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
   targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
   configurationURL: "http://boot-server.local/configs/worker-config.yaml"
   hardwareRequirements:
     minCPUCores: 4
@@ -165,6 +167,7 @@ metadata:
 spec:
   inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
   targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
   configurationURL: "http://boot-server.local/configs/worker-config.yaml"
   hardwareRequirements:
     minCPUCores: 4

--- a/hack/smoke/manifests/40-cluster-and-machine.yaml
+++ b/hack/smoke/manifests/40-cluster-and-machine.yaml
@@ -86,6 +86,10 @@ spec:
   # but no real machine boots; these are never fetched.
   inspectionImageURL: http://boot.example.invalid/ipxe/inspect.ipxe
   targetImageURL: http://boot.example.invalid/images/placeholder.tar.gz
+  # Required by the CRD (pattern ^sha256:<64-hex>$). Never verified here — no
+  # real image is fetched — so an all-zero placeholder digest satisfies
+  # admission without implying a real artifact.
+  targetImageDigest: sha256:0000000000000000000000000000000000000000000000000000000000000000
   configurationURL: http://boot.example.invalid/configs/smoke.yaml
 ---
 # CAPI Machine with a PRE-BAKED bootstrap.dataSecretName. This bypasses the

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -362,6 +362,7 @@ func createBeskar7Machine(ctx context.Context, ns, b7mName string, ownerMachine 
 		Spec: infrastructurev1beta1.Beskar7MachineSpec{
 			InspectionImageURL: "http://boot-server/inspect.ipxe",
 			TargetImageURL:     "http://boot-server/kairos.tar.gz",
+			TargetImageDigest:  "sha256:a3b4c5d6e7f80102030405060708090a0b0c0d0e0f101112131415161718191a",
 			// HardwareRequirements is nil intentionally: with no requirements the
 			// validateInspectionReport fast-paths to "passed" for any report, which
 			// keeps the fixture minimal.


### PR DESCRIPTION
## Summary

Phase A of the contract-v2 epic (#115). The whole-disk image handoff pins the target Kairos raw image by SHA-256 digest delivered on the kernel cmdline — the digest is the integrity/authenticity anchor for the HTTP-fetched image, since TLS is **not** the trust root for the target artifact (the inspector's rustls store carries only the callback CA). This PR adds the controller-side field and renders it into the boot script.

- **api**: add required `Beskar7Machine.Spec.TargetImageDigest` (pattern `^sha256:[a-f0-9]{64}$`); repurpose the `TargetImageURL` godoc from kexec → Kairos whole-disk raw image + digest pinning.
- **controllers/boot_handler**: validate the digest actually rendered into the cmdline (`validateBootDigest`, SEC-7 defence-in-depth on top of the CRD pattern) and emit `beskar7.target-digest` between `beskar7.target` and `beskar7.ca`, matching contract §4.1.
- regenerate CRDs (`config/crd/bases` + `charts/beskar7/crds` copies) and update examples/tests for the now-required field.

## Contract reference

- `docs/inspector-contract.md` §4.1 (rendered iPXE ordering), §8.1 (target-image integrity / digest pinning).

## Test plan

- [x] `make test` — all packages pass
- [x] `golangci-lint run` — 0 issues
- [x] `make manifests` regenerated CRDs committed; chart CRD copies in sync
- [x] `boot_handler_test.go`: asserts `beskar7.target-digest=` is rendered, asserts cmdline ordering, 12-case `validateBootDigest` table, invalid-digest → opaque 404
- [ ] Reviewer: confirm the all-zeros example digest placeholder is acceptable for `examples/*` (real operators compute the digest from their image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)