### PR TITLE
feat: render beskar7.disk from optional Beskar7Machine.Spec.TargetDisk

### DIFF
--- a/api/v1beta1/beskar7machine_types.go
+++ b/api/v1beta1/beskar7machine_types.go
@@ -93,6 +93,16 @@ type Beskar7MachineSpec struct {
 	// +kubebuilder:validation:Pattern="^sha256:[a-f0-9]{64}$"
 	TargetImageDigest string `json:"targetImageDigest"`
 
+	// TargetDisk optionally pins the disk the inspector writes the OS image to.
+	// A stable device path (/dev/disk/by-id/..., /dev/disk/by-path/...) or a
+	// kernel name (/dev/nvme0n1, sda). When set, the inspector uses exactly that
+	// device and aborts (never falling back) if it is ineligible; when empty, the
+	// inspector auto-selects the smallest eligible disk (contract §5 beskar7.disk,
+	// §9.1 step 2). Non-secret.
+	// +kubebuilder:validation:Pattern="^[A-Za-z0-9._:/+-]+$"
+	// +optional
+	TargetDisk string `json:"targetDisk,omitempty"`
+
 	// ConfigurationURL is an optional URL for OS-specific configuration.
 	// The inspection image will pass this to the target OS during kexec.
 	// +kubebuilder:validation:Pattern="^https?://.*"

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -68,6 +68,9 @@ spec:
                 type: string
               providerID:
                 type: string
+              targetDisk:
+                pattern: ^[A-Za-z0-9._:/+-]+$
+                type: string
               targetImageDigest:
                 pattern: ^sha256:[a-f0-9]{64}$
                 type: string

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -57,6 +57,9 @@ spec:
                         type: string
                       providerID:
                         type: string
+                      targetDisk:
+                        pattern: ^[A-Za-z0-9._:/+-]+$
+                        type: string
                       targetImageDigest:
                         pattern: ^sha256:[a-f0-9]{64}$
                         type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -68,6 +68,9 @@ spec:
                 type: string
               providerID:
                 type: string
+              targetDisk:
+                pattern: ^[A-Za-z0-9._:/+-]+$
+                type: string
               targetImageDigest:
                 pattern: ^sha256:[a-f0-9]{64}$
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -57,6 +57,9 @@ spec:
                         type: string
                       providerID:
                         type: string
+                      targetDisk:
+                        pattern: ^[A-Za-z0-9._:/+-]+$
+                        type: string
                       targetImageDigest:
                         pattern: ^sha256:[a-f0-9]{64}$
                         type: string

--- a/controllers/boot_handler.go
+++ b/controllers/boot_handler.go
@@ -306,12 +306,39 @@ func validateBootURL(field, raw string) error {
 // sufficient and stronger guard against cmdline injection (SEC-7 posture).
 var bootDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 
+// bootDiskPattern is compiled once at init time. It accepts device paths and
+// kernel names that contain only the character set permitted by the CRD
+// +kubebuilder:validation:Pattern marker. An empty string is valid (the field
+// is optional). A value matching this pattern contains no whitespace or
+// control characters (SEC-7 posture).
+var bootDiskPattern = regexp.MustCompile(`^[A-Za-z0-9._:/+-]+$`)
+
 // validateBootDigest rejects a digest that does not match the contract §5/§8.1
 // canonical form. Defence-in-depth (SEC-7) on top of the CRD pattern: operates
 // on the value actually rendered, not the value admitted.
 func validateBootDigest(raw string) error {
 	if !bootDigestPattern.MatchString(raw) {
 		return fmt.Errorf("TargetImageDigest is not a valid sha256 digest (must match ^sha256:[0-9a-f]{64}$)")
+	}
+	return nil
+}
+
+// validateBootDisk rejects a non-empty disk value that contains whitespace or
+// control characters or falls outside the CRD-permitted character set. Defence-
+// in-depth (SEC-7 posture) on the value actually rendered onto the kernel
+// cmdline. An empty string is accepted — the field is optional (contract §5
+// beskar7.disk, §9.1 step 2).
+func validateBootDisk(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	if strings.ContainsFunc(raw, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	}) {
+		return fmt.Errorf("TargetDisk contains whitespace or control characters")
+	}
+	if !bootDiskPattern.MatchString(raw) {
+		return fmt.Errorf("TargetDisk contains characters outside the permitted set (^[A-Za-z0-9._:/+-]+$)")
 	}
 	return nil
 }
@@ -360,6 +387,11 @@ func (h *BootHandler) renderBootScript(
 	if err := validateBootDigest(b7m.Spec.TargetImageDigest); err != nil {
 		return "", err
 	}
+	if b7m.Spec.TargetDisk != "" {
+		if err := validateBootDisk(b7m.Spec.TargetDisk); err != nil {
+			return "", err
+		}
+	}
 
 	// Read the bearer-token plaintext from the per-host bootstrap-token Secret.
 	// The handler received the {nonce} in the URL; it hands back the bearer token
@@ -386,6 +418,7 @@ func (h *BootHandler) renderBootScript(
 		b7m.Spec.TargetImageURL,
 		b7m.Spec.TargetImageDigest,
 		caB64,
+		b7m.Spec.TargetDisk,
 	)
 
 	// Cap the rendered script length (SEC-10). The Linux kernel cmdline cap is
@@ -409,7 +442,16 @@ func (h *BootHandler) renderBootScript(
 //
 // The parameter order on the kernel cmdline follows contract v2 §4.1 exactly:
 // beskar7.api, beskar7.namespace, beskar7.host, beskar7.token, beskar7.target,
-// beskar7.target-digest, beskar7.ca.
+// beskar7.target-digest, beskar7.ca[, beskar7.disk].
+//
+// beskar7.disk is appended immediately after beskar7.ca when targetDisk is
+// non-empty, per contract §4.1 template:
+//
+//	... beskar7.ca={base64CA} [beskar7.disk={disk}]
+//	initrd ...
+//
+// When targetDisk is empty the line is byte-identical to the pre-D-011 §11
+// format (no trailing space, no empty param).
 //
 // Optional parameters (beskar7.timeout, beskar7.debug) are omitted in
 // contract v2 — no operator UI to supply them yet.
@@ -422,9 +464,14 @@ func buildBootIPXEScript(
 	targetImageURL string,
 	targetDigest string,
 	caB64 string,
+	targetDisk string,
 ) string {
+	diskParam := ""
+	if targetDisk != "" {
+		diskParam = " beskar7.disk=" + targetDisk
+	}
 	return fmt.Sprintf(
-		"#!ipxe\nkernel %s/vmlinuz beskar7.api=%s beskar7.namespace=%s beskar7.host=%s beskar7.token=%s beskar7.target=%s beskar7.target-digest=%s beskar7.ca=%s\ninitrd %s/initrd.img\nboot\n",
+		"#!ipxe\nkernel %s/vmlinuz beskar7.api=%s beskar7.namespace=%s beskar7.host=%s beskar7.token=%s beskar7.target=%s beskar7.target-digest=%s beskar7.ca=%s%s\ninitrd %s/initrd.img\nboot\n",
 		inspectionImageURL,
 		apiBase,
 		namespace,
@@ -433,6 +480,7 @@ func buildBootIPXEScript(
 		targetImageURL,
 		targetDigest,
 		caB64,
+		diskParam,
 		inspectionImageURL,
 	)
 }

--- a/controllers/boot_handler_test.go
+++ b/controllers/boot_handler_test.go
@@ -1047,3 +1047,113 @@ func (c *logCaptureSinkChild) WithName(_ string) logr.LogSink { return c }
 func logWithSink(s logr.LogSink) logr.Logger {
 	return logr.New(s)
 }
+
+// ── TargetDisk feature tests (contract §5 beskar7.disk, §9.1 step 2) ─────────
+
+var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
+	const (
+		testInspectionURL = "https://boot.example.com/inspect"
+		testAPIBase       = "https://beskar7.example.com:8082"
+		testNamespace     = "default"
+		testHost          = "host-01"
+		testToken         = "tok-abc123"
+		testTargetURL     = "https://images.example.com/kairos.img"
+		testCA            = "FAKECABASE64=="
+	)
+
+	It("renders beskar7.disk immediately after beskar7.ca when TargetDisk is set", func() {
+		disk := "/dev/disk/by-id/nvme-FOO"
+		script := buildBootIPXEScript(
+			testInspectionURL,
+			testAPIBase,
+			testNamespace,
+			testHost,
+			testToken,
+			testTargetURL,
+			bootTestDigest,
+			testCA,
+			disk,
+		)
+
+		By("asserting beskar7.disk appears in the kernel line")
+		Expect(script).To(ContainSubstring("beskar7.disk=" + disk))
+
+		By("asserting beskar7.disk is positioned immediately after beskar7.ca")
+		caIdx := strings.Index(script, "beskar7.ca=")
+		diskIdx := strings.Index(script, "beskar7.disk=")
+		Expect(diskIdx).To(BeNumerically(">", caIdx),
+			"beskar7.disk must appear after beskar7.ca")
+		// The token between the two params must be exactly " beskar7.disk=":
+		// no intervening content (no other params between them).
+		caEnd := caIdx + len("beskar7.ca=") + len(testCA)
+		Expect(script[caEnd:caEnd+len(" beskar7.disk=")]).To(Equal(" beskar7.disk="),
+			"beskar7.disk must be the immediate successor of beskar7.ca with a single space")
+
+		By("asserting beskar7.disk appears before the initrd line")
+		initrdIdx := strings.Index(script, "\ninitrd ")
+		Expect(diskIdx).To(BeNumerically("<", initrdIdx),
+			"beskar7.disk must precede the initrd line")
+	})
+
+	It("omits beskar7.disk entirely when TargetDisk is empty", func() {
+		script := buildBootIPXEScript(
+			testInspectionURL,
+			testAPIBase,
+			testNamespace,
+			testHost,
+			testToken,
+			testTargetURL,
+			bootTestDigest,
+			testCA,
+			"",
+		)
+
+		By("asserting beskar7.disk is absent")
+		Expect(script).NotTo(ContainSubstring("beskar7.disk"),
+			"empty TargetDisk must produce no beskar7.disk token in the script")
+
+		By("asserting the kernel line ends with beskar7.ca=<value> immediately followed by newline+initrd")
+		caIdx := strings.Index(script, "beskar7.ca=")
+		Expect(caIdx).To(BeNumerically(">", 0))
+		caEnd := caIdx + len("beskar7.ca=") + len(testCA)
+		Expect(script[caEnd]).To(Equal(byte('\n')),
+			"no trailing space after beskar7.ca when TargetDisk is empty — byte-identical to pre-change format")
+	})
+})
+
+var _ = Describe("validateBootDisk", func() {
+	type diskCase struct {
+		name    string
+		input   string
+		wantErr bool
+	}
+	cases := []diskCase{
+		// ── accept ──
+		{name: "empty string (optional field)", input: "", wantErr: false},
+		{name: "kernel short name", input: "sda", wantErr: false},
+		{name: "kernel nvme name", input: "nvme0n1", wantErr: false},
+		{name: "by-id path", input: "/dev/disk/by-id/nvme-Samsung_SSD_990_PRO_2TB_S6Z0NX0W123456", wantErr: false},
+		{name: "by-path path", input: "/dev/disk/by-path/pci-0000:02:00.0-nvme-1", wantErr: false},
+		{name: "dot-separated label", input: "disk.by-id.nvme+foo", wantErr: false},
+		// ── reject ──
+		{name: "value with space (injection vector)", input: "/dev/sda beskar7.api=ATTACKER", wantErr: true},
+		{name: "value with newline (injection vector)", input: "/dev/sda\nbeskar7.token=ATTACKER", wantErr: true},
+		{name: "value with tab (injection vector)", input: "/dev/sda\tbeskar7.api=ATTACKER", wantErr: true},
+		{name: "value with control char (injection vector)", input: "/dev/sda\x01evil", wantErr: true},
+		{name: "value with shell metachar dollar", input: "/dev/sda$PWD", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		It("validateBootDisk: "+tc.name, func() {
+			err := validateBootDisk(tc.input)
+			if tc.wantErr {
+				Expect(err).To(HaveOccurred(),
+					"expected validateBootDisk to reject %q but it accepted it", tc.input)
+			} else {
+				Expect(err).NotTo(HaveOccurred(),
+					"expected validateBootDisk to accept %q but it rejected: %v", tc.input, err)
+			}
+		})
+	}
+})

--- a/docs/inspector-contract.md
+++ b/docs/inspector-contract.md
@@ -151,17 +151,15 @@ boot
 - The script boots the inspector image directly; it does NOT chainload another
   iPXE script (the per-host script IS this response).
 
-> **Implementation status (v2):** the required parts of this section are
-> **implemented** in this repo. `Beskar7Machine.Spec.TargetImageDigest` exists
-> (required, `^sha256:[a-f0-9]{64}$`) and `buildBootIPXEScript` renders
-> `beskar7.target` + `beskar7.target-digest`; `TargetImageURL`'s godoc is
-> Kairos-correct. What remains **net-new** is the *optional* `beskar7.disk`
-> render shown in brackets above — it needs a new optional `Beskar7Machine`
-> target-disk spec field (e.g. `Spec.TargetDisk`) and a `/boot` render of it,
-> an additive controller follow-up (§11). It is absent from the rendered script
-> today, which is correct: default (auto-select) provisioning needs no
-> `beskar7.disk`. The **inspector** deploy path (§9.1 step 5) is the other
-> net-new surface, built in the inspector repo against this spec.
+> **Implementation status (v2):** this section is **implemented** in this repo.
+> `Beskar7Machine.Spec.TargetImageDigest` exists (required,
+> `^sha256:[a-f0-9]{64}$`) and `buildBootIPXEScript` renders `beskar7.target` +
+> `beskar7.target-digest`; `TargetImageURL`'s godoc is Kairos-correct. The
+> *optional* `beskar7.disk` render shown in brackets above is also implemented:
+> `Beskar7Machine.Spec.TargetDisk` (optional, `^[A-Za-z0-9._:/+-]+$`) is rendered
+> by `/boot` immediately after `beskar7.ca` when set, and omitted when empty (the
+> default auto-select path). The **inspector** deploy path (§9.1 step 5) is built
+> in the inspector repo against this spec.
 
 ### 4.2 `POST /api/v1/inspection/{namespace}/{hostName}` — hardware report
 
@@ -204,7 +202,7 @@ these from `/proc/cmdline`.
 | `beskar7.target` | yes | `Beskar7Machine.Spec.TargetImageURL` — the **Kairos whole-disk raw image** the inspector writes to the target disk. MUST be an `http://` or `https://` URL; plain HTTP is permitted (integrity comes from `beskar7.target-digest`, not TLS — see §8.1). Non-secret. |
 | `beskar7.target-digest` | yes | `Beskar7Machine.Spec.TargetImageDigest` — the expected SHA-256 of the bytes at `beskar7.target`, matching `^sha256:[0-9a-f]{64}$`. The inspector MUST verify the written image against this digest and MUST refuse to **boot** (mount/inject/reboot) a non-matching image (§8.1). Non-secret; it is the sole integrity **and authenticity** anchor for the OS image. |
 | `beskar7.ca` | yes | Base64-encoded PEM of the CA the inspector uses to verify the callback's TLS cert. **Inline only.** `/boot` sources it from the manager's callback cert dir (`ca.crt` if present — cert-manager and the chart's self-signed path both provide it — else the self-signed `tls.crt`). Bounded by kernel cmdline length (~2–4 KiB): a single self-signed/issuer cert fits; a full multi-cert chain may not. A `beskar7.ca-url` fetch variant for chain delivery is deferred to a later contract version. See §8. Note: this CA verifies **only** the callback endpoints (`/inspection`, `/bootstrap`); it does NOT verify `beskar7.target` (§8.1). |
-| `beskar7.disk` | no | Operator override pinning the target disk — a stable device path (`/dev/disk/by-id/...`, `/dev/disk/by-path/...`) or a kernel name (`/dev/nvme0n1`, `sda`). When **absent**, the inspector auto-selects the smallest eligible disk (§9.1 step 2). When **present**, the inspector MUST resolve it once to its canonical whole-disk kernel device (`/dev/<kname>`, following any `by-id`/`by-path` symlink) and thereafter use *that resolved node* for both validation and the write, so the device validated is the device written (no TOCTOU re-lookup). It MUST use exactly that device and MUST abort — never silently falling back to auto-selection (a wrong pin fails loudly) — if the device is missing, not a block device, **not a whole disk** (a partition, `dm`/loop, or other non-whole-disk node), removable, read-only, **backs the running ramdisk**, or is smaller than the image. Sourced from an optional `Beskar7Machine` target-disk spec field rendered by `/boot` (an additive controller follow-up — see §11). Non-secret. |
+| `beskar7.disk` | no | Operator override pinning the target disk — a stable device path (`/dev/disk/by-id/...`, `/dev/disk/by-path/...`) or a kernel name (`/dev/nvme0n1`, `sda`). When **absent**, the inspector auto-selects the smallest eligible disk (§9.1 step 2). When **present**, the inspector MUST resolve it once to its canonical whole-disk kernel device (`/dev/<kname>`, following any `by-id`/`by-path` symlink) and thereafter use *that resolved node* for both validation and the write, so the device validated is the device written (no TOCTOU re-lookup). It MUST use exactly that device and MUST abort — never silently falling back to auto-selection (a wrong pin fails loudly) — if the device is missing, not a block device, **not a whole disk** (a partition, `dm`/loop, or other non-whole-disk node), removable, read-only, **backs the running ramdisk**, or is smaller than the image. Sourced from the optional `Beskar7Machine.Spec.TargetDisk` field, rendered by `/boot` after `beskar7.ca` when set. Non-secret. |
 | `beskar7.timeout` | no | Inspector-side overall timeout (seconds). |
 | `beskar7.debug` | no | `true` to enable verbose logging / debug shell on failure. |
 
@@ -536,7 +534,7 @@ apart. The inspector therefore MUST treat the GET as a **poll**, not a one-shot:
 | Version | Delta |
 |---|---|
 | **v1** | Initial frozen contract: boot-nonce + bearer-token two-secret trust model, three HTTPS endpoints (`/boot`, `/inspection`, `/bootstrap`), §6 inspection report schema + golden fixture, inline `beskar7.ca`. Handoff was **kexec into `beskar7.target`** (a kernel+initrd image). |
-| **v2** | **Handoff redesign — §6 report schema unchanged.** Replaces kexec with whole-disk image deployment: the inspector writes a Kairos whole-disk raw image (`beskar7.target`) to the target disk, injects the per-host config (with CAPI user-data) as a numbered Kairos cloud-config (`99_beskar7.yaml`) into the image's `COS_OEM` partition, and reboots. Adds required cmdline param `beskar7.target-digest` (`sha256:<hex>`) plus optional `beskar7.disk` (operator disk-selection override), the §8.1 digest-pinning trust model (target image over plain HTTP, integrity by content digest, not TLS), and a specified disk-selection policy (smallest eligible disk by default). Reframes §9 around the two-phase enroll/provision role model (§9.0–9.2). **Report path:** the §6 schema and golden fixture are untouched, so the bump forces **no** inspector report-code or fixture change. **Controller side:** the required CRD delta — the `Beskar7Machine.Spec.TargetImageDigest` field and the `/boot` render of `beskar7.target` + `beskar7.target-digest` — is **implemented** in this repo. What stays net-new is the *optional* `beskar7.disk` render and its backing `Beskar7Machine` target-disk spec field (additive follow-up, §11), plus the entire inspector deploy path (§9.1 step 5). The deploy path is a new, separately-tested drift surface (§10). |
+| **v2** | **Handoff redesign — §6 report schema unchanged.** Replaces kexec with whole-disk image deployment: the inspector writes a Kairos whole-disk raw image (`beskar7.target`) to the target disk, injects the per-host config (with CAPI user-data) as a numbered Kairos cloud-config (`99_beskar7.yaml`) into the image's `COS_OEM` partition, and reboots. Adds required cmdline param `beskar7.target-digest` (`sha256:<hex>`) plus optional `beskar7.disk` (operator disk-selection override), the §8.1 digest-pinning trust model (target image over plain HTTP, integrity by content digest, not TLS), and a specified disk-selection policy (smallest eligible disk by default). Reframes §9 around the two-phase enroll/provision role model (§9.0–9.2). **Report path:** the §6 schema and golden fixture are untouched, so the bump forces **no** inspector report-code or fixture change. **Controller side:** the CRD delta is **implemented** in this repo — the required `Beskar7Machine.Spec.TargetImageDigest` field and the `/boot` render of `beskar7.target` + `beskar7.target-digest`, plus the optional `Beskar7Machine.Spec.TargetDisk` field and its `beskar7.disk` render. The inspector deploy path (§9.1 step 5) is a new, separately-tested drift surface (§10). |
 
 ---
 
@@ -556,13 +554,11 @@ apart. The inspector therefore MUST treat the GET as a **poll**, not a one-shot:
   into status on first boot / from `InspectionReport.NICs` for inventory. It MUST
   NOT become a required spec field (it duplicates the operator's DHCP mapping and
   is not a trust anchor).
-- **Operator-pinned target disk — controller render** (additive Phase A follow-up):
-  §5/§9.1 now specify disk selection — the smallest eligible disk by default, or an
-  explicit `beskar7.disk` override. The inspector honors `beskar7.disk` whenever it is
-  present, so the override is forward-compatible. The controller-side change to
-  *expose* it — an optional `Beskar7Machine` target-disk spec field and its `/boot`
-  render — is a separate, additive PR and is **not** required for default
-  (auto-select) provisioning.
+- **Operator-pinned target disk** (implemented): §5/§9.1 specify disk selection —
+  the smallest eligible disk by default, or an explicit `beskar7.disk` override.
+  The inspector honors `beskar7.disk`, and the controller now renders it from the
+  optional `Beskar7Machine.Spec.TargetDisk` field (`/boot`, after `beskar7.ca`,
+  only when set). It is **not** required for default (auto-select) provisioning.
 - **kexec for boot-time speed** (future optimization): v2 reboots via host
   firmware (one POST cycle). A later version MAY `kexec` directly into the freshly
   written OS to skip the firmware POST, but kexec needs real firmware and a

--- a/examples/complete-cluster.yaml
+++ b/examples/complete-cluster.yaml
@@ -117,6 +117,7 @@ spec:
       inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
       targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
       targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
+      # targetDisk: /dev/disk/by-id/nvme-...  # optional: pin the install disk; omit to let the inspector auto-select
       configurationURL:   "http://boot-server.local/configs/control-plane.yaml"
       hardwareRequirements:
         minCPUCores: 4
@@ -165,6 +166,7 @@ spec:
       inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
       targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
       targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
+      # targetDisk: /dev/disk/by-id/nvme-...  # optional: pin the install disk; omit to let the inspector auto-select
       configurationURL:   "http://boot-server.local/configs/worker.yaml"
       hardwareRequirements:
         minCPUCores: 4


### PR DESCRIPTION
## Summary

The inspector already honors a `beskar7.disk` cmdline param to pin the install
disk; the controller now **renders** it. This closes the operator-pinned-disk
loop the contract recorded as an additive §11 follow-up — until now the
capability was a dead-end (the inspector read a param nothing produced).

- **API**: new optional `Beskar7MachineSpec.TargetDisk` (pattern
  `^[A-Za-z0-9._:/+-]+$`, `omitempty`). A stable device path
  (`/dev/disk/by-id/...`) or kernel name (`/dev/nvme0n1`, `sda`); when empty the
  inspector auto-selects the smallest eligible disk.
- **`/boot` render**: `validateBootDisk` (defense-in-depth on the *rendered*
  value — rejects whitespace/control + enforces the CRD charset, the SEC-7
  posture mirroring `validateBootURL`/`validateBootDigest`); `buildBootIPXEScript`
  conditionally appends ` beskar7.disk=<disk>` immediately after `beskar7.ca` when
  set. **When empty, the kernel line is byte-identical to before** (no trailing
  space, no empty param).
- **Manifests**: `make manifests` + `make sync-chart-crds` — the new field is in
  both `config/crd/bases/` and `charts/beskar7/crds/` (in sync).
- **Example**: commented `targetDisk` override in `examples/complete-cluster.yaml`.
- **Contract doc**: §4.1/§5/§10.1/§11 updated from "deferred §11 follow-up" to
  "implemented".

## Test plan
- [x] `make manifests` idempotent (no further drift); CRD base + chart copy carry
      `targetDisk` with the pattern.
- [x] `make test` green; `golangci-lint run` 0 issues; `gofmt -s` clean.
- [x] New tests: `buildBootIPXEScript` render (set → `beskar7.disk=` right after
      `beskar7.ca=`; empty → no `beskar7.disk` token, byte-identical line) +
      `validateBootDisk` table (empty ok; space/tab/newline/control/metachar
      rejected).
- [x] **Security-reviewed** (security-engineer): **safe-to-ship**, no
      Critical/High. The cmdline-injection surface is fully closed — the regexp
      (brute-forced across Unicode) admits no whitespace/separator, RE2 `$` won't
      match before `\n` (no multiline smuggling), and the render-time check fires
      on every path before `buildBootIPXEScript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)