### PR TITLE
feat: render BOOTIF from ?mac= + document Phase-1 networking (D-013)

### DIFF
--- a/controllers/boot_handler.go
+++ b/controllers/boot_handler.go
@@ -249,7 +249,13 @@ func (h *BootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// renderBootScript is a pure function of (ph, machine, secret, config) so
 	// the response is byte-identical on the fresh-consume and already-consumed
 	// paths.
-	script, err := h.renderBootScript(ctx, log, ph)
+	//
+	// The operator's first-stage iPXE chainload appends ?mac=${net0/mac} by
+	// convention so multi-NIC hosts can hint which NIC the inspector should treat
+	// as the provisioning interface. The value is optional: single-NIC hosts work
+	// without it (the inspector falls back to its own NIC selection heuristic).
+	mac := r.URL.Query().Get("mac")
+	script, err := h.renderBootScript(ctx, log, ph, mac)
 	if err != nil {
 		log.V(1).Info("boot GET: render failed", "err", err.Error())
 		h.opaqueFailure(w)
@@ -313,6 +319,33 @@ var bootDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 // control characters (SEC-7 posture).
 var bootDiskPattern = regexp.MustCompile(`^[A-Za-z0-9._:/+-]+$`)
 
+// bootifMACPattern matches the colon-separated MAC form produced by iPXE's
+// ${net0/mac} expansion: exactly six lowercase-or-uppercase hex octets
+// separated by colons. Accepts no whitespace, no dashes — those only appear
+// in the pxelinux BOOTIF output form produced by formatBootif, not in the
+// iPXE query param. (SEC-7 posture: unrecognised shape → omit, don't inject.)
+var bootifMACPattern = regexp.MustCompile(`^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$`)
+
+// formatBootif converts an iPXE ${net0/mac} value (colon-separated, e.g.
+// "52:54:00:12:34:56") to the pxelinux BOOTIF form read by the inspector from
+// /proc/cmdline ("01-52-54-00-12-34-56"). The leading "01-" is the ARP hardware
+// type for Ethernet (RFC 5227). Returns ("", false) for an empty or
+// malformed MAC — the BOOTIF token is simply omitted (omit-on-invalid is correct
+// because BOOTIF is an optional hint; the inspector falls back to single-NIC
+// selection when it is absent). Unlike the CRD-backed beskar7.* params, the
+// `mac` query value has NO admission-time validation, so this regexp is the
+// SOLE guard against cmdline injection: it admits no whitespace or separator
+// other than ':' (and Go's `$` does not match before a trailing newline), so a
+// malformed or injection-attempt mac is dropped and never reaches the cmdline.
+func formatBootif(mac string) (string, bool) {
+	if mac == "" || !bootifMACPattern.MatchString(mac) {
+		return "", false
+	}
+	// Replace colons with dashes and lowercase the whole string.
+	dashed := strings.ToLower(strings.ReplaceAll(mac, ":", "-"))
+	return "01-" + dashed, true
+}
+
 // validateBootDigest rejects a digest that does not match the contract §5/§8.1
 // canonical form. Defence-in-depth (SEC-7) on top of the CRD pattern: operates
 // on the value actually rendered, not the value admitted.
@@ -346,14 +379,21 @@ func validateBootDisk(raw string) error {
 // renderBootScript resolves the consuming Beskar7Machine, reads the bearer-token
 // plaintext from the per-host Secret, and renders the §4.1 iPXE script.
 //
-// Pure function of (host, machine, secret, config): the rendered output is
-// byte-identical on fresh-consume and already-consumed paths for the same host.
-// No secret material is logged here; the caller logs only namespace + host +
-// outcome.
+// macParam is the raw value of the ?mac= query parameter supplied by the
+// first-stage iPXE chainload (iPXE convention: ${net0/mac}). It is validated
+// and converted to the pxelinux BOOTIF form by formatBootif; an empty or
+// malformed value results in no BOOTIF token on the kernel cmdline (omit-on-
+// invalid; see formatBootif).
+//
+// Pure function of (host, machine, secret, config, macParam): the rendered
+// output is byte-identical on fresh-consume and already-consumed paths for the
+// same host and the same macParam. No secret material is logged here; the
+// caller logs only namespace + host + outcome.
 func (h *BootHandler) renderBootScript(
 	ctx context.Context,
 	log logr.Logger,
 	ph *infrastructurev1beta1.PhysicalHost,
+	macParam string,
 ) (string, error) {
 	// Walk to the consuming Beskar7Machine via Spec.ConsumerRef.
 	cr := ph.Spec.ConsumerRef
@@ -409,6 +449,11 @@ func (h *BootHandler) renderBootScript(
 	// base64-encode the CA PEM for inline delivery via beskar7.ca=.
 	caB64 := base64.StdEncoding.EncodeToString(h.Config.CABytes)
 
+	// Convert the optional ?mac= query param to the pxelinux BOOTIF form.
+	// formatBootif returns ("", false) for an empty or malformed MAC so a bad
+	// value is simply omitted rather than rendered (omit-on-invalid; SEC-7).
+	bootif, _ := formatBootif(macParam)
+
 	script := buildBootIPXEScript(
 		b7m.Spec.InspectionImageURL,
 		h.Config.APIBase,
@@ -419,6 +464,7 @@ func (h *BootHandler) renderBootScript(
 		b7m.Spec.TargetImageDigest,
 		caB64,
 		b7m.Spec.TargetDisk,
+		bootif,
 	)
 
 	// Cap the rendered script length (SEC-10). The Linux kernel cmdline cap is
@@ -442,7 +488,7 @@ func (h *BootHandler) renderBootScript(
 //
 // The parameter order on the kernel cmdline follows contract v2 §4.1 exactly:
 // beskar7.api, beskar7.namespace, beskar7.host, beskar7.token, beskar7.target,
-// beskar7.target-digest, beskar7.ca[, beskar7.disk].
+// beskar7.target-digest, beskar7.ca[, beskar7.disk][, BOOTIF=<bootif>].
 //
 // beskar7.disk is appended immediately after beskar7.ca when targetDisk is
 // non-empty, per contract §4.1 template:
@@ -450,8 +496,12 @@ func (h *BootHandler) renderBootScript(
 //	... beskar7.ca={base64CA} [beskar7.disk={disk}]
 //	initrd ...
 //
-// When targetDisk is empty the line is byte-identical to the pre-D-011 §11
-// format (no trailing space, no empty param).
+// BOOTIF is appended after the beskar7.disk slot (or after beskar7.ca when
+// targetDisk is empty) when bootif is non-empty. BOOTIF is the pxelinux
+// convention read by the inspector from /proc/cmdline to identify the
+// provisioning NIC on multi-NIC hosts; it is NOT a beskar7.* key. When bootif
+// is empty the kernel line is byte-identical to the pre-D-013 format (no
+// trailing space, no empty param).
 //
 // Optional parameters (beskar7.timeout, beskar7.debug) are omitted in
 // contract v2 — no operator UI to supply them yet.
@@ -465,13 +515,18 @@ func buildBootIPXEScript(
 	targetDigest string,
 	caB64 string,
 	targetDisk string,
+	bootif string,
 ) string {
 	diskParam := ""
 	if targetDisk != "" {
 		diskParam = " beskar7.disk=" + targetDisk
 	}
+	bootifParam := ""
+	if bootif != "" {
+		bootifParam = " BOOTIF=" + bootif
+	}
 	return fmt.Sprintf(
-		"#!ipxe\nkernel %s/vmlinuz beskar7.api=%s beskar7.namespace=%s beskar7.host=%s beskar7.token=%s beskar7.target=%s beskar7.target-digest=%s beskar7.ca=%s%s\ninitrd %s/initrd.img\nboot\n",
+		"#!ipxe\nkernel %s/vmlinuz beskar7.api=%s beskar7.namespace=%s beskar7.host=%s beskar7.token=%s beskar7.target=%s beskar7.target-digest=%s beskar7.ca=%s%s%s\ninitrd %s/initrd.img\nboot\n",
 		inspectionImageURL,
 		apiBase,
 		namespace,
@@ -481,6 +536,7 @@ func buildBootIPXEScript(
 		targetDigest,
 		caB64,
 		diskParam,
+		bootifParam,
 		inspectionImageURL,
 	)
 }

--- a/controllers/boot_handler_test.go
+++ b/controllers/boot_handler_test.go
@@ -1073,6 +1073,7 @@ var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
 			bootTestDigest,
 			testCA,
 			disk,
+			"", // no BOOTIF
 		)
 
 		By("asserting beskar7.disk appears in the kernel line")
@@ -1105,7 +1106,8 @@ var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
 			testTargetURL,
 			bootTestDigest,
 			testCA,
-			"",
+			"", // no disk
+			"", // no BOOTIF
 		)
 
 		By("asserting beskar7.disk is absent")
@@ -1118,6 +1120,118 @@ var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
 		caEnd := caIdx + len("beskar7.ca=") + len(testCA)
 		Expect(script[caEnd]).To(Equal(byte('\n')),
 			"no trailing space after beskar7.ca when TargetDisk is empty — byte-identical to pre-change format")
+	})
+
+	// ── BOOTIF rendering (D-013) ────────────────────────────────────────────
+
+	It("renders BOOTIF after beskar7.disk when both disk and bootif are set", func() {
+		disk := "/dev/sda"
+		bootif := "01-52-54-00-12-34-56"
+		script := buildBootIPXEScript(
+			testInspectionURL,
+			testAPIBase,
+			testNamespace,
+			testHost,
+			testToken,
+			testTargetURL,
+			bootTestDigest,
+			testCA,
+			disk,
+			bootif,
+		)
+
+		By("asserting BOOTIF appears in the kernel line")
+		Expect(script).To(ContainSubstring("BOOTIF=" + bootif))
+
+		By("asserting BOOTIF is positioned after beskar7.disk")
+		diskIdx := strings.Index(script, "beskar7.disk=")
+		bootifIdx := strings.Index(script, "BOOTIF=")
+		Expect(bootifIdx).To(BeNumerically(">", diskIdx),
+			"BOOTIF must appear after beskar7.disk")
+
+		By("asserting BOOTIF appears before the initrd line")
+		initrdIdx := strings.Index(script, "\ninitrd ")
+		Expect(bootifIdx).To(BeNumerically("<", initrdIdx),
+			"BOOTIF must precede the initrd line")
+
+		By("asserting BOOTIF is immediately after beskar7.disk with a single space")
+		diskEnd := diskIdx + len("beskar7.disk=") + len(disk)
+		Expect(script[diskEnd:diskEnd+len(" BOOTIF=")]).To(Equal(" BOOTIF="),
+			"BOOTIF must be the immediate successor of beskar7.disk with a single space")
+	})
+
+	It("renders BOOTIF after beskar7.ca (no disk) when only bootif is set", func() {
+		bootif := "01-52-54-00-12-34-56"
+		script := buildBootIPXEScript(
+			testInspectionURL,
+			testAPIBase,
+			testNamespace,
+			testHost,
+			testToken,
+			testTargetURL,
+			bootTestDigest,
+			testCA,
+			"", // no disk
+			bootif,
+		)
+
+		By("asserting BOOTIF appears in the kernel line")
+		Expect(script).To(ContainSubstring("BOOTIF=" + bootif))
+
+		By("asserting beskar7.disk is absent")
+		Expect(script).NotTo(ContainSubstring("beskar7.disk"))
+
+		By("asserting BOOTIF is immediately after beskar7.ca with a single space")
+		caIdx := strings.Index(script, "beskar7.ca=")
+		caEnd := caIdx + len("beskar7.ca=") + len(testCA)
+		Expect(script[caEnd:caEnd+len(" BOOTIF=")]).To(Equal(" BOOTIF="),
+			"BOOTIF must be the immediate successor of beskar7.ca with a single space when disk is absent")
+
+		By("asserting BOOTIF appears before the initrd line")
+		bootifIdx := strings.Index(script, "BOOTIF=")
+		initrdIdx := strings.Index(script, "\ninitrd ")
+		Expect(bootifIdx).To(BeNumerically("<", initrdIdx),
+			"BOOTIF must precede the initrd line")
+	})
+
+	It("omits BOOTIF entirely when bootif is empty, output byte-identical to pre-D-013 format", func() {
+		script := buildBootIPXEScript(
+			testInspectionURL,
+			testAPIBase,
+			testNamespace,
+			testHost,
+			testToken,
+			testTargetURL,
+			bootTestDigest,
+			testCA,
+			"", // no disk
+			"", // no BOOTIF
+		)
+		scriptWithBootif := buildBootIPXEScript(
+			testInspectionURL,
+			testAPIBase,
+			testNamespace,
+			testHost,
+			testToken,
+			testTargetURL,
+			bootTestDigest,
+			testCA,
+			"",
+			"01-52-54-00-12-34-56",
+		)
+
+		By("asserting BOOTIF is absent when bootif is empty")
+		Expect(script).NotTo(ContainSubstring("BOOTIF"),
+			"empty bootif must produce no BOOTIF token in the script")
+
+		By("asserting the kernel line ends with beskar7.ca=<value> immediately followed by newline")
+		caIdx := strings.Index(script, "beskar7.ca=")
+		caEnd := caIdx + len("beskar7.ca=") + len(testCA)
+		Expect(script[caEnd]).To(Equal(byte('\n')),
+			"no trailing space after beskar7.ca when bootif is empty — byte-identical to pre-D-013 format")
+
+		By("the BOOTIF variant is different from the no-BOOTIF variant")
+		Expect(script).NotTo(Equal(scriptWithBootif))
 	})
 })
 
@@ -1153,6 +1267,103 @@ var _ = Describe("validateBootDisk", func() {
 			} else {
 				Expect(err).NotTo(HaveOccurred(),
 					"expected validateBootDisk to accept %q but it rejected: %v", tc.input, err)
+			}
+		})
+	}
+})
+
+// ── formatBootif unit tests (D-013 / SEC-7 posture) ───────────────────────────
+
+var _ = Describe("formatBootif", func() {
+	type bootifCase struct {
+		name       string
+		input      string
+		wantResult string
+		wantOK     bool
+	}
+	cases := []bootifCase{
+		// ── accept ──
+		{
+			name:       "well-formed lowercase MAC",
+			input:      "52:54:00:12:34:56",
+			wantResult: "01-52-54-00-12-34-56",
+			wantOK:     true,
+		},
+		{
+			name:       "well-formed uppercase MAC (lowercased in output)",
+			input:      "52:54:00:AA:BB:CC",
+			wantResult: "01-52-54-00-aa-bb-cc",
+			wantOK:     true,
+		},
+		{
+			name:       "all-zeros broadcast MAC",
+			input:      "00:00:00:00:00:00",
+			wantResult: "01-00-00-00-00-00-00",
+			wantOK:     true,
+		},
+		{
+			name:       "all-ff broadcast MAC",
+			input:      "ff:ff:ff:ff:ff:ff",
+			wantResult: "01-ff-ff-ff-ff-ff-ff",
+			wantOK:     true,
+		},
+		// ── reject ──
+		{
+			name:   "empty string",
+			input:  "",
+			wantOK: false,
+		},
+		{
+			name:   "too short (5 octets)",
+			input:  "52:54:00:12:34",
+			wantOK: false,
+		},
+		{
+			name:   "too long (7 octets)",
+			input:  "52:54:00:12:34:56:78",
+			wantOK: false,
+		},
+		{
+			name:   "non-hex characters (injection attempt)",
+			input:  "zz:54:00:12:34:56",
+			wantOK: false,
+		},
+		{
+			name:   "spaces instead of colons",
+			input:  "52 54 00 12 34 56",
+			wantOK: false,
+		},
+		{
+			name:   "dashes instead of colons (BOOTIF output form, not input form)",
+			input:  "52-54-00-12-34-56",
+			wantOK: false,
+		},
+		{
+			name:   "injection: key=value appended after valid prefix",
+			input:  "52:54:00:12:34:56 beskar7.api=ATTACKER",
+			wantOK: false,
+		},
+		{
+			name:   "injection: newline in value",
+			input:  "52:54:00:12:34:56\nbeskar7.token=ATTACKER",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		It("formatBootif: "+tc.name, func() {
+			result, ok := formatBootif(tc.input)
+			if tc.wantOK {
+				Expect(ok).To(BeTrue(),
+					"expected formatBootif(%q) to succeed but it returned false", tc.input)
+				Expect(result).To(Equal(tc.wantResult),
+					"formatBootif(%q) returned %q, want %q", tc.input, result, tc.wantResult)
+			} else {
+				Expect(ok).To(BeFalse(),
+					"expected formatBootif(%q) to return (false) but it returned (%q, true)", tc.input, result)
+				Expect(result).To(Equal(""),
+					"on failure formatBootif must return empty string")
 			}
 		})
 	}

--- a/docs/inspector-contract.md
+++ b/docs/inspector-contract.md
@@ -132,10 +132,18 @@ boots the inspector image with the §5 parameters on the kernel cmdline:
 
 ```ipxe
 #!ipxe
-kernel {InspectionImageURL}/vmlinuz beskar7.api={api} beskar7.namespace={ns} beskar7.host={host} beskar7.token={token} beskar7.target={target} beskar7.target-digest={digest} beskar7.ca={base64CA} [beskar7.disk={disk}] [beskar7.timeout={t}] [beskar7.debug=true]
+kernel {InspectionImageURL}/vmlinuz beskar7.api={api} beskar7.namespace={ns} beskar7.host={host} beskar7.token={token} beskar7.target={target} beskar7.target-digest={digest} beskar7.ca={base64CA} [beskar7.disk={disk}] [BOOTIF={01-mac}] [beskar7.timeout={t}] [beskar7.debug=true]
 initrd {InspectionImageURL}/initrd.img
 boot
 ```
+
+The operator's first-stage iPXE (the one that fetches this `/boot` URL after
+DHCP+TFTP) SHOULD append the booting NIC's MAC as a `?mac=${net0/mac}` query
+parameter. `/boot` validates it (a well-formed colon-MAC; a malformed value is
+omitted, never rendered — no cmdline injection) and renders it as
+`BOOTIF=01-<mac-with-dashes>` so the inspector configures the correct interface
+on a multi-NIC host (§8.2). Omitted when no valid `mac` is supplied — the
+inspector then configures the single physical NIC.
 
 - `{InspectionImageURL}` is `Beskar7Machine.Spec.InspectionImageURL` (the
   consuming machine, resolved via the host's `ConsumerRef`) — the HTTPS base URL
@@ -205,6 +213,8 @@ these from `/proc/cmdline`.
 | `beskar7.disk` | no | Operator override pinning the target disk — a stable device path (`/dev/disk/by-id/...`, `/dev/disk/by-path/...`) or a kernel name (`/dev/nvme0n1`, `sda`). When **absent**, the inspector auto-selects the smallest eligible disk (§9.1 step 2). When **present**, the inspector MUST resolve it once to its canonical whole-disk kernel device (`/dev/<kname>`, following any `by-id`/`by-path` symlink) and thereafter use *that resolved node* for both validation and the write, so the device validated is the device written (no TOCTOU re-lookup). It MUST use exactly that device and MUST abort — never silently falling back to auto-selection (a wrong pin fails loudly) — if the device is missing, not a block device, **not a whole disk** (a partition, `dm`/loop, or other non-whole-disk node), removable, read-only, **backs the running ramdisk**, or is smaller than the image. Sourced from the optional `Beskar7Machine.Spec.TargetDisk` field, rendered by `/boot` after `beskar7.ca` when set. Non-secret. |
 | `beskar7.timeout` | no | Inspector-side overall timeout (seconds). |
 | `beskar7.debug` | no | `true` to enable verbose logging / debug shell on failure. |
+| `BOOTIF` | no | The provisioning NIC's MAC in the pxelinux/iPXE form `01-aa-bb-cc-dd-ee-ff` (a `01` hardware-type prefix + the MAC with dashes). **Not** a `beskar7.*` key — it is the established netboot convention. `/boot` renders it from a `?mac=<mac>` query the operator's first-stage iPXE appends (e.g. `${net0/mac}`); see §4.1, §8.2. The inspector DHCP-configures the matching interface. **Absent** → the inspector configures the single physical NIC (multi-NIC hosts therefore need `BOOTIF`). Non-secret. |
+| `beskar7.ip` | reserved | Planned static-network fallback for DHCP-less / VLAN-pinned environments, kernel-`ip=` syntax (`<ip>::<gw>:<mask>[:<dns>]`). Not rendered in v2 — DHCP is the only network mechanism (§8.2); reserved here so the name is not reused. |
 
 The only **secret** on the cmdline is `beskar7.token`. This is acceptable for a
 single-purpose, ephemeral, operator-controlled inspection ramdisk (see §8); the
@@ -374,6 +384,43 @@ security:
   verified-TLS `/bootstrap` GET and is injected locally (§9), never embedded in
   the published image.
 
+### 8.2 Network bring-up (the inspector configures its own networking)
+
+The §4 endpoints assume the inspector can reach `beskar7.api`, but the inspector
+boots with the provisioning NIC **down and unaddressed**. It MUST therefore
+configure networking itself, in Phase 1, **before** the inspection POST:
+
+- **The kernel's `ip=` autoconfiguration MUST NOT be relied upon.** The inspector
+  ships a minimal initramfs and loads NIC drivers as modules *after* boot (a
+  packaging decision: the distro kernel builds them modular), which is past the
+  kernel's ipconfig stage — so kernel-level DHCP cannot bring the link up. The
+  inspector brings the link up and acquires an address itself.
+- **DHCP is the network mechanism.** The inspector runs a one-shot DHCP exchange
+  on the provisioning NIC (the provisioning network is, by construction, the
+  DHCP/PXE environment the host already booted from), then applies the leased
+  address + default route. No `dhclient`/`udhcpc` — it is done natively, in
+  keeping with the single-purpose ramdisk.
+- **NIC selection** is by `BOOTIF` (§5): the MAC of the interface that PXE-booted,
+  which `/boot` renders from the operator iPXE's `?mac=` query (§4.1). When
+  `BOOTIF` is absent the inspector configures the single physical NIC; a host with
+  **multiple** NICs therefore requires `BOOTIF` to disambiguate which network to
+  join.
+- **DNS / `beskar7.api` form.** v2 ships **no resolver** in the initramfs, so
+  `beskar7.api` SHOULD be an **IP-literal** (the controller renders it from the
+  externally-reachable callback address per §8 anyway). If an operator must use a
+  hostname, their DHCP must supply a usable DNS server and the inspector must
+  write `/etc/resolv.conf` from it — that resolver path is a §11 follow-up, not in
+  v2. A hostname `beskar7.api` with no resolver fails loudly at the report POST.
+- **Trust.** DHCP is unauthenticated and the provisioning L2 is **semi-trusted**:
+  a rogue DHCP server can deny or misdirect provisioning (a DoS), but it CANNOT
+  break join-secret confidentiality — that is gated by the verified-TLS
+  `/bootstrap` GET against the cmdline-delivered CA (§8), not by the network. This
+  is the same residual the boot-nonce L2 exposure already accepts (§11).
+
+Deferred (§11): multi-NIC "DHCP every link and race" when no `BOOTIF`; a
+`beskar7.ip=` static fallback; VLAN-tagged provisioning networks; the
+DHCP-option-6 → `/etc/resolv.conf` resolver.
+
 ---
 
 ## 9. Inspector required behavior (client contract)
@@ -409,7 +456,11 @@ and never rebooting — this is the CI / report-only mode.
 
 The inspector MUST:
 
-1. Parse the §5 cmdline params from `/proc/cmdline`.
+1. Parse the §5 cmdline params from `/proc/cmdline`, then **bring up the
+   provisioning network** (§8.2): load the NIC driver, select the interface by
+   `BOOTIF` (or the single physical NIC), DHCP for an address, and apply the
+   leased address + default route — so the callback is reachable for step 3.
+   (`--dry-run` skips network bring-up; the CI host is already networked.)
 2. Probe hardware natively (SMBIOS/DMI via `/sys/firmware/dmi/tables`, plus `/sys`
    and `/proc`) and build the §6 report satisfying §6.1. **Select the target disk**:
    if `beskar7.disk` is set, resolve it once to its canonical whole-disk kernel node
@@ -559,6 +610,15 @@ apart. The inspector therefore MUST treat the GET as a **poll**, not a one-shot:
   The inspector honors `beskar7.disk`, and the controller now renders it from the
   optional `Beskar7Machine.Spec.TargetDisk` field (`/boot`, after `beskar7.ca`,
   only when set). It is **not** required for default (auto-select) provisioning.
+- **Network bring-up breadth** (additive, §8.2): v2 does single-NIC DHCP with
+  `BOOTIF` selection and an IP-literal `beskar7.api`. Deferred: multi-NIC "DHCP
+  every link and race" when `BOOTIF` is absent; a `beskar7.ip=` static-network
+  fallback (the §5-reserved param, plus an optional `Beskar7Machine` spec field
+  to render it — YAGNI until a real static-network requirement lands);
+  VLAN-tagged provisioning networks; and the DHCP-option-6 → `/etc/resolv.conf`
+  writer that would let `beskar7.api` be a hostname. Each is additive — the
+  inspector's single network-bring-up entry point absorbs them without changing
+  the Phase-1 flow.
 - **kexec for boot-time speed** (future optimization): v2 reboots via host
   firmware (one POST cycle). A later version MAY `kexec` directly into the freshly
   written OS to skip the firmware POST, but kexec needs real firmware and a


### PR DESCRIPTION
## What

The controller half of D-013 (native Phase-1 networking, the inspector half merged in #20), plus the contract documentation for the networking model.

### `controllers/boot_handler.go`
- `/boot` now reads an optional `?mac=` query parameter — the operator's first-stage iPXE appends `${net0/mac}` so the inspector can disambiguate the provisioning NIC on multi-NIC hosts. It is rendered as `BOOTIF=01-<mac-with-dashes>` on the inspector kernel cmdline (pxelinux convention). Single-NIC hosts work without it (the inspector falls back to the only link).
- `formatBootif` validates the MAC against a strict anchored regexp `^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$` and is **omit-on-invalid**: a malformed value (or an injection attempt) renders **no** BOOTIF token. Unlike the CRD-backed `beskar7.*` params, this query value has no admission-webhook backstop, so the regexp is the **sole** injection guard — it admits no whitespace/separator, and Go's `$` does not match before a trailing newline. `buildBootIPXEScript` appends the token after the `beskar7.disk` slot; output is byte-identical to before when the param is absent.

### `docs/inspector-contract.md`
- New **§8.2 Network bring-up**: the inspector configures its own networking in Phase 1 (kernel `ip=` can't help — modular NIC drivers load post-boot per D-012); DHCP on the BOOTIF-selected (or sole) NIC; `beskar7.api` SHOULD be an IP-literal (no resolver in v2); documents the semi-trusted-L2 residual (the join secret is gated by verified TLS, not by the network).
- §5: `BOOTIF` row + reserved `beskar7.ip` (static fallback, not rendered in v2).
- §4.1: the `?mac=${net0/mac}` → `BOOTIF` render note on the iPXE template.
- §9.1 step 1: bring up the network before the inspection POST (skipped under `--dry-run`).
- §11: network bring-up breadth follow-ups.

## Validation
- `make test` (66.3% pkg coverage), `golangci-lint` (0 issues), `gofmt -s`, `make manifests` (no drift) — all clean.
- **Security-reviewed** (security-engineer): safe to ship, no findings. `formatBootif` is airtight as the sole guard — Go's `$` newline behaviour verified empirically, percent-decode-before-validate confirmed, the token cannot be displaced into another cmdline slot.
- Mirrors the #118 SEC-7 render-validation pattern with a stricter (separator-free) regexp.
- The single-NIC DHCP→verified-TLS→202→full-Phase-2 path was validated end-to-end on QEMU before this change; BOOTIF exercises the multi-NIC selection path the single-NIC smoke didn't need.

## Follow-up (not in this PR)
`docs/ipxe-setup.md` (the operator guide) is broadly stale vs contract v2 — it still references a nonexistent `beskar7.mac` and predates the `?mac=`/BOOTIF chainload. The contract is the source of truth and now documents the correct convention; reconciling the operator guide is a separate tech-writer task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)