### PR TITLE
docs(contract): document D-013 networking-breadth Phase 1 (race + resolv.conf)

### DIFF
--- a/docs/inspector-contract.md
+++ b/docs/inspector-contract.md
@@ -143,7 +143,8 @@ parameter. `/boot` validates it (a well-formed colon-MAC; a malformed value is
 omitted, never rendered — no cmdline injection) and renders it as
 `BOOTIF=01-<mac-with-dashes>` so the inspector configures the correct interface
 on a multi-NIC host (§8.2). Omitted when no valid `mac` is supplied — the
-inspector then configures the single physical NIC.
+inspector then uses its single NIC, or DHCP-races all links and applies the
+gatewayed winner on a multi-NIC host (§8.2).
 
 - `{InspectionImageURL}` is `Beskar7Machine.Spec.InspectionImageURL` (the
   consuming machine, resolved via the host's `ConsumerRef`) — the HTTPS base URL
@@ -213,7 +214,7 @@ these from `/proc/cmdline`.
 | `beskar7.disk` | no | Operator override pinning the target disk — a stable device path (`/dev/disk/by-id/...`, `/dev/disk/by-path/...`) or a kernel name (`/dev/nvme0n1`, `sda`). When **absent**, the inspector auto-selects the smallest eligible disk (§9.1 step 2). When **present**, the inspector MUST resolve it once to its canonical whole-disk kernel device (`/dev/<kname>`, following any `by-id`/`by-path` symlink) and thereafter use *that resolved node* for both validation and the write, so the device validated is the device written (no TOCTOU re-lookup). It MUST use exactly that device and MUST abort — never silently falling back to auto-selection (a wrong pin fails loudly) — if the device is missing, not a block device, **not a whole disk** (a partition, `dm`/loop, or other non-whole-disk node), removable, read-only, **backs the running ramdisk**, or is smaller than the image. Sourced from the optional `Beskar7Machine.Spec.TargetDisk` field, rendered by `/boot` after `beskar7.ca` when set. Non-secret. |
 | `beskar7.timeout` | no | Inspector-side overall timeout (seconds). |
 | `beskar7.debug` | no | `true` to enable verbose logging / debug shell on failure. |
-| `BOOTIF` | no | The provisioning NIC's MAC in the pxelinux/iPXE form `01-aa-bb-cc-dd-ee-ff` (a `01` hardware-type prefix + the MAC with dashes). **Not** a `beskar7.*` key — it is the established netboot convention. `/boot` renders it from a `?mac=<mac>` query the operator's first-stage iPXE appends (e.g. `${net0/mac}`); see §4.1, §8.2. The inspector DHCP-configures the matching interface. **Absent** → the inspector configures the single physical NIC (multi-NIC hosts therefore need `BOOTIF`). Non-secret. |
+| `BOOTIF` | no | The provisioning NIC's MAC in the pxelinux/iPXE form `01-aa-bb-cc-dd-ee-ff` (a `01` hardware-type prefix + the MAC with dashes). **Not** a `beskar7.*` key — it is the established netboot convention. `/boot` renders it from a `?mac=<mac>` query the operator's first-stage iPXE appends (e.g. `${net0/mac}`); see §4.1, §8.2. The inspector DHCP-configures the matching interface. **Absent** → a single-NIC host uses its one NIC; a multi-NIC host DHCP-races all links and applies the gatewayed winner (§8.2). `BOOTIF` is the deterministic pin and is the way to select a specific network. Non-secret. |
 | `beskar7.ip` | reserved | Planned static-network fallback for DHCP-less / VLAN-pinned environments, kernel-`ip=` syntax (`<ip>::<gw>:<mask>[:<dns>]`). Not rendered in v2 — DHCP is the only network mechanism (§8.2); reserved here so the name is not reused. |
 
 The only **secret** on the cmdline is `beskar7.token`. This is acceptable for a
@@ -401,25 +402,33 @@ configure networking itself, in Phase 1, **before** the inspection POST:
   address + default route. No `dhclient`/`udhcpc` — it is done natively, in
   keeping with the single-purpose ramdisk.
 - **NIC selection** is by `BOOTIF` (§5): the MAC of the interface that PXE-booted,
-  which `/boot` renders from the operator iPXE's `?mac=` query (§4.1). When
-  `BOOTIF` is absent the inspector configures the single physical NIC; a host with
-  **multiple** NICs therefore requires `BOOTIF` to disambiguate which network to
-  join.
-- **DNS / `beskar7.api` form.** v2 ships **no resolver** in the initramfs, so
-  `beskar7.api` SHOULD be an **IP-literal** (the controller renders it from the
-  externally-reachable callback address per §8 anyway). If an operator must use a
-  hostname, their DHCP must supply a usable DNS server and the inspector must
-  write `/etc/resolv.conf` from it — that resolver path is a §11 follow-up, not in
-  v2. A hostname `beskar7.api` with no resolver fails loudly at the report POST.
+  which `/boot` renders from the operator iPXE's `?mac=` query (§4.1) — the
+  deterministic pin and the recommended path. When `BOOTIF` is **absent**: a
+  single-NIC host uses its one NIC; a **multi-NIC** host brings every link up,
+  runs DHCP on all of them concurrently, and applies the winner — preferring a
+  lease that carries a default gateway (that network routes toward `beskar7.api`),
+  then the lowest-sorted interface name. Only the winner is left addressed; the
+  losing links are brought back down. So a multi-NIC host can provision without
+  `BOOTIF`, but `BOOTIF` removes the ambiguity (and is the way to pin a specific
+  network when several offer gatewayed leases).
+- **DNS / `beskar7.api` form.** The inspector writes the DHCP option-6 servers to
+  `/etc/resolv.conf`, so a hostname `beskar7.api` resolves. Operators SHOULD
+  nonetheless use an **IP-literal** `beskar7.api` (the controller renders one from
+  the externally-reachable callback address per §8): a hostname additionally
+  relies on the semi-trusted DHCP-supplied resolver. Confidentiality is unaffected
+  either way — the downstream POST/GET still verify against the cmdline-delivered
+  CA (§8.1), so a misdirected hostname **fails the TLS check** rather than leaking
+  the join secret. When DHCP offers no option-6 servers, no `/etc/resolv.conf` is
+  written and a hostname `beskar7.api` fails at the report POST — use an
+  IP-literal.
 - **Trust.** DHCP is unauthenticated and the provisioning L2 is **semi-trusted**:
   a rogue DHCP server can deny or misdirect provisioning (a DoS), but it CANNOT
   break join-secret confidentiality — that is gated by the verified-TLS
   `/bootstrap` GET against the cmdline-delivered CA (§8), not by the network. This
   is the same residual the boot-nonce L2 exposure already accepts (§11).
 
-Deferred (§11): multi-NIC "DHCP every link and race" when no `BOOTIF`; a
-`beskar7.ip=` static fallback; VLAN-tagged provisioning networks; the
-DHCP-option-6 → `/etc/resolv.conf` resolver.
+Deferred (§11): a `beskar7.ip=` static fallback for DHCP-less / VLAN-pinned
+networks; VLAN-tagged provisioning networks.
 
 ---
 
@@ -458,9 +467,10 @@ The inspector MUST:
 
 1. Parse the §5 cmdline params from `/proc/cmdline`, then **bring up the
    provisioning network** (§8.2): load the NIC driver, select the interface by
-   `BOOTIF` (or the single physical NIC), DHCP for an address, and apply the
-   leased address + default route — so the callback is reachable for step 3.
-   (`--dry-run` skips network bring-up; the CI host is already networked.)
+   `BOOTIF` (or the single NIC, or by DHCP-racing all links on a multi-NIC host),
+   DHCP for an address, apply the leased address + default route, and write any
+   DHCP-supplied DNS to `/etc/resolv.conf` — so the callback is reachable for step
+   3. (`--dry-run` skips network bring-up; the CI host is already networked.)
 2. Probe hardware natively (SMBIOS/DMI via `/sys/firmware/dmi/tables`, plus `/sys`
    and `/proc`) and build the §6 report satisfying §6.1. **Select the target disk**:
    if `beskar7.disk` is set, resolve it once to its canonical whole-disk kernel node
@@ -610,15 +620,15 @@ apart. The inspector therefore MUST treat the GET as a **poll**, not a one-shot:
   The inspector honors `beskar7.disk`, and the controller now renders it from the
   optional `Beskar7Machine.Spec.TargetDisk` field (`/boot`, after `beskar7.ca`,
   only when set). It is **not** required for default (auto-select) provisioning.
-- **Network bring-up breadth** (additive, §8.2): v2 does single-NIC DHCP with
-  `BOOTIF` selection and an IP-literal `beskar7.api`. Deferred: multi-NIC "DHCP
-  every link and race" when `BOOTIF` is absent; a `beskar7.ip=` static-network
-  fallback (the §5-reserved param, plus an optional `Beskar7Machine` spec field
-  to render it — YAGNI until a real static-network requirement lands);
-  VLAN-tagged provisioning networks; and the DHCP-option-6 → `/etc/resolv.conf`
-  writer that would let `beskar7.api` be a hostname. Each is additive — the
-  inspector's single network-bring-up entry point absorbs them without changing
-  the Phase-1 flow.
+- **Network bring-up breadth** (additive, §8.2): implemented so far — DHCP with
+  `BOOTIF` selection, the no-`BOOTIF` multi-NIC "DHCP every link and race"
+  (gatewayed-lease preference), and the DHCP-option-6 → `/etc/resolv.conf` writer
+  that lets `beskar7.api` be a hostname (IP-literal still recommended). Still
+  deferred: a `beskar7.ip=` static-network fallback (the §5-reserved param, plus
+  an optional `Beskar7Machine` spec field to render it — YAGNI until a real
+  static-network requirement lands) and VLAN-tagged provisioning networks. Each is
+  additive — the inspector's single network-bring-up entry point absorbs them
+  without changing the Phase-1 flow.
 - **kexec for boot-time speed** (future optimization): v2 reboots via host
   firmware (one POST cycle). A later version MAY `kexec` directly into the freshly
   written OS to skip the firmware POST, but kexec needs real firmware and a


### PR DESCRIPTION
## What

Brings `docs/inspector-contract.md` in line with the D-013 networking-breadth Phase-1 work that just shipped in the inspector:
- **Multi-NIC DHCP race** (inspector PR #22): a multi-NIC host with no `BOOTIF` now races DHCP across all links and applies the gatewayed winner.
- **DHCP option-6 → `/etc/resolv.conf`** (inspector PR #23): a hostname `beskar7.api` now resolves.

Clarifications only — **no contract version bump**.

## §8.2 (network bring-up)
- **NIC selection**: `BOOTIF` stays the deterministic pin; document the no-`BOOTIF` multi-NIC race (bring all links up, DHCP concurrently, prefer the gatewayed lease then lowest-sorted interface, leave only the winner addressed).
- **DNS**: the inspector writes `/etc/resolv.conf` from option 6 so a hostname resolves. **IP-literal `beskar7.api` stays the recommended form** — a hostname additionally trusts the semi-trusted DHCP-supplied resolver. The security stance the architect ruled on: confidentiality is unaffected either way, because the downstream POST/GET still verify against the cmdline-delivered CA (§8.1), so a rogue-DHCP-misdirected hostname **fails the TLS check rather than leaking the join secret**.
- Pruned the trailing "Deferred" line to just `beskar7.ip` + VLAN.

## Consistency edits
§4.1 (`?mac` render note), §5 `BOOTIF` row, §9.1 step 1, and the §11 "Network bring-up breadth" entry — the race + resolv.conf move from *deferred* to *implemented*; `beskar7.ip=` static fallback and VLAN remain deferred.

## Validation
Docs-only; no code, CRD, or kubebuilder-marker changes. Both behaviors documented here were validated end-to-end on dome libvirt (the multi-NIC race picked the gatewayed NIC over a sorts-first gatewayless decoy; the resolv.conf path let a hostname `beskar7.api` resolve and complete the verified-TLS POST → 202).

🤖 Generated with [Claude Code](https://claude.com/claude-code)