### PR TITLE
feat: Beskar7Machine.Spec.StaticIP + /boot beskar7.ip render (D-013 Phase 2, contract v3)

### DIFF
--- a/api/v1beta1/beskar7machine_types.go
+++ b/api/v1beta1/beskar7machine_types.go
@@ -103,6 +103,36 @@ type Beskar7MachineSpec struct {
 	// +optional
 	TargetDisk string `json:"targetDisk,omitempty"`
 
+	// StaticIP pins a static IPv4 address on the provisioning NIC instead of
+	// DHCP. For use on DHCP-less or VLAN-pinned provisioning networks where no
+	// DHCP server is present (contract v3 §5 beskar7.ip, §8.2).
+	//
+	// Format: the kernel ip= subset "<ip>::<gw>:<mask>[:<dns>]" where:
+	//   - <ip>   dotted IPv4 (required)
+	//   - ::     always-empty server-IP field (two colons; required separator)
+	//   - <gw>   dotted IPv4 default gateway (optional; omit for a gateway-less net)
+	//   - <mask> dotted IPv4 netmask (255.255.255.0) or bare CIDR prefix (0–32)
+	//   - <dns>  dotted IPv4 resolver (optional)
+	//
+	// Examples:
+	//   "192.168.150.10::192.168.150.1:255.255.255.0"
+	//   "10.0.0.5:::24:8.8.8.8"
+	//
+	// When set, /boot renders this value as beskar7.ip=<value> on the inspector
+	// kernel cmdline; the inspector then configures the selected NIC statically
+	// and skips DHCP entirely. When empty, DHCP is used (the default).
+	//
+	// The inspector selects the NIC to configure by BOOTIF (if present on the
+	// cmdline), then falls back to its single NIC or the DHCP-race winner on
+	// multi-NIC hosts (§8.2). A multi-NIC host using beskar7.ip without BOOTIF
+	// is rejected by the inspector.
+	//
+	// Non-secret. The controller validates this field server-side at render time
+	// regardless of CRD admission (C-1a injection guard, SEC-7).
+	// +kubebuilder:validation:Pattern=`^([0-9]{1,3}\.){3}[0-9]{1,3}::(([0-9]{1,3}\.){3}[0-9]{1,3})?:(([0-9]{1,3}\.){3}[0-9]{1,3}|[0-9]{1,2})(:([0-9]{1,3}\.){3}[0-9]{1,3})?$`
+	// +optional
+	StaticIP *string `json:"staticIP,omitempty"`
+
 	// ConfigurationURL is an optional URL for OS-specific configuration.
 	// The inspection image will pass this to the target OS during kexec.
 	// +kubebuilder:validation:Pattern="^https?://.*"
@@ -224,6 +254,11 @@ func (in *Beskar7MachineSpec) DeepCopyInto(out *Beskar7MachineSpec) {
 	*out = *in
 	if in.ProviderID != nil {
 		in, out := &in.ProviderID, &out.ProviderID
+		*out = new(string)
+		**out = **in
+	}
+	if in.StaticIP != nil {
+		in, out := &in.StaticIP, &out.StaticIP
 		*out = new(string)
 		**out = **in
 	}

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -68,6 +68,9 @@ spec:
                 type: string
               providerID:
                 type: string
+              staticIP:
+                pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}::(([0-9]{1,3}\.){3}[0-9]{1,3})?:(([0-9]{1,3}\.){3}[0-9]{1,3}|[0-9]{1,2})(:([0-9]{1,3}\.){3}[0-9]{1,3})?$
+                type: string
               targetDisk:
                 pattern: ^[A-Za-z0-9._:/+-]+$
                 type: string

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -57,6 +57,9 @@ spec:
                         type: string
                       providerID:
                         type: string
+                      staticIP:
+                        pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}::(([0-9]{1,3}\.){3}[0-9]{1,3})?:(([0-9]{1,3}\.){3}[0-9]{1,3}|[0-9]{1,2})(:([0-9]{1,3}\.){3}[0-9]{1,3})?$
+                        type: string
                       targetDisk:
                         pattern: ^[A-Za-z0-9._:/+-]+$
                         type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machines.yaml
@@ -68,6 +68,9 @@ spec:
                 type: string
               providerID:
                 type: string
+              staticIP:
+                pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}::(([0-9]{1,3}\.){3}[0-9]{1,3})?:(([0-9]{1,3}\.){3}[0-9]{1,3}|[0-9]{1,2})(:([0-9]{1,3}\.){3}[0-9]{1,3})?$
+                type: string
               targetDisk:
                 pattern: ^[A-Za-z0-9._:/+-]+$
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_beskar7machinetemplates.yaml
@@ -57,6 +57,9 @@ spec:
                         type: string
                       providerID:
                         type: string
+                      staticIP:
+                        pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}::(([0-9]{1,3}\.){3}[0-9]{1,3})?:(([0-9]{1,3}\.){3}[0-9]{1,3}|[0-9]{1,2})(:([0-9]{1,3}\.){3}[0-9]{1,3})?$
+                        type: string
                       targetDisk:
                         pattern: ^[A-Za-z0-9._:/+-]+$
                         type: string

--- a/controllers/boot_handler.go
+++ b/controllers/boot_handler.go
@@ -326,6 +326,25 @@ var bootDiskPattern = regexp.MustCompile(`^[A-Za-z0-9._:/+-]+$`)
 // iPXE query param. (SEC-7 posture: unrecognised shape → omit, don't inject.)
 var bootifMACPattern = regexp.MustCompile(`^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$`)
 
+// staticIPPattern is compiled once at init time. It admits only the
+// kernel ip= subset shape the inspector accepts:
+//
+//	<ip>::[<gw>]:<mask>[:<dns>]
+//
+// where <ip>, <gw>, <dns> are dotted IPv4 and <mask> is either a dotted IPv4
+// netmask or a bare CIDR prefix-length integer (0–32 as one or two digits).
+// The pattern is anchored (Go regexp `$` does not match before a trailing `\n`,
+// so `^...$` is newline-safe — no whitespace or separator injection is possible
+// for a matching value). This is the C-1a handler-side guard for SEC-7; the
+// matching CRD +kubebuilder:validation:Pattern is C-1b (defence-in-depth at
+// admission time).
+//
+// The pattern accepts only `[0-9.:]` characters and the expected structure,
+// so a matching value is guaranteed whitespace-free and cannot contain cmdline
+// separators. Octet-range validation is left to the inspector (contract §5);
+// the controller's job is injection-safety + basic shape.
+var staticIPPattern = regexp.MustCompile(`^([0-9]{1,3}\.){3}[0-9]{1,3}::(([0-9]{1,3}\.){3}[0-9]{1,3})?:(([0-9]{1,3}\.){3}[0-9]{1,3}|[0-9]{1,2})(:([0-9]{1,3}\.){3}[0-9]{1,3})?$`)
+
 // formatBootif converts an iPXE ${net0/mac} value (colon-separated, e.g.
 // "52:54:00:12:34:56") to the pxelinux BOOTIF form read by the inspector from
 // /proc/cmdline ("01-52-54-00-12-34-56"). The leading "01-" is the ARP hardware
@@ -372,6 +391,32 @@ func validateBootDisk(raw string) error {
 	}
 	if !bootDiskPattern.MatchString(raw) {
 		return fmt.Errorf("TargetDisk contains characters outside the permitted set (^[A-Za-z0-9._:/+-]+$)")
+	}
+	return nil
+}
+
+// validateStaticIP rejects a non-empty static IP value that does not match the
+// contract v3 §5 beskar7.ip kernel-ip= subset shape, or that contains whitespace
+// or control characters (cmdline injection guard, SEC-7, C-1a). An empty string
+// is accepted — the field is optional; when empty no beskar7.ip token is rendered.
+//
+// The anchored staticIPPattern match is the primary guard: it admits only
+// `[0-9.:]` and the <ip>::[<gw>]:<mask>[:<dns>] structure, so a matching value
+// is guaranteed whitespace-free and cannot contain cmdline separators or inject
+// additional parameters. The explicit whitespace/control check is belt-and-
+// suspenders — the regex already excludes them, but the explicit check documents
+// the intent (same pattern as validateBootDisk).
+func validateStaticIP(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	if strings.ContainsFunc(raw, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	}) {
+		return fmt.Errorf("StaticIP contains whitespace or control characters")
+	}
+	if !staticIPPattern.MatchString(raw) {
+		return fmt.Errorf("StaticIP does not match the expected format <ip>::[<gw>]:<mask>[:<dns>] (^([0-9]{1,3}\\.){3}[0-9]{1,3}::(([0-9]{1,3}\\.){3}[0-9]{1,3})?:(([0-9]{1,3}\\.){3}[0-9]{1,3}|[0-9]{1,2})(:([0-9]{1,3}\\.){3}[0-9]{1,3})?$)")
 	}
 	return nil
 }
@@ -432,6 +477,20 @@ func (h *BootHandler) renderBootScript(
 			return "", err
 		}
 	}
+	// Validate StaticIP before rendering (SEC-7 / C-1a) and fail closed on an
+	// invalid value — for parity with the sibling rendered CRD fields (TargetDisk,
+	// TargetImageURL, …) and because StaticIP exists for DHCP-less networks, where
+	// silently omitting it (the formatBootif posture, right for an optional query
+	// hint) would leave the host with no usable network at all. An empty/unset
+	// field is the normal DHCP path and renders no beskar7.ip token. The anchored
+	// validateStaticIP guard still guarantees no cmdline injection either way.
+	var staticIP string
+	if b7m.Spec.StaticIP != nil && *b7m.Spec.StaticIP != "" {
+		if err := validateStaticIP(*b7m.Spec.StaticIP); err != nil {
+			return "", err
+		}
+		staticIP = *b7m.Spec.StaticIP
+	}
 
 	// Read the bearer-token plaintext from the per-host bootstrap-token Secret.
 	// The handler received the {nonce} in the URL; it hands back the bearer token
@@ -465,6 +524,7 @@ func (h *BootHandler) renderBootScript(
 		caB64,
 		b7m.Spec.TargetDisk,
 		bootif,
+		staticIP,
 	)
 
 	// Cap the rendered script length (SEC-10). The Linux kernel cmdline cap is
@@ -486,25 +546,28 @@ func (h *BootHandler) renderBootScript(
 // script. All inputs are caller-resolved; this function performs no I/O.
 // Package-level so tests can call it directly for golden-string assertions.
 //
-// The parameter order on the kernel cmdline follows contract v2 §4.1 exactly:
+// The parameter order on the kernel cmdline follows contract v3 §4.1 exactly:
 // beskar7.api, beskar7.namespace, beskar7.host, beskar7.token, beskar7.target,
-// beskar7.target-digest, beskar7.ca[, beskar7.disk][, BOOTIF=<bootif>].
+// beskar7.target-digest, beskar7.ca[, beskar7.disk][, beskar7.ip=<ip>][, BOOTIF=<bootif>].
 //
 // beskar7.disk is appended immediately after beskar7.ca when targetDisk is
 // non-empty, per contract §4.1 template:
 //
-//	... beskar7.ca={base64CA} [beskar7.disk={disk}]
+//	... beskar7.ca={base64CA} [beskar7.disk={disk}] [beskar7.ip={ip}]
 //	initrd ...
 //
-// BOOTIF is appended after the beskar7.disk slot (or after beskar7.ca when
-// targetDisk is empty) when bootif is non-empty. BOOTIF is the pxelinux
-// convention read by the inspector from /proc/cmdline to identify the
-// provisioning NIC on multi-NIC hosts; it is NOT a beskar7.* key. When bootif
-// is empty the kernel line is byte-identical to the pre-D-013 format (no
-// trailing space, no empty param).
+// beskar7.ip is appended after the beskar7.disk slot (or after beskar7.ca when
+// targetDisk is empty) when staticIP is non-empty. It delivers the static IPv4
+// address to the inspector for DHCP-less / VLAN-pinned provisioning networks
+// (contract v3 §5, §8.2). When staticIP is empty the token is omitted entirely.
+//
+// BOOTIF is appended last (after beskar7.ip when present, after beskar7.disk
+// when staticIP is absent, after beskar7.ca when both are absent). When bootif
+// is empty the kernel line is byte-identical to the pre-D-013 / pre-v3 format
+// (no trailing space, no empty param).
 //
 // Optional parameters (beskar7.timeout, beskar7.debug) are omitted in
-// contract v2 — no operator UI to supply them yet.
+// contract v3 — no operator UI to supply them yet.
 func buildBootIPXEScript(
 	inspectionImageURL string,
 	apiBase string,
@@ -516,17 +579,22 @@ func buildBootIPXEScript(
 	caB64 string,
 	targetDisk string,
 	bootif string,
+	staticIP string,
 ) string {
 	diskParam := ""
 	if targetDisk != "" {
 		diskParam = " beskar7.disk=" + targetDisk
+	}
+	staticIPParam := ""
+	if staticIP != "" {
+		staticIPParam = " beskar7.ip=" + staticIP
 	}
 	bootifParam := ""
 	if bootif != "" {
 		bootifParam = " BOOTIF=" + bootif
 	}
 	return fmt.Sprintf(
-		"#!ipxe\nkernel %s/vmlinuz beskar7.api=%s beskar7.namespace=%s beskar7.host=%s beskar7.token=%s beskar7.target=%s beskar7.target-digest=%s beskar7.ca=%s%s%s\ninitrd %s/initrd.img\nboot\n",
+		"#!ipxe\nkernel %s/vmlinuz beskar7.api=%s beskar7.namespace=%s beskar7.host=%s beskar7.token=%s beskar7.target=%s beskar7.target-digest=%s beskar7.ca=%s%s%s%s\ninitrd %s/initrd.img\nboot\n",
 		inspectionImageURL,
 		apiBase,
 		namespace,
@@ -536,6 +604,7 @@ func buildBootIPXEScript(
 		targetDigest,
 		caB64,
 		diskParam,
+		staticIPParam,
 		bootifParam,
 		inspectionImageURL,
 	)

--- a/controllers/boot_handler_test.go
+++ b/controllers/boot_handler_test.go
@@ -1074,6 +1074,7 @@ var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
 			testCA,
 			disk,
 			"", // no BOOTIF
+			"", // no StaticIP
 		)
 
 		By("asserting beskar7.disk appears in the kernel line")
@@ -1108,6 +1109,7 @@ var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
 			testCA,
 			"", // no disk
 			"", // no BOOTIF
+			"", // no StaticIP
 		)
 
 		By("asserting beskar7.disk is absent")
@@ -1138,6 +1140,7 @@ var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
 			testCA,
 			disk,
 			bootif,
+			"", // no StaticIP
 		)
 
 		By("asserting BOOTIF appears in the kernel line")
@@ -1173,6 +1176,7 @@ var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
 			testCA,
 			"", // no disk
 			bootif,
+			"", // no StaticIP
 		)
 
 		By("asserting BOOTIF appears in the kernel line")
@@ -1206,6 +1210,7 @@ var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
 			testCA,
 			"", // no disk
 			"", // no BOOTIF
+			"", // no StaticIP
 		)
 		scriptWithBootif := buildBootIPXEScript(
 			testInspectionURL,
@@ -1218,6 +1223,7 @@ var _ = Describe("buildBootIPXEScript — TargetDisk rendering", func() {
 			testCA,
 			"",
 			"01-52-54-00-12-34-56",
+			"", // no StaticIP
 		)
 
 		By("asserting BOOTIF is absent when bootif is empty")
@@ -1267,6 +1273,273 @@ var _ = Describe("validateBootDisk", func() {
 			} else {
 				Expect(err).NotTo(HaveOccurred(),
 					"expected validateBootDisk to accept %q but it rejected: %v", tc.input, err)
+			}
+		})
+	}
+})
+
+// ── StaticIP feature tests (contract v3 §5 beskar7.ip, §8.2) ─────────────────
+
+var _ = Describe("buildBootIPXEScript — StaticIP rendering", func() {
+	const (
+		testInspectionURL2 = "https://boot.example.com/inspect"
+		testAPIBase2       = "https://beskar7.example.com:8082"
+		testNamespace2     = "default"
+		testHost2          = "host-01"
+		testToken2         = "tok-abc123"
+		testTargetURL2     = "https://images.example.com/kairos.img"
+		testCA2            = "FAKECABASE64=="
+	)
+
+	It("renders beskar7.ip after beskar7.ca (no disk) when StaticIP is set", func() {
+		staticIP := "192.168.150.10::192.168.150.1:255.255.255.0"
+		script := buildBootIPXEScript(
+			testInspectionURL2,
+			testAPIBase2,
+			testNamespace2,
+			testHost2,
+			testToken2,
+			testTargetURL2,
+			bootTestDigest,
+			testCA2,
+			"", // no disk
+			"", // no BOOTIF
+			staticIP,
+		)
+
+		By("asserting beskar7.ip appears in the kernel line")
+		Expect(script).To(ContainSubstring("beskar7.ip=" + staticIP))
+
+		By("asserting beskar7.ip is positioned immediately after beskar7.ca with a single space")
+		caIdx := strings.Index(script, "beskar7.ca=")
+		caEnd := caIdx + len("beskar7.ca=") + len(testCA2)
+		Expect(script[caEnd:caEnd+len(" beskar7.ip=")]).To(Equal(" beskar7.ip="),
+			"beskar7.ip must be the immediate successor of beskar7.ca with a single space when disk is absent")
+
+		By("asserting beskar7.ip appears before the initrd line")
+		ipIdx := strings.Index(script, "beskar7.ip=")
+		initrdIdx := strings.Index(script, "\ninitrd ")
+		Expect(ipIdx).To(BeNumerically("<", initrdIdx), "beskar7.ip must precede the initrd line")
+	})
+
+	It("renders beskar7.ip after beskar7.disk when both disk and staticIP are set", func() {
+		disk := "/dev/sda"
+		staticIP := "192.168.150.10::192.168.150.1:255.255.255.0"
+		script := buildBootIPXEScript(
+			testInspectionURL2,
+			testAPIBase2,
+			testNamespace2,
+			testHost2,
+			testToken2,
+			testTargetURL2,
+			bootTestDigest,
+			testCA2,
+			disk,
+			"", // no BOOTIF
+			staticIP,
+		)
+
+		By("asserting beskar7.disk and beskar7.ip both appear")
+		Expect(script).To(ContainSubstring("beskar7.disk=" + disk))
+		Expect(script).To(ContainSubstring("beskar7.ip=" + staticIP))
+
+		By("asserting beskar7.ip is immediately after beskar7.disk with a single space")
+		diskIdx := strings.Index(script, "beskar7.disk=")
+		diskEnd := diskIdx + len("beskar7.disk=") + len(disk)
+		Expect(script[diskEnd:diskEnd+len(" beskar7.ip=")]).To(Equal(" beskar7.ip="),
+			"beskar7.ip must be the immediate successor of beskar7.disk with a single space")
+
+		By("asserting ordering: beskar7.ca < beskar7.disk < beskar7.ip < initrd")
+		caIdx := strings.Index(script, "beskar7.ca=")
+		ipIdx := strings.Index(script, "beskar7.ip=")
+		initrdIdx := strings.Index(script, "\ninitrd ")
+		Expect(caIdx).To(BeNumerically("<", diskIdx))
+		Expect(diskIdx).To(BeNumerically("<", ipIdx))
+		Expect(ipIdx).To(BeNumerically("<", initrdIdx))
+	})
+
+	It("renders BOOTIF after beskar7.ip when all three optional params are set", func() {
+		disk := "/dev/sda"
+		staticIP := "192.168.150.10::192.168.150.1:255.255.255.0"
+		bootif := "01-52-54-00-12-34-56"
+		script := buildBootIPXEScript(
+			testInspectionURL2,
+			testAPIBase2,
+			testNamespace2,
+			testHost2,
+			testToken2,
+			testTargetURL2,
+			bootTestDigest,
+			testCA2,
+			disk,
+			bootif,
+			staticIP,
+		)
+
+		By("asserting all three optional params appear")
+		Expect(script).To(ContainSubstring("beskar7.disk=" + disk))
+		Expect(script).To(ContainSubstring("beskar7.ip=" + staticIP))
+		Expect(script).To(ContainSubstring("BOOTIF=" + bootif))
+
+		By("asserting ordering: beskar7.disk < beskar7.ip < BOOTIF")
+		diskIdx := strings.Index(script, "beskar7.disk=")
+		ipIdx := strings.Index(script, "beskar7.ip=")
+		bootifIdx := strings.Index(script, "BOOTIF=")
+		Expect(diskIdx).To(BeNumerically("<", ipIdx), "beskar7.disk must precede beskar7.ip")
+		Expect(ipIdx).To(BeNumerically("<", bootifIdx), "beskar7.ip must precede BOOTIF")
+	})
+
+	It("omits beskar7.ip entirely when StaticIP is empty, output byte-identical to v2 format", func() {
+		scriptV2 := buildBootIPXEScript(
+			testInspectionURL2,
+			testAPIBase2,
+			testNamespace2,
+			testHost2,
+			testToken2,
+			testTargetURL2,
+			bootTestDigest,
+			testCA2,
+			"", // no disk
+			"", // no BOOTIF
+			"", // no StaticIP
+		)
+		scriptWithIP := buildBootIPXEScript(
+			testInspectionURL2,
+			testAPIBase2,
+			testNamespace2,
+			testHost2,
+			testToken2,
+			testTargetURL2,
+			bootTestDigest,
+			testCA2,
+			"", // no disk
+			"", // no BOOTIF
+			"192.168.150.10::192.168.150.1:255.255.255.0",
+		)
+
+		By("asserting beskar7.ip is absent when staticIP is empty")
+		Expect(scriptV2).NotTo(ContainSubstring("beskar7.ip"),
+			"empty StaticIP must produce no beskar7.ip token in the script")
+
+		By("asserting the kernel line ends with beskar7.ca=<value> immediately followed by newline")
+		caIdx := strings.Index(scriptV2, "beskar7.ca=")
+		caEnd := caIdx + len("beskar7.ca=") + len(testCA2)
+		Expect(scriptV2[caEnd]).To(Equal(byte('\n')),
+			"no trailing space after beskar7.ca when StaticIP is empty — byte-identical to pre-v3 format")
+
+		By("the StaticIP variant differs from the empty-StaticIP variant")
+		Expect(scriptV2).NotTo(Equal(scriptWithIP))
+	})
+})
+
+// ── validateStaticIP unit tests (contract v3 §5, SEC-7) ──────────────────────
+
+var _ = Describe("validateStaticIP", func() {
+	type staticIPCase struct {
+		name    string
+		input   string
+		wantErr bool
+	}
+	cases := []staticIPCase{
+		// ── accept ──
+		{
+			name:    "valid ip+gw+netmask",
+			input:   "192.168.150.10::192.168.150.1:255.255.255.0",
+			wantErr: false,
+		},
+		{
+			name:    "valid ip+gw+CIDR-prefix",
+			input:   "10.0.0.5::10.0.0.1:24",
+			wantErr: false,
+		},
+		{
+			name:    "valid ip+no-gw+CIDR-prefix+dns",
+			input:   "10.0.0.5:::24:8.8.8.8",
+			wantErr: false,
+		},
+		{
+			name:    "valid ip+no-gw+netmask",
+			input:   "192.168.1.100:::255.255.255.0",
+			wantErr: false,
+		},
+		{
+			name:    "valid ip+gw+netmask+dns",
+			input:   "192.168.150.10::192.168.150.1:255.255.255.0:8.8.8.8",
+			wantErr: false,
+		},
+		{
+			name:    "valid CIDR prefix 0 (single digit)",
+			input:   "10.0.0.1:::0",
+			wantErr: false,
+		},
+		{
+			name:    "valid CIDR prefix 32 (two digits)",
+			input:   "10.0.0.1:::32",
+			wantErr: false,
+		},
+		{
+			name:    "empty string (optional field)",
+			input:   "",
+			wantErr: false,
+		},
+		// ── reject ──
+		{
+			name:    "plain IPv4 with no colons (non-ip= shape)",
+			input:   "192.168.1.1",
+			wantErr: true,
+		},
+		{
+			name:    "missing double-colon server-IP separator",
+			input:   "192.168.1.1:192.168.1.1:255.255.255.0",
+			wantErr: true,
+		},
+		{
+			name:    "garbage string",
+			input:   "not-an-ip-at-all",
+			wantErr: true,
+		},
+		{
+			name:    "value with space (cmdline injection vector)",
+			input:   "192.168.1.1::192.168.1.254:24 beskar7.token=ATTACKER",
+			wantErr: true,
+		},
+		{
+			name:    "value with newline (cmdline injection vector)",
+			input:   "192.168.1.1::192.168.1.254:24\nbeskar7.token=ATTACKER",
+			wantErr: true,
+		},
+		{
+			name:    "value with tab (cmdline injection vector)",
+			input:   "192.168.1.1::192.168.1.254:24\tbeskar7.api=ATTACKER",
+			wantErr: true,
+		},
+		{
+			name:    "beskar7.x= appended after valid prefix (injection via extra param)",
+			input:   "192.168.1.1::192.168.1.254:24:8.8.8.8 beskar7.x=INJECTED",
+			wantErr: true,
+		},
+		{
+			name:    "hostname instead of IP",
+			input:   "host.example.com:::24",
+			wantErr: true,
+		},
+		{
+			name:    "CIDR prefix three digits (out of shape)",
+			input:   "10.0.0.1:::128",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		It("validateStaticIP: "+tc.name, func() {
+			err := validateStaticIP(tc.input)
+			if tc.wantErr {
+				Expect(err).To(HaveOccurred(),
+					"expected validateStaticIP to reject %q but it accepted it", tc.input)
+			} else {
+				Expect(err).NotTo(HaveOccurred(),
+					"expected validateStaticIP to accept %q but it rejected: %v", tc.input, err)
 			}
 		})
 	}

--- a/docs/inspector-contract.md
+++ b/docs/inspector-contract.md
@@ -1,6 +1,6 @@
 # Beskar7 Controller ↔ Inspector Contract
 
-**Contract version: `v2`**
+**Contract version: `v3`**
 
 This document is the single source of truth for the wire contract between the
 Beskar7 controller (`github.com/projectbeskar/beskar7`) and the inspection
@@ -9,12 +9,11 @@ change to the wire format, auth, endpoints, or cmdline parameters is a contract
 version bump and requires updating this document and the golden fixture
 (see [Versioning and anti-drift](#versioning-and-anti-drift)).
 
-> **v2 in one line:** the inspector no longer `kexec`s into a kernel+initrd. It
-> writes a complete Kairos whole-disk image to the target disk, injects the
-> per-host config (carrying CAPI bootstrap user-data) into the image's
-> `COS_OEM` partition, and reboots the host into the provisioned OS. The
-> inspection report schema (§6) is **unchanged** from v1. See
-> [Version history](#101-version-history) for the full delta.
+> **v3 in one line:** un-reserves the optional `beskar7.ip` kernel cmdline
+> parameter and adds the matching `Beskar7Machine.Spec.StaticIP` CRD field plus
+> its `/boot` render. The inspection report schema (§6) and the v2 whole-disk
+> deploy flow are **unchanged**. See [Version history](#101-version-history) for
+> the full delta.
 
 Requirement keywords (MUST, MUST NOT, SHOULD, MAY) are used per RFC 2119.
 
@@ -132,7 +131,7 @@ boots the inspector image with the §5 parameters on the kernel cmdline:
 
 ```ipxe
 #!ipxe
-kernel {InspectionImageURL}/vmlinuz beskar7.api={api} beskar7.namespace={ns} beskar7.host={host} beskar7.token={token} beskar7.target={target} beskar7.target-digest={digest} beskar7.ca={base64CA} [beskar7.disk={disk}] [BOOTIF={01-mac}] [beskar7.timeout={t}] [beskar7.debug=true]
+kernel {InspectionImageURL}/vmlinuz beskar7.api={api} beskar7.namespace={ns} beskar7.host={host} beskar7.token={token} beskar7.target={target} beskar7.target-digest={digest} beskar7.ca={base64CA} [beskar7.disk={disk}] [beskar7.ip={ip}] [BOOTIF={01-mac}] [beskar7.timeout={t}] [beskar7.debug=true]
 initrd {InspectionImageURL}/initrd.img
 boot
 ```
@@ -160,15 +159,19 @@ gatewayed winner on a multi-NIC host (§8.2).
 - The script boots the inspector image directly; it does NOT chainload another
   iPXE script (the per-host script IS this response).
 
-> **Implementation status (v2):** this section is **implemented** in this repo.
+> **Implementation status (v3):** this section is **implemented** in this repo.
 > `Beskar7Machine.Spec.TargetImageDigest` exists (required,
 > `^sha256:[a-f0-9]{64}$`) and `buildBootIPXEScript` renders `beskar7.target` +
 > `beskar7.target-digest`; `TargetImageURL`'s godoc is Kairos-correct. The
 > *optional* `beskar7.disk` render shown in brackets above is also implemented:
 > `Beskar7Machine.Spec.TargetDisk` (optional, `^[A-Za-z0-9._:/+-]+$`) is rendered
 > by `/boot` immediately after `beskar7.ca` when set, and omitted when empty (the
-> default auto-select path). The **inspector** deploy path (§9.1 step 5) is built
-> in the inspector repo against this spec.
+> default auto-select path). The *optional* `beskar7.ip` render is implemented in
+> v3: `Beskar7Machine.Spec.StaticIP` (optional pointer, pattern matching the
+> `<ip>::[<gw>]:<mask>[:<dns>]` shape) is rendered by `/boot` after `beskar7.disk`
+> (or after `beskar7.ca` when `beskar7.disk` is absent) when set, and omitted when
+> nil/empty. The **inspector** deploy path (§9.1 step 5) is built in the inspector
+> repo against this spec.
 
 ### 4.2 `POST /api/v1/inspection/{namespace}/{hostName}` — hardware report
 
@@ -215,7 +218,7 @@ these from `/proc/cmdline`.
 | `beskar7.timeout` | no | Inspector-side overall timeout (seconds). |
 | `beskar7.debug` | no | `true` to enable verbose logging / debug shell on failure. |
 | `BOOTIF` | no | The provisioning NIC's MAC in the pxelinux/iPXE form `01-aa-bb-cc-dd-ee-ff` (a `01` hardware-type prefix + the MAC with dashes). **Not** a `beskar7.*` key — it is the established netboot convention. `/boot` renders it from a `?mac=<mac>` query the operator's first-stage iPXE appends (e.g. `${net0/mac}`); see §4.1, §8.2. The inspector DHCP-configures the matching interface. **Absent** → a single-NIC host uses its one NIC; a multi-NIC host DHCP-races all links and applies the gatewayed winner (§8.2). `BOOTIF` is the deterministic pin and is the way to select a specific network. Non-secret. |
-| `beskar7.ip` | reserved | Planned static-network fallback for DHCP-less / VLAN-pinned environments, kernel-`ip=` syntax (`<ip>::<gw>:<mask>[:<dns>]`). Not rendered in v2 — DHCP is the only network mechanism (§8.2); reserved here so the name is not reused. |
+| `beskar7.ip` | no | Static-network override for DHCP-less / VLAN-pinned provisioning networks. Format: kernel `ip=` subset `<ip>::[<gw>]:<mask>[:<dns>]` where `<ip>` is a dotted IPv4, `<gw>` is an optional dotted IPv4 gateway (omit for a gateway-less net), `<mask>` is a dotted IPv4 netmask or a bare CIDR prefix-length integer (`0`–`32`), and `<dns>` is an optional dotted IPv4 resolver. Sourced from the optional `Beskar7Machine.Spec.StaticIP` field; rendered by `/boot` after `beskar7.disk` (or after `beskar7.ca` when `beskar7.disk` is absent) when set, and omitted entirely when absent. When `beskar7.ip` is present, the inspector configures the selected provisioning NIC statically and **skips DHCP**. The inspector selects the NIC by `BOOTIF` (when present); a multi-NIC host with `beskar7.ip` but no `BOOTIF` is rejected by the inspector (§8.2). Non-secret. |
 
 The only **secret** on the cmdline is `beskar7.token`. This is acceptable for a
 single-purpose, ephemeral, operator-controlled inspection ramdisk (see §8); the
@@ -426,9 +429,21 @@ configure networking itself, in Phase 1, **before** the inspection POST:
   break join-secret confidentiality — that is gated by the verified-TLS
   `/bootstrap` GET against the cmdline-delivered CA (§8), not by the network. This
   is the same residual the boot-nonce L2 exposure already accepts (§11).
+- **Static-network path (v3, `beskar7.ip`).** DHCP is the default; the
+  `beskar7.ip` param is the alternative for DHCP-less or VLAN-pinned provisioning
+  networks where no DHCP server is present. When `beskar7.ip` is set (rendered from
+  `Beskar7Machine.Spec.StaticIP` by `/boot`, §5), the inspector configures the
+  selected NIC statically with the given address, gateway, mask, and optional
+  resolver, and **skips DHCP entirely**. NIC selection still follows the `BOOTIF`
+  pin (§5, §8.2 above) — a multi-NIC host supplying `beskar7.ip` without `BOOTIF`
+  is ambiguous and MUST be rejected by the inspector (it cannot know which NIC to
+  configure statically). Single-NIC hosts work without `BOOTIF`. The
+  confidentiality model is unchanged: the static address is delivered over the same
+  verified-TLS `/boot` channel as the rest of the cmdline; a MITM on the
+  provisioning L2 cannot lift the join secret from the `/bootstrap` GET regardless
+  of whether DHCP or static addressing is used.
 
-Deferred (§11): a `beskar7.ip=` static fallback for DHCP-less / VLAN-pinned
-networks; VLAN-tagged provisioning networks.
+Deferred (§11): VLAN-tagged provisioning networks.
 
 ---
 
@@ -596,6 +611,7 @@ apart. The inspector therefore MUST treat the GET as a **poll**, not a one-shot:
 |---|---|
 | **v1** | Initial frozen contract: boot-nonce + bearer-token two-secret trust model, three HTTPS endpoints (`/boot`, `/inspection`, `/bootstrap`), §6 inspection report schema + golden fixture, inline `beskar7.ca`. Handoff was **kexec into `beskar7.target`** (a kernel+initrd image). |
 | **v2** | **Handoff redesign — §6 report schema unchanged.** Replaces kexec with whole-disk image deployment: the inspector writes a Kairos whole-disk raw image (`beskar7.target`) to the target disk, injects the per-host config (with CAPI user-data) as a numbered Kairos cloud-config (`99_beskar7.yaml`) into the image's `COS_OEM` partition, and reboots. Adds required cmdline param `beskar7.target-digest` (`sha256:<hex>`) plus optional `beskar7.disk` (operator disk-selection override), the §8.1 digest-pinning trust model (target image over plain HTTP, integrity by content digest, not TLS), and a specified disk-selection policy (smallest eligible disk by default). Reframes §9 around the two-phase enroll/provision role model (§9.0–9.2). **Report path:** the §6 schema and golden fixture are untouched, so the bump forces **no** inspector report-code or fixture change. **Controller side:** the CRD delta is **implemented** in this repo — the required `Beskar7Machine.Spec.TargetImageDigest` field and the `/boot` render of `beskar7.target` + `beskar7.target-digest`, plus the optional `Beskar7Machine.Spec.TargetDisk` field and its `beskar7.disk` render. The inspector deploy path (§9.1 step 5) is a new, separately-tested drift surface (§10). |
+| **v3** | **Static-network override — §6 report schema and golden fixture unchanged.** Un-reserves the optional `beskar7.ip` cmdline param (§5): adds `Beskar7Machine.Spec.StaticIP` (optional `*string`, CRD validation pattern for the `<ip>::[<gw>]:<mask>[:<dns>]` shape); `/boot` renders `beskar7.ip=<value>` after `beskar7.disk` (or after `beskar7.ca` when `beskar7.disk` is absent) when set. The inspector configures the selected NIC statically and skips DHCP when `beskar7.ip` is present; a multi-NIC host with `beskar7.ip` and no `BOOTIF` is rejected. Handler-side `validateStaticIP` / `formatStaticIP` guard (C-1a, SEC-7 omit-on-invalid) mirrors `formatBootif`. **No inspector report-code or fixture change.** The v2 whole-disk deploy flow (§9.1 steps 4–5) is unchanged. |
 
 ---
 
@@ -620,15 +636,15 @@ apart. The inspector therefore MUST treat the GET as a **poll**, not a one-shot:
   The inspector honors `beskar7.disk`, and the controller now renders it from the
   optional `Beskar7Machine.Spec.TargetDisk` field (`/boot`, after `beskar7.ca`,
   only when set). It is **not** required for default (auto-select) provisioning.
-- **Network bring-up breadth** (additive, §8.2): implemented so far — DHCP with
-  `BOOTIF` selection, the no-`BOOTIF` multi-NIC "DHCP every link and race"
-  (gatewayed-lease preference), and the DHCP-option-6 → `/etc/resolv.conf` writer
-  that lets `beskar7.api` be a hostname (IP-literal still recommended). Still
-  deferred: a `beskar7.ip=` static-network fallback (the §5-reserved param, plus
-  an optional `Beskar7Machine` spec field to render it — YAGNI until a real
-  static-network requirement lands) and VLAN-tagged provisioning networks. Each is
-  additive — the inspector's single network-bring-up entry point absorbs them
-  without changing the Phase-1 flow.
+- **Network bring-up breadth** (additive, §8.2): implemented — DHCP with `BOOTIF`
+  selection, the no-`BOOTIF` multi-NIC "DHCP every link and race"
+  (gatewayed-lease preference), the DHCP-option-6 → `/etc/resolv.conf` writer
+  that lets `beskar7.api` be a hostname (IP-literal still recommended), and (v3)
+  the `beskar7.ip=` static-network fallback for DHCP-less / VLAN-pinned networks
+  (`Beskar7Machine.Spec.StaticIP` → `/boot` renders `beskar7.ip=<value>` →
+  inspector configures the NIC statically, skips DHCP; multi-NIC requires `BOOTIF`
+  — §5, §8.2). Still deferred: VLAN-tagged provisioning networks (additive, does
+  not change the Phase-1 flow).
 - **kexec for boot-time speed** (future optimization): v2 reboots via host
   firmware (one POST cycle). A later version MAY `kexec` directly into the freshly
   written OS to skip the firmware POST, but kexec needs real firmware and a

--- a/examples/minimal-test.yaml
+++ b/examples/minimal-test.yaml
@@ -40,6 +40,15 @@ spec:
   targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
   targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
   configurationURL: "http://boot-server.local/configs/test-config.yaml"
+  # staticIP is optional. Set it only when the provisioning network has no DHCP
+  # server (DHCP-less or VLAN-pinned environments). When set, /boot renders
+  # beskar7.ip=<value> on the inspector kernel cmdline; the inspector configures
+  # the NIC statically and skips DHCP. Format: <ip>::[<gw>]:<mask>[:<dns>].
+  # Examples:
+  #   staticIP: "192.168.150.10::192.168.150.1:255.255.255.0"
+  #   staticIP: "10.0.0.5:::24:8.8.8.8"
+  # Leave unset (or remove the field) to use DHCP (the default).
+  # staticIP: "192.168.150.10::192.168.150.1:255.255.255.0"
 
 ---
 # Monitor with:


### PR DESCRIPTION
## What

The controller half of D-013 Phase 2: a static-network override for DHCP-less / VLAN-pinned provisioning networks. A new optional **`Beskar7Machine.Spec.StaticIP`** whose value `/boot` renders onto the inspector kernel cmdline as `beskar7.ip=<value>`. The inspector (merged: projectbeskar/beskar7-inspector#24) then configures the pinned NIC statically and skips DHCP.

## Changes
- **`api/v1beta1`**: `StaticIP *string` (optional) in the kernel-`ip=` subset `<ip>::<gw>:<mask>[:<dns>]`, with a `+kubebuilder:validation:Pattern` admission guard + nil-check deepcopy.
- **`controllers/boot_handler.go`**: `buildBootIPXEScript` renders `beskar7.ip` after the `beskar7.disk` slot (byte-identical when unset). `validateStaticIP` is the handler-side anchored-regexp guard (SEC-7 / C-1a) — admits only `[0-9.:]` in the `ip=` shape + an explicit whitespace/control check; Go's `$` doesn't match before a trailing newline, so a value can't inject another cmdline param. **Fails closed** on an invalid value (opaque `/boot` failure), for parity with the sibling rendered CRD fields (`TargetDisk`, `TargetImageURL`).
- **`docs/inspector-contract.md` → v3**: un-reserves §5 `beskar7.ip`, documents the §8.2 static path + §4.1 render slot, moves the §11 item to *implemented*, adds the §10.1 v3 history row. §6 report schema + golden fixture **unchanged**.
- `make manifests` + `make sync-chart-crds`; `examples/minimal-test.yaml` shows the field.

## Security
Reviewed by security-engineer: **SAFE TO SHIP** — injection-safety verified by running the regexp against the space / newline / tab / appended-`key=value` / hostname corpus; the CRD pattern and the handler pattern are the **identical** string (no drift surface); the value is never logged. The **fail-closed** behaviour (vs the initial omit-on-invalid) was the review's one non-blocking note — omit-on-invalid was wrong for a DHCP-less feature (it would strand the host with no network), so `StaticIP` now matches `TargetDisk`.

## Tests
`validateStaticIP` injection table (accept: full/no-gw/CIDR-prefix/dns/empty; reject: space, newline, tab, appended param, hostname, out-of-shape prefix) + render/ordering tests (`ca < disk < ip < BOOTIF`, byte-identical when absent). `make test`, `golangci-lint` (0 issues), `gofmt -s`, `make manifests` (no drift), chart CRDs in sync — all clean.

## Validation
The inspector consuming `beskar7.ip` was validated end-to-end on dome (inspector #24: a no-DHCP network, static `192.168.174.50/24`, verified-TLS POST → 202). This PR's render is unit-tested; the two halves meet at the cmdline-param format, which both sides implement identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)