### PR TITLE
chore(release): v0.4.0-alpha.7 (controller↔inspector contract v1→v4) + TEST-2 cert doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [v0.4.0-alpha.7] - 2026-06-07
+
+The "controller↔inspector contract" release: defines and ships the full provisioning contract (v1 → v4) between the Beskar7 controller and the new Rust `beskar7-inspector`, replacing the early kexec model with a digest-pinned whole-disk image handoff and a per-host iPXE boot/token flow with a provisioning-complete callback. Validated end-to-end on real bare metal: a blank host → `Ready` k3s node with `ProviderID` set.
+
 ### Added
+- **Controller↔inspector contract spec + golden-fixture test** (#110, #114) — `docs/inspector-contract.md` (now v4) plus a Go golden-fixture test guarding the `InspectionReportRequest` schema against drift with the inspector.
+- **Per-host iPXE `/boot` endpoint + single-use boot nonce** (D-009/D-010, #111, #112) — nonce-gated `GET /api/v1/boot/{ns}/{host}/{nonce}` renders the per-host kernel cmdline (`beskar7.api/token/ca/target/digest`); the boot nonce is minted alongside, and is distinct from, the bearer token, and is single-use (consumed on first fetch).
+- **External callback Service + serving-cert SAN sizing** (H-1, #113) — the chart exposes the callback Service externally and sizes the serving-cert SAN via `callback.externalNames`/`callback.externalIPs`, so bare-metal hosts can reach `:8082` with a verifiable cert.
+- **Whole-disk image handoff with digest pinning** (contract v2, D-011, #115, #116, #117) — repurposed `Beskar7Machine.Spec.TargetImageURL` + new **required** `TargetImageDigest`; the inspector streams the image to the target disk verifying sha256, discovers/mounts the `COS_OEM` partition, injects the per-host cloud-config, and reboots. `beskar7.target-digest` rendered on the cmdline. Supersedes the kexec model.
+- **Target-disk selection** (#118) — optional `Beskar7Machine.Spec.TargetDisk` rendered as `beskar7.disk`; absent → the inspector auto-selects the smallest eligible whole disk.
+- **D-013 provisioning networking** (#119, #121, #122) — `BOOTIF` rendered from the `?mac=` query param; native DHCP with multi-NIC race resolution (gatewayed-winner) + DNS `resolv.conf`; static-network override `Beskar7Machine.Spec.StaticIP` → `beskar7.ip` for DHCP-less / VLAN-pinned provisioning networks.
 - **`StateDeploying` phase** — `PhysicalHost` now transitions `Inspecting → Deploying` when the inspection report is accepted, and `Deploying → Ready` only when the inspector POSTs the provisioned-complete callback. `ProviderID`, `Status.Ready`, and `Status.Initialization.Provisioned` on `Beskar7Machine` are set at `Ready` entry, not at inspection completion (D-015).
 - **`POST /api/v1/provisioned/{namespace}/{hostName}` callback endpoint** — bearer-gated HTTPS endpoint on `:8082`; the inspector calls it after the verified whole-disk write and `COS_OEM` inject, before `reboot(2)`. Returns `202 Accepted`. Implemented in `controllers/provisioned_handler.go`; route registered in `SetupCallbackServer` (D-015).
 - **`--deployment-timeout` manager flag** — bounds how long a host may stay in `Deploying` before the `Beskar7Machine` is marked terminally failed with `FailureReason=DeploymentTimedOut`. Default 20 min. Measured from `PhysicalHost.Status.DeployingTimestamp` (D-015).
@@ -17,6 +27,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - **`ClearBootSourceOverride` now sends `Target=NoneBootSourceOverrideTarget`** — previously sent `Enabled=Disabled` with no `BootSourceOverrideTarget`, which caused a `400` on real BMCs (Redfish requires the field). Corrected in `internal/redfish/gofish_client.go` (D-015 bonus fix).
 - **Inspection timeout no longer fires on a completed inspection** — `handleInspectingHost` now checks `InspectionPhase==Complete` before the timeout, so a completed-but-slow inspection is not spuriously failed `InspectionTimedOut` (D-015 finding #1).
 - **Bearer token lifetime extended to 60 min** — `InspectionTimeout(10m) + DeploymentTimeout(20m) = 30m` could expire the token before the provisioned callback fires on a slow deploy. `TokenLifetime` raised from 30 min to 60 min in `internal/auth/token.go` (SEC-D015-1).
+
+### Documentation
+- **Inspector contract → v4** — `docs/inspector-contract.md` documents the `/provisioned` endpoint (§4.4), the `StateDeploying` flow (§2), and the deploy timeout; §11 closes the CAPI-bootstrap→Kairos mapping open item with the D-014 ruling (byte-verbatim; the bootstrap provider owns the format).
+- **Callback serving-cert constraint (TEST-2)** — §8 now states the callback serving cert must be a non-CA leaf with its issuing CA in `ca.crt`; the Rust inspector verifies with rustls/webpki (stricter than OpenSSL) and rejects a self-signed `CA:TRUE` cert used as both leaf and CA. cert-manager and the chart's self-signed path (`genCA`+`genSignedCert`) already comply.
+- **Examples** — replaced the broken kubeadm `examples/complete-cluster.yaml` (cannot produce a Kairos node) with the end-to-end-proven `examples/kairos-k3s-node.yaml`; `state-management.md` and `ipxe-setup.md` updated for the `StateDeploying` phase and `/provisioned` step.
 
 ## [v0.4.0-alpha.6] - 2026-05-29
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.0-alpha.6
+VERSION ?= v0.4.0-alpha.7
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0-alpha.6
-appVersion: "v0.4.0-alpha.6"
+version: 0.4.0-alpha.7
+appVersion: "v0.4.0-alpha.7"
 keywords:
   - cluster-api
   - infrastructure

--- a/controllers/inspection_handler.go
+++ b/controllers/inspection_handler.go
@@ -378,8 +378,13 @@ func (h *InspectionHandler) setInspectionResultAnnotation(
 // subsequent inspection POST and bootstrap GET (§8). Preference order:
 //  1. ca.crt — written by cert-manager and the chart's self-signed path;
 //     a dedicated CA cert is the best choice.
-//  2. tls.crt — self-signed certificates are their own CA; fall back to it
-//     when ca.crt is absent.
+//  2. tls.crt — last-resort fallback when ca.crt is absent. NOTE: the Rust
+//     inspector verifies with rustls/webpki, which REJECTS a CA:TRUE cert
+//     presented as the end-entity. A single self-signed CA:TRUE cert used as
+//     both the served leaf and this CA fails the callback TLS handshake (even
+//     though curl/OpenSSL accept it). Always provide a dedicated ca.crt plus a
+//     non-CA leaf in tls.crt — cert-manager and the chart's self-signed path
+//     (genCA + genSignedCert) both do. See docs/inspector-contract.md §8.
 //
 // Returns the raw PEM bytes. An error here blocks manager startup so
 // misconfiguration is loud (fail at setup, not at first /boot request).

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -273,8 +273,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.0-alpha.N`; bump N for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.0-alpha.6
-   git push origin v0.4.0-alpha.6
+   git tag v0.4.0-alpha.7
+   git push origin v0.4.0-alpha.7
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.6`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.7`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/inspector-contract.md
+++ b/docs/inspector-contract.md
@@ -358,6 +358,17 @@ evaluate correctly:
   from bare metal and a `.svc`-only cert forces operators toward insecure-skip —
   operators MUST override it (the manager SHOULD warn at startup if it is a
   `.svc` name).
+- **Serving-cert structure (the inspector verifies with rustls/webpki, which is
+  stricter than OpenSSL)**: the callback serving cert MUST be a non-CA **leaf**
+  (`basicConstraints: CA:FALSE`, `extendedKeyUsage: serverAuth`) issued by a
+  separate CA, and `beskar7.ca` MUST be that **issuing CA**, not the leaf. A
+  single self-signed cert that is its own CA (`CA:TRUE`) used as both the served
+  cert and `beskar7.ca` is **rejected** by the inspector at the TLS handshake
+  even though `curl`/OpenSSL accept it — webpki requires the end-entity to differ
+  from the trust anchor. cert-manager and the chart's self-signed path
+  (`genCA` + `genSignedCert`, with `ca.crt` in the secret so `/boot` sources the
+  CA, not the leaf) both satisfy this; a hand-rolled cert dir with only a
+  self-signed `tls.crt` and no `ca.crt` does NOT.
 - **Chainload hop**: the operator's boot infrastructure serves the per-host iPXE
   script (containing the `/boot/...{nonce}` URL) and the kernel/initrd. That hop
   MUST be HTTPS — it carries the nonce in the clear otherwise, and a plain-HTTP

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ The external SAN is added to both certificate paths: the cert-manager `Certifica
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.6/beskar7-manifests-v0.4.0-alpha.6.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.7/beskar7-manifests-v0.4.0-alpha.7.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -171,7 +171,7 @@ Memory Limit = (Host Count × 0.5MB) + (Webhook Concurrency × 10MB) + 100MB (ba
 Configure reconciliation intervals based on your needs:
 
 ```yaml
-# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.6.
+# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.7.
 args:
 - --leader-elect=true
 - --metrics-bind-address=:8443

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Operators
 
-This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.6. Each item is anchored to source code so you can verify the claim.
+This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.7. Each item is anchored to source code so you can verify the claim.
 
 If you are looking for hardening recommendations, see [Configuration](configuration.md). For RBAC details, see [RBAC Hardening](rbac-hardening.md). For incident debugging, see [Troubleshooting](troubleshooting.md).
 

--- a/examples/minimal-test-cluster.yaml
+++ b/examples/minimal-test-cluster.yaml
@@ -1,6 +1,6 @@
 # Minimal Test Cluster Example
 #
-# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.6
+# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.7
 # inspection workflow. NOT a working cluster — bring this up first to verify the
 # inspection round-trip, then graduate to examples/kairos-k3s-node.yaml.
 #

--- a/examples/security/README.md
+++ b/examples/security/README.md
@@ -1,6 +1,6 @@
 # Beskar7 Security Examples
 
-Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.6 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
+Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.7 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
 
 ## What's actually enforced
 

--- a/examples/security/development.yaml
+++ b/examples/security/development.yaml
@@ -1,4 +1,4 @@
-# Development-style security configuration for Beskar7 v0.4.0-alpha.6.
+# Development-style security configuration for Beskar7 v0.4.0-alpha.7.
 #
 # Loosens TLS verification for self-signed BMC certs typical in lab setups.
 # Do NOT use this configuration in production.

--- a/examples/security/production.yaml
+++ b/examples/security/production.yaml
@@ -1,4 +1,4 @@
-# Production-style security configuration for Beskar7 v0.4.0-alpha.6.
+# Production-style security configuration for Beskar7 v0.4.0-alpha.7.
 #
 # This file demonstrates the enforced security knobs only — the
 # beskar7-security-policy ConfigMap and the various "security framework"


### PR DESCRIPTION
## Release prep: v0.4.0-alpha.7

Bumps all version strings to `v0.4.0-alpha.7` (`Chart.yaml` version+appVersion, `Makefile` `VERSION`, doc/example references) and writes the `v0.4.0-alpha.7` CHANGELOG entry.

alpha.7 ships the **entire controller↔inspector contract arc** merged since alpha.6 (#110–#123) — the per-host `/boot` endpoint + boot nonce (D-009/D-010), whole-disk image handoff + digest pinning (D-011, contract v2), target-disk selection, D-013 provisioning networking (BOOTIF / multi-NIC race / static IP), the provisioning-complete callback + completion fixes (D-015), the external callback Service + SAN sizing (H-1), and the golden-fixture contract test. **Validated end-to-end on real bare metal** (blank host → `Ready` k3s node, `ProviderID` set).

Also folds in **TEST-2** (a small follow-up): documents that the callback serving cert must be a non-CA leaf with its issuing CA in `ca.crt` — the Rust inspector verifies with rustls/webpki (stricter than OpenSSL) and rejects a self-signed `CA:TRUE` cert used as both leaf and CA. The chart's self-signed path already complies; this corrects the misleading `readCallbackCA` godoc and adds the constraint to contract §8.

### After merge
Tag `v0.4.0-alpha.7` on the merge commit to trigger the release workflow (`release.yml` → ghcr image + release manifests + helm publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
