### PR TITLE
feat(controller): contract v4.1 — provision-failed fast-fail callback (D-016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+- **`POST /api/v1/provision-failed/{namespace}/{hostName}` callback endpoint** (contract v4.1) — bearer-gated HTTPS endpoint on `:8082`; the inspector calls it when Phase 2 fails (image fetch, digest verify, disk write, or `COS_OEM` inject) before exiting, reporting the failure promptly instead of waiting out `--deployment-timeout` (up to 20 min). The `PhysicalHost` transitions `StateDeploying → StateError` immediately; the `Beskar7Machine` is marked `FailureReason=DeploymentFailed` with the sanitized inspector reason in `FailureMessage`. Backward-compatible: a v4 controller without the endpoint returns 404, which the v4.1 inspector tolerates. Implemented in `controllers/provision_failed_handler.go`; route registered in `SetupCallbackServer`.
+- **`DeploymentFailed` failure reason** — new `FailureReason` constant on `Beskar7Machine` (`DeploymentFailedReason = "DeploymentFailed"`), distinct from `DeploymentTimedOut` (timeout) and `PhysicalHostError` (Redfish/BMC-level error). The `StateError` handler in `Beskar7MachineReconciler` attributes the reason by inspecting the `PhysicalHost.Status.ErrorMessage` prefix set by the provision-failed handler.
+- **Inspector contract v4.1** — `docs/inspector-contract.md` bumped to v4.1; §4.5 documents the new `/provision-failed` endpoint; §2 provisioning sequence updated with the fast-fail path; §11 open item on provisioning-failure recovery closed.
+
 ## [v0.4.0-alpha.7] - 2026-06-07
 
 The "controller↔inspector contract" release: defines and ships the full provisioning contract (v1 → v4) between the Beskar7 controller and the new Rust `beskar7-inspector`, replacing the early kexec model with a digest-pinned whole-disk image handoff and a per-host iPXE boot/token flow with a provisioning-complete callback. Validated end-to-end on real bare metal: a blank host → `Ready` k3s node with `ProviderID` set.

--- a/api/v1beta1/beskar7machine_types.go
+++ b/api/v1beta1/beskar7machine_types.go
@@ -57,6 +57,13 @@ const (
 	// automatically; the operator must investigate and either delete-and-recreate the
 	// Beskar7Machine or fix the iPXE setup.
 	InspectionTimedOutReason string = "InspectionTimedOut"
+	// DeploymentFailedReason (Severity=Error, terminal) indicates that the inspector
+	// explicitly reported a deploy failure via POST /api/v1/provision-failed (v4.1).
+	// Distinct from DeploymentTimedOut (timeout waiting for the callback) and from
+	// PhysicalHostError (Redfish/BMC-level error). Use this reason when the inspector
+	// itself signals that the image fetch, digest verify, disk write, or COS_OEM
+	// inject failed and provisioning cannot proceed.
+	DeploymentFailedReason string = "DeploymentFailed"
 )
 
 // Beskar7MachineSpec defines the desired state of Beskar7Machine.

--- a/controllers/annotations.go
+++ b/controllers/annotations.go
@@ -90,6 +90,18 @@ const BootNonceAnnotation = "infrastructure.cluster.x-k8s.io/boot-nonce"
 // The authenticated POST itself is the signal; the body is advisory only (D-015).
 const ProvisionedRequestAnnotation = "infrastructure.cluster.x-k8s.io/provisioned-request"
 
+// ProvisionFailedRequestAnnotation is set by the provision-failed HTTP handler on a
+// PhysicalHost to signal that the inspector encountered a fatal error during OS
+// deployment (image fetch, digest-verify, whole-disk write, or COS_OEM inject) and
+// the deploy cannot proceed. The PhysicalHost controller reads this annotation,
+// transitions State from Deploying to Error, sets Status.ErrorMessage to the sanitized
+// failure message, and clears the annotation so it is not acted on twice (v4.1).
+//
+// Value: a sanitized human-readable failure reason (≤256 chars, control-chars stripped,
+// prefixed with "inspector reported deploy failure: "). The authenticated POST itself is
+// the failure signal; the reason is advisory only and MUST be treated as untrusted input.
+const ProvisionFailedRequestAnnotation = "infrastructure.cluster.x-k8s.io/provision-failed-request"
+
 // BootNonceAnnotationValue is the wire format for BootNonceAnnotation.
 // Producer (Beskar7Machine controller) JSON-marshals one of these; consumer
 // (PhysicalHost controller) unmarshals and persists to Status.Bootstrap.

--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -307,12 +307,20 @@ func (r *Beskar7MachineReconciler) handlePhysicalHostState(ctx context.Context, 
 
 	case infrastructurev1beta1.StateError:
 		logger.Error(nil, "PhysicalHost is in error state", "errorMessage", physicalHost.Status.ErrorMessage)
-		conditions.MarkFalse(b7machine, infrastructurev1beta1.InfrastructureReadyCondition,
-			infrastructurev1beta1.PhysicalHostErrorReason, clusterv1.ConditionSeverityError,
-			"PhysicalHost %q in error state: %s", physicalHost.Name, physicalHost.Status.ErrorMessage)
-		phase := "Failed"
-		b7machine.Status.Phase = &phase
-		b7machine.Status.Ready = false
+		// Distinguish a deploy-reported failure (inspector POST /provision-failed, v4.1) from
+		// a Redfish/BMC-level error. The provision-failed handler prefixes ErrorMessage with
+		// provisionFailedReasonPrefix; all other error paths do not use that prefix.
+		// Using the prefix as the discriminator keeps the distinction simple and avoids adding
+		// a new CRD field — the PhysicalHost.Status.ErrorMessage already carries the full
+		// sanitized reason that the operator needs to diagnose the failure.
+		reason := infrastructurev1beta1.PhysicalHostErrorReason
+		if strings.HasPrefix(physicalHost.Status.ErrorMessage, provisionFailedReasonPrefix) {
+			reason = infrastructurev1beta1.DeploymentFailedReason
+		}
+		msg := fmt.Sprintf("PhysicalHost %q in error state: %s", physicalHost.Name, physicalHost.Status.ErrorMessage)
+		// markTerminalFailure sets FailureReason, FailureMessage, Phase=Failed, Ready=false,
+		// and marks InfrastructureReadyCondition=False in one call.
+		r.markTerminalFailure(b7machine, reason, msg)
 		return ctrl.Result{}, nil
 
 	default:

--- a/controllers/d016_provision_failed_test.go
+++ b/controllers/d016_provision_failed_test.go
@@ -34,6 +34,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -429,6 +430,20 @@ var _ = Describe("v4.1 sanitizeFailureReason", func() {
 		// plus the prefix.
 		expectedCapped := provisionFailedReasonPrefix + strings.Repeat("x", provisionFailedReasonMaxLen)
 		Expect(result).To(Equal(expectedCapped))
+	})
+
+	It("rune-boundary-truncates a multibyte reason to valid UTF-8 (SEC-D016-1)", func() {
+		// A multibyte reason overflowing the byte cap must NOT split mid-rune into
+		// invalid UTF-8 (etcd/protobuf would reject the status write, defeating fast-fail).
+		for _, r := range []string{
+			"x" + strings.Repeat("é", 200), // 2-byte runes; cut lands mid-rune
+			strings.Repeat("漢", 100),       // 3-byte runes
+			strings.Repeat("🚀", 80),        // 4-byte runes
+		} {
+			result := sanitizeFailureReason(r)
+			Expect(utf8.ValidString(result)).To(BeTrue(), "sanitized reason must be valid UTF-8")
+			Expect(len(result)).To(BeNumerically("<=", len(provisionFailedReasonPrefix)+provisionFailedReasonMaxLen))
+		}
 	})
 
 	It("preserves a short reason exactly (minus whitespace trim)", func() {

--- a/controllers/d016_provision_failed_test.go
+++ b/controllers/d016_provision_failed_test.go
@@ -1,0 +1,601 @@
+/*
+Copyright 2024 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Tests for the v4.1 contract provision-failed fast-fail flow:
+//
+//   - POST /api/v1/provision-failed: valid bearer + StateDeploying → 202 + annotation set
+//   - POST /api/v1/provision-failed: missing / wrong bearer → 401
+//   - POST /api/v1/provision-failed: oversized / garbage body → still 202 (body advisory)
+//   - POST /api/v1/provision-failed: host NOT in StateDeploying → no transition
+//   - PhysicalHost: ProvisionFailedRequestAnnotation → StateError + sanitized ErrorMessage
+//   - sanitizeFailureReason: control chars/newlines stripped, length-capped, empty→generic
+//   - Beskar7Machine StateError (deploy-failure path): terminal failure, DeploymentFailed reason
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	infrastructurev1beta1 "github.com/projectbeskar/beskar7/api/v1beta1"
+	"github.com/projectbeskar/beskar7/internal/auth"
+	internalredfish "github.com/projectbeskar/beskar7/internal/redfish"
+)
+
+// buildProvisionFailedMux wires the ProvisionFailedHandler onto a ServeMux using the
+// same route pattern as SetupCallbackServer, bound to an httptest.Server. Avoids
+// calling SetupCallbackServer (which requires a real cert dir) — tests everything
+// below TLS.
+func buildProvisionFailedMux() (*http.ServeMux, *ProvisionFailedHandler) {
+	log := ctrl.Log.WithName("provision-failed-handler-test")
+	handler := &ProvisionFailedHandler{
+		Client: k8sClient,
+		Log:    log,
+	}
+	verifier := newBearerTokenVerifier(k8sClient, log)
+	mux := http.NewServeMux()
+	mux.Handle("POST /api/v1/provision-failed/{namespace}/{hostName}",
+		auth.RequireBearer(log, verifier, handler))
+	return mux, handler
+}
+
+// ── provision-failed handler HTTP tests ──────────────────────────────────────
+
+var _ = Describe("v4.1 ProvisionFailedHandler HTTP", func() {
+	var (
+		testNs     *corev1.Namespace
+		ph         *infrastructurev1beta1.PhysicalHost
+		tokenPlain string
+	)
+
+	BeforeEach(func() {
+		testNs = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "d016-http-"}}
+		Expect(k8sClient.Create(ctx, testNs)).To(Succeed())
+
+		var hash string
+		var err error
+		tokenPlain, hash, err = auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		_, expiresAt := auth.LifetimeFor(time.Now())
+
+		ph = &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "host-pfail-http", Namespace: testNs.Name},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address:              "https://192.168.2.210",
+					CredentialsSecretRef: "dummy-creds",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ph)).To(Succeed())
+		ph.Status.State = infrastructurev1beta1.StateDeploying
+		ph.Status.Bootstrap = &infrastructurev1beta1.BootstrapStatus{
+			TokenHash: hash,
+			ExpiresAt: &expiresAt,
+		}
+		Expect(k8sClient.Status().Update(ctx, ph)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, testNs)).To(Succeed())
+	})
+
+	It("returns 202 Accepted with {\"status\":\"accepted\"} for a valid bearer POST in StateDeploying", func() {
+		mux, _ := buildProvisionFailedMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		body := bytes.NewBufferString(`{"reason":"image fetch failed: connection refused"}`)
+		req, err := http.NewRequest(http.MethodPost,
+			srv.URL+"/api/v1/provision-failed/"+testNs.Name+"/"+ph.Name,
+			body)
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Authorization", "Bearer "+tokenPlain)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusAccepted),
+			"valid bearer POST must return 202 Accepted")
+
+		var respBody map[string]string
+		Expect(json.NewDecoder(resp.Body).Decode(&respBody)).To(Succeed())
+		Expect(respBody["status"]).To(Equal("accepted"))
+
+		By("Verifying ProvisionFailedRequestAnnotation was set on the PhysicalHost")
+		updated := &infrastructurev1beta1.PhysicalHost{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, updated)).To(Succeed())
+		Expect(updated.Annotations).To(HaveKey(ProvisionFailedRequestAnnotation))
+		val := updated.Annotations[ProvisionFailedRequestAnnotation]
+		Expect(val).To(HavePrefix(provisionFailedReasonPrefix))
+		Expect(val).To(ContainSubstring("image fetch failed"))
+	})
+
+	It("returns 401 for missing bearer token", func() {
+		mux, _ := buildProvisionFailedMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		req, err := http.NewRequest(http.MethodPost,
+			srv.URL+"/api/v1/provision-failed/"+testNs.Name+"/"+ph.Name,
+			bytes.NewBufferString(`{"reason":"fail"}`))
+		Expect(err).NotTo(HaveOccurred())
+		// Deliberately no Authorization header.
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("returns 401 for a wrong bearer token", func() {
+		mux, _ := buildProvisionFailedMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		req, err := http.NewRequest(http.MethodPost,
+			srv.URL+"/api/v1/provision-failed/"+testNs.Name+"/"+ph.Name,
+			bytes.NewBufferString(`{"reason":"fail"}`))
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Authorization", "Bearer this-is-the-wrong-token")
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("accepts an oversized body and still returns 202 for valid bearer", func() {
+		mux, _ := buildProvisionFailedMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		// Body larger than provisionFailedMaxBodyBytes (64 KiB). The handler caps and
+		// discards; body size alone must not cause an error.
+		bigBody := bytes.Repeat([]byte("x"), provisionFailedMaxBodyBytes+1024)
+		req, err := http.NewRequest(http.MethodPost,
+			srv.URL+"/api/v1/provision-failed/"+testNs.Name+"/"+ph.Name,
+			bytes.NewReader(bigBody))
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Authorization", "Bearer "+tokenPlain)
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusAccepted),
+			"oversized body must not fail; body is advisory only")
+	})
+
+	It("accepts a garbage (non-JSON) body and still returns 202 for valid bearer", func() {
+		mux, _ := buildProvisionFailedMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		req, err := http.NewRequest(http.MethodPost,
+			srv.URL+"/api/v1/provision-failed/"+testNs.Name+"/"+ph.Name,
+			bytes.NewBufferString("THIS IS NOT JSON !!!"))
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Authorization", "Bearer "+tokenPlain)
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusAccepted),
+			"non-JSON body must not fail; body is advisory only")
+
+		By("Verifying annotation uses the generic reason when body is unparseable")
+		updated := &infrastructurev1beta1.PhysicalHost{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, updated)).To(Succeed())
+		Expect(updated.Annotations).To(HaveKeyWithValue(ProvisionFailedRequestAnnotation, provisionFailedReasonGeneric))
+	})
+
+	It("does NOT set annotation when host is NOT in StateDeploying", func() {
+		// Move host to a non-Deploying state (e.g. StateInspecting).
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, ph)).To(Succeed())
+		ph.Status.State = infrastructurev1beta1.StateInspecting
+		Expect(k8sClient.Status().Update(ctx, ph)).To(Succeed())
+
+		mux, _ := buildProvisionFailedMux()
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		req, err := http.NewRequest(http.MethodPost,
+			srv.URL+"/api/v1/provision-failed/"+testNs.Name+"/"+ph.Name,
+			bytes.NewBufferString(`{"reason":"fail"}`))
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Authorization", "Bearer "+tokenPlain)
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusAccepted),
+			"handler returns 202 even when host not in Deploying (no-op, not an error)")
+
+		By("Verifying annotation was NOT set on a non-Deploying host")
+		updated := &infrastructurev1beta1.PhysicalHost{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, updated)).To(Succeed())
+		Expect(updated.Annotations).NotTo(HaveKey(ProvisionFailedRequestAnnotation),
+			"must not set annotation on non-Deploying host")
+	})
+})
+
+// ── PhysicalHost: applyProvisionFailedRequestAnnotation ──────────────────────
+
+var _ = Describe("v4.1 PhysicalHost applyProvisionFailedRequestAnnotation", func() {
+	var testNs *corev1.Namespace
+
+	BeforeEach(func() {
+		testNs = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "d016-ph-"}}
+		Expect(k8sClient.Create(ctx, testNs)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, testNs)).To(Succeed())
+	})
+
+	It("transitions Deploying→Error and sets ErrorMessage from annotation value", func() {
+		errorMsg := provisionFailedReasonPrefix + "image digest mismatch"
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "host-pf-deploying",
+				Namespace: testNs.Name,
+				Annotations: map[string]string{
+					ProvisionFailedRequestAnnotation: errorMsg,
+				},
+			},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address:              "https://192.168.2.220",
+					CredentialsSecretRef: "dummy-creds",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ph)).To(Succeed())
+		ph.Status.State = infrastructurev1beta1.StateDeploying
+		Expect(k8sClient.Status().Update(ctx, ph)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, ph)).To(Succeed())
+
+		r := &PhysicalHostReconciler{
+			Client: k8sClient,
+			Log:    ctrl.Log.WithName("d016-ph-test"),
+			Scheme: k8sClient.Scheme(),
+		}
+		r.applyProvisionFailedRequestAnnotation(r.Log, ph)
+
+		By("Verifying State == Error")
+		Expect(ph.Status.State).To(Equal(infrastructurev1beta1.StateError))
+
+		By("Verifying ErrorMessage is set to the annotation value")
+		Expect(ph.Status.ErrorMessage).To(Equal(errorMsg))
+
+		By("Verifying Ready is false")
+		Expect(ph.Status.Ready).To(BeFalse())
+
+		By("Verifying annotation was cleared")
+		Expect(ph.Annotations).NotTo(HaveKey(ProvisionFailedRequestAnnotation))
+	})
+
+	It("does NOT transition when host is NOT in StateDeploying", func() {
+		errorMsg := provisionFailedReasonPrefix + "some error"
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "host-pf-notdeploying",
+				Namespace: testNs.Name,
+				Annotations: map[string]string{
+					ProvisionFailedRequestAnnotation: errorMsg,
+				},
+			},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address:              "https://192.168.2.221",
+					CredentialsSecretRef: "dummy-creds",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ph)).To(Succeed())
+		ph.Status.State = infrastructurev1beta1.StateReady // not Deploying
+		Expect(k8sClient.Status().Update(ctx, ph)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, ph)).To(Succeed())
+
+		r := &PhysicalHostReconciler{
+			Client: k8sClient,
+			Log:    ctrl.Log.WithName("d016-notdeploying-test"),
+			Scheme: k8sClient.Scheme(),
+		}
+		r.applyProvisionFailedRequestAnnotation(r.Log, ph)
+
+		By("Verifying State remains Ready (no transition)")
+		Expect(ph.Status.State).To(Equal(infrastructurev1beta1.StateReady),
+			"host not in Deploying must not be transitioned to Error")
+
+		By("Verifying annotation was cleared")
+		Expect(ph.Annotations).NotTo(HaveKey(ProvisionFailedRequestAnnotation),
+			"annotation must be cleared even when state guard fires")
+	})
+
+	It("clears annotation idempotently when host is already in StateError", func() {
+		errorMsg := provisionFailedReasonPrefix + "already failed"
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "host-pf-already-error",
+				Namespace: testNs.Name,
+				Annotations: map[string]string{
+					ProvisionFailedRequestAnnotation: errorMsg,
+				},
+			},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address:              "https://192.168.2.222",
+					CredentialsSecretRef: "dummy-creds",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ph)).To(Succeed())
+		ph.Status.State = infrastructurev1beta1.StateError
+		ph.Status.ErrorMessage = errorMsg
+		Expect(k8sClient.Status().Update(ctx, ph)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, ph)).To(Succeed())
+
+		r := &PhysicalHostReconciler{
+			Client: k8sClient,
+			Log:    ctrl.Log.WithName("d016-already-error-test"),
+			Scheme: k8sClient.Scheme(),
+		}
+		r.applyProvisionFailedRequestAnnotation(r.Log, ph)
+
+		By("Verifying State remains Error (no double-transition)")
+		Expect(ph.Status.State).To(Equal(infrastructurev1beta1.StateError))
+		Expect(ph.Status.ErrorMessage).To(Equal(errorMsg))
+
+		By("Verifying annotation was cleared")
+		Expect(ph.Annotations).NotTo(HaveKey(ProvisionFailedRequestAnnotation))
+	})
+})
+
+// ── sanitizeFailureReason unit tests ─────────────────────────────────────────
+
+var _ = Describe("v4.1 sanitizeFailureReason", func() {
+	It("returns generic message for empty input", func() {
+		Expect(sanitizeFailureReason("")).To(Equal(provisionFailedReasonGeneric))
+	})
+
+	It("returns generic message for whitespace-only input", func() {
+		Expect(sanitizeFailureReason("   \t  ")).To(Equal(provisionFailedReasonGeneric))
+	})
+
+	It("prefixes a normal reason with provisionFailedReasonPrefix", func() {
+		result := sanitizeFailureReason("image fetch failed")
+		Expect(result).To(Equal(provisionFailedReasonPrefix + "image fetch failed"))
+	})
+
+	It("strips newlines from the reason", func() {
+		result := sanitizeFailureReason("line1\nline2\r\nline3")
+		Expect(result).NotTo(ContainSubstring("\n"))
+		Expect(result).NotTo(ContainSubstring("\r"))
+		Expect(result).To(ContainSubstring("line1"))
+		Expect(result).To(ContainSubstring("line2"))
+		Expect(result).To(ContainSubstring("line3"))
+	})
+
+	It("strips ASCII control characters", func() {
+		// Bell (\a), NUL (\x00), unit separator (\x1f)
+		result := sanitizeFailureReason("bad\x00char\ahere\x1f")
+		Expect(result).NotTo(ContainSubstring("\x00"))
+		Expect(result).NotTo(ContainSubstring("\a"))
+		Expect(result).NotTo(ContainSubstring("\x1f"))
+		Expect(result).To(ContainSubstring("bad"))
+		Expect(result).To(ContainSubstring("char"))
+		Expect(result).To(ContainSubstring("here"))
+	})
+
+	It("caps reason to provisionFailedReasonMaxLen before prefixing", func() {
+		longReason := strings.Repeat("x", provisionFailedReasonMaxLen+100)
+		result := sanitizeFailureReason(longReason)
+		// The capped reason must be exactly provisionFailedReasonMaxLen chars of 'x',
+		// plus the prefix.
+		expectedCapped := provisionFailedReasonPrefix + strings.Repeat("x", provisionFailedReasonMaxLen)
+		Expect(result).To(Equal(expectedCapped))
+	})
+
+	It("preserves a short reason exactly (minus whitespace trim)", func() {
+		result := sanitizeFailureReason("  disk write error  ")
+		Expect(result).To(Equal(provisionFailedReasonPrefix + "disk write error"))
+	})
+})
+
+// ── Beskar7Machine StateError → DeploymentFailed reason ──────────────────────
+
+var _ = Describe("v4.1 Beskar7Machine StateError deploy-failure path", func() {
+	var (
+		testNs *corev1.Namespace
+		mockRf *internalredfish.MockClient
+		r      *Beskar7MachineReconciler
+	)
+
+	BeforeEach(func() {
+		testNs = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "d016-b7m-"}}
+		Expect(k8sClient.Create(ctx, testNs)).To(Succeed())
+
+		credSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "bmc-creds-d016", Namespace: testNs.Name},
+			Data: map[string][]byte{
+				"username": []byte("admin"),
+				"password": []byte("secret"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, credSecret)).To(Succeed())
+
+		mockRf = internalredfish.NewMockClient()
+		r = &Beskar7MachineReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			Log:    ctrl.Log.WithName("d016-b7m-test"),
+			RedfishClientFactory: func(_ context.Context, _, _, _ string, _ bool, _ []byte) (internalredfish.Client, error) {
+				return mockRf, nil
+			},
+			BootstrapURLBase: "https://example.com:8082",
+		}
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, testNs)).To(Succeed())
+	})
+
+	It("marks terminal failure with DeploymentFailedReason when ErrorMessage has the inspector prefix", func() {
+		deployFailMsg := provisionFailedReasonPrefix + "COS_OEM partition not found"
+
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "host-b7m-pfail", Namespace: testNs.Name},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address:              "https://192.168.2.230",
+					CredentialsSecretRef: "bmc-creds-d016",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ph)).To(Succeed())
+		ph.Status.State = infrastructurev1beta1.StateError
+		ph.Status.ErrorMessage = deployFailMsg
+		Expect(k8sClient.Status().Update(ctx, ph)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, ph)).To(Succeed())
+
+		b7m := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "b7m-pfail", Namespace: testNs.Name},
+			Spec: infrastructurev1beta1.Beskar7MachineSpec{
+				InspectionImageURL: "http://boot/inspect.ipxe",
+				TargetImageURL:     "http://boot/kairos.raw",
+				TargetImageDigest:  bootTestDigest,
+			},
+		}
+
+		result, err := r.handlePhysicalHostState(ctx, r.Log, b7m, ph)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}), "terminal failure must not requeue")
+
+		By("Verifying FailureReason == DeploymentFailedReason")
+		Expect(b7m.Status.FailureReason).NotTo(BeNil())
+		Expect(*b7m.Status.FailureReason).To(Equal(infrastructurev1beta1.DeploymentFailedReason))
+
+		By("Verifying FailureMessage is set and contains the error detail")
+		Expect(b7m.Status.FailureMessage).NotTo(BeNil())
+		Expect(*b7m.Status.FailureMessage).To(ContainSubstring("COS_OEM partition not found"))
+
+		By("Verifying Phase == Failed and Ready == false")
+		Expect(b7m.Status.Phase).NotTo(BeNil())
+		Expect(*b7m.Status.Phase).To(Equal("Failed"))
+		Expect(b7m.Status.Ready).To(BeFalse())
+
+		By("Verifying InfrastructureReadyCondition is False with DeploymentFailedReason")
+		cond := conditions.Get(b7m, infrastructurev1beta1.InfrastructureReadyCondition)
+		Expect(cond).NotTo(BeNil(), "InfrastructureReadyCondition must be set")
+		Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(infrastructurev1beta1.DeploymentFailedReason))
+	})
+
+	It("marks terminal failure with PhysicalHostErrorReason when ErrorMessage lacks the inspector prefix", func() {
+		// A Redfish/BMC error has no prefix from the inspector.
+		bmcErr := "Redfish connection failed: timeout"
+
+		ph := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "host-b7m-bmcerr", Namespace: testNs.Name},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address:              "https://192.168.2.231",
+					CredentialsSecretRef: "bmc-creds-d016",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ph)).To(Succeed())
+		ph.Status.State = infrastructurev1beta1.StateError
+		ph.Status.ErrorMessage = bmcErr
+		Expect(k8sClient.Status().Update(ctx, ph)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, ph)).To(Succeed())
+
+		b7m := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "b7m-bmcerr", Namespace: testNs.Name},
+			Spec: infrastructurev1beta1.Beskar7MachineSpec{
+				InspectionImageURL: "http://boot/inspect.ipxe",
+				TargetImageURL:     "http://boot/kairos.raw",
+				TargetImageDigest:  bootTestDigest,
+			},
+		}
+
+		result, err := r.handlePhysicalHostState(ctx, r.Log, b7m, ph)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		By("Verifying FailureReason == PhysicalHostErrorReason (not DeploymentFailed)")
+		Expect(b7m.Status.FailureReason).NotTo(BeNil())
+		Expect(*b7m.Status.FailureReason).To(Equal(infrastructurev1beta1.PhysicalHostErrorReason))
+
+		By("Verifying InfrastructureReadyCondition has PhysicalHostErrorReason")
+		cond := conditions.Get(b7m, infrastructurev1beta1.InfrastructureReadyCondition)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Reason).To(Equal(infrastructurev1beta1.PhysicalHostErrorReason))
+	})
+})
+
+// ── Beskar7Machine markTerminalFailure with DeploymentFailed ─────────────────
+
+var _ = Describe("v4.1 Beskar7Machine markTerminalFailure DeploymentFailed", func() {
+	It("sets FailureReason, FailureMessage, Phase=Failed, Ready=false, and condition", func() {
+		b7m := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "b7m-terminal", Namespace: "default"},
+		}
+		r := &Beskar7MachineReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			Log:    ctrl.Log.WithName("d016-terminal-test"),
+		}
+		msg := "inspector reported deploy failure: disk write I/O error"
+		r.markTerminalFailure(b7m, infrastructurev1beta1.DeploymentFailedReason, msg)
+
+		Expect(b7m.Status.FailureReason).NotTo(BeNil())
+		Expect(*b7m.Status.FailureReason).To(Equal(infrastructurev1beta1.DeploymentFailedReason))
+		Expect(b7m.Status.FailureMessage).NotTo(BeNil())
+		Expect(*b7m.Status.FailureMessage).To(Equal(msg))
+		Expect(b7m.Status.Phase).NotTo(BeNil())
+		Expect(*b7m.Status.Phase).To(Equal("Failed"))
+		Expect(b7m.Status.Ready).To(BeFalse())
+
+		cond := conditions.Get(b7m, infrastructurev1beta1.InfrastructureReadyCondition)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(infrastructurev1beta1.DeploymentFailedReason))
+		Expect(cond.Severity).To(Equal(clusterv1.ConditionSeverityError))
+	})
+})

--- a/controllers/inspection_handler.go
+++ b/controllers/inspection_handler.go
@@ -415,7 +415,7 @@ func readCallbackCA(certDir string) ([]byte, error) {
 
 // SetupCallbackServer wires the host-callback HTTPS server into the manager.
 //
-// The server hosts four host-scoped endpoints:
+// The server hosts five host-scoped endpoints:
 //
 //   - POST /api/v1/inspection/{namespace}/{hostName}: receives inspection
 //     reports from the inspection image (handled by InspectionHandler).
@@ -426,6 +426,9 @@ func readCallbackCA(certDir string) ([]byte, error) {
 //   - POST /api/v1/provisioned/{namespace}/{hostName}: receives the OS-deployment
 //     complete signal from the inspector (handled by ProvisionedHandler). Bearer-gated.
 //     Returns 202 Accepted; body is advisory only — the authenticated POST is the signal.
+//   - POST /api/v1/provision-failed/{namespace}/{hostName}: receives an explicit
+//     OS-deployment failure signal from the inspector (handled by ProvisionFailedHandler).
+//     Bearer-gated. Returns 202 Accepted; body carries an advisory reason field.
 //   - GET  /api/v1/boot/{namespace}/{hostName}/{nonce}: serves the per-host
 //     iPXE boot script (handled by BootHandler). NOT bearer-gated — gated by
 //     the single-use boot nonce (D-009). Rate-limited per source IP.
@@ -495,6 +498,12 @@ func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string, bootstrapUR
 		Log:    provisionedLog,
 	}
 
+	provisionFailedLog := ctrl.Log.WithName("provision-failed-handler")
+	provisionFailedHandler := &ProvisionFailedHandler{
+		Client: mgr.GetClient(),
+		Log:    provisionFailedLog,
+	}
+
 	bootLog := ctrl.Log.WithName("boot-handler")
 	bootHandler := &BootHandler{
 		Client: mgr.GetClient(),
@@ -512,6 +521,7 @@ func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string, bootstrapUR
 	inspectionVerifier := newBearerTokenVerifier(mgr.GetClient(), inspectionLog)
 	bootstrapVerifier := newBearerTokenVerifier(mgr.GetClient(), bootstrapLog)
 	provisionedVerifier := newBearerTokenVerifier(mgr.GetClient(), provisionedLog)
+	provisionFailedVerifier := newBearerTokenVerifier(mgr.GetClient(), provisionFailedLog)
 
 	mux := http.NewServeMux()
 	// Go 1.22+ pattern matching: bind path values for the verifier and handler.
@@ -523,6 +533,11 @@ func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string, bootstrapUR
 	// Bearer-gated with the same per-host token as inspection/bootstrap.
 	mux.Handle("POST /api/v1/provisioned/{namespace}/{hostName}",
 		auth.RequireBearer(provisionedLog, provisionedVerifier, provisionedHandler))
+	// Provision-failed callback (v4.1): inspector signals an explicit deploy failure.
+	// Bearer-gated with the same per-host token as inspection/bootstrap/provisioned.
+	// A v4 controller without this route returns 404, which the v4.1 inspector tolerates.
+	mux.Handle("POST /api/v1/provision-failed/{namespace}/{hostName}",
+		auth.RequireBearer(provisionFailedLog, provisionFailedVerifier, provisionFailedHandler))
 	// /boot is NOT bearer-gated. Rate limiting is applied inside BootHandler.ServeHTTP.
 	mux.Handle("GET /api/v1/boot/{namespace}/{hostName}/{nonce}", bootHandler)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -333,6 +333,12 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 	// controller can complete provisioning.
 	r.applyProvisionedRequestAnnotation(logger, physicalHost)
 
+	// Consume the provision-failed-request annotation (v4.1): the provision-failed
+	// HTTP handler sets it when the inspector signals a fatal deploy failure. We
+	// transition State from Deploying to Error and set Status.ErrorMessage so the
+	// Beskar7Machine controller can mark a terminal failure promptly.
+	r.applyProvisionFailedRequestAnnotation(logger, physicalHost)
+
 	// Determine state based on ConsumerRef
 	if physicalHost.Spec.ConsumerRef != nil {
 		// Host is claimed: guard transitions that must NOT overwrite the
@@ -608,6 +614,46 @@ func (r *PhysicalHostReconciler) applyProvisionedRequestAnnotation(logger logr.L
 	}
 
 	delete(physicalHost.Annotations, ProvisionedRequestAnnotation)
+}
+
+// applyProvisionFailedRequestAnnotation reads the ProvisionFailedRequestAnnotation and,
+// when present on a host in StateDeploying, transitions Status.State to StateError and
+// sets Status.ErrorMessage to the sanitized failure reason carried in the annotation
+// value (v4.1). The provision-failed HTTP handler is the sole writer of this annotation.
+//
+// Guard: only acts when the host is in StateDeploying. An annotation on a host in any
+// other state is cleared without transition — the Beskar7Machine controller detects the
+// unexpected state on its next reconcile.
+//
+// Idempotent: if the host is already in StateError when the annotation fires again (e.g.
+// a duplicate delivery before the first annotation is cleared), we clear the annotation
+// and return without re-writing status.
+func (r *PhysicalHostReconciler) applyProvisionFailedRequestAnnotation(logger logr.Logger, physicalHost *infrastructurev1beta1.PhysicalHost) {
+	val, ok := physicalHost.Annotations[ProvisionFailedRequestAnnotation]
+	if !ok {
+		return
+	}
+
+	switch physicalHost.Status.State {
+	case infrastructurev1beta1.StateDeploying:
+		logger.Info("Applying provision-failed annotation: transitioning Deploying→Error",
+			"host", physicalHost.Name)
+		physicalHost.Status.State = infrastructurev1beta1.StateError
+		physicalHost.Status.Ready = false
+		physicalHost.Status.ErrorMessage = val
+	case infrastructurev1beta1.StateError:
+		// Already in error (idempotent delivery or second annotation before first was cleared).
+		logger.V(1).Info("Provision-failed annotation on already-errored host; clearing idempotently",
+			"host", physicalHost.Name)
+	default:
+		// Unexpected state: the host received a provision-failed signal while not in
+		// Deploying. Log at Info (operator-visible) and clear the annotation; the
+		// Beskar7Machine controller will detect the unexpected state on its next reconcile.
+		logger.Info("Provision-failed annotation on host in unexpected state; clearing without transition",
+			"host", physicalHost.Name, "state", physicalHost.Status.State)
+	}
+
+	delete(physicalHost.Annotations, ProvisionFailedRequestAnnotation)
 }
 
 // reconcileDelete handles PhysicalHost deletion.

--- a/controllers/provision_failed_handler.go
+++ b/controllers/provision_failed_handler.go
@@ -169,9 +169,13 @@ func sanitizeFailureReason(reason string) string {
 	if cleaned == "" {
 		return provisionFailedReasonGeneric
 	}
-	// Cap to provisionFailedReasonMaxLen before prepending the prefix.
+	// Cap to provisionFailedReasonMaxLen before prepending the prefix. The cap is a
+	// byte length, but IsPrint admits multibyte runes, so a naive byte slice can
+	// split a rune and emit invalid UTF-8 — which etcd/protobuf rejects on the
+	// status write, defeating the fast-fail (SEC-D016-1). ToValidUTF8 drops any
+	// dangling partial rune left at the cut.
 	if len(cleaned) > provisionFailedReasonMaxLen {
-		cleaned = cleaned[:provisionFailedReasonMaxLen]
+		cleaned = strings.ToValidUTF8(cleaned[:provisionFailedReasonMaxLen], "")
 	}
 	return provisionFailedReasonPrefix + cleaned
 }

--- a/controllers/provision_failed_handler.go
+++ b/controllers/provision_failed_handler.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2024 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"unicode"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrastructurev1beta1 "github.com/projectbeskar/beskar7/api/v1beta1"
+)
+
+const (
+	// provisionFailedMaxBodyBytes caps the request body for the provision-failed handler.
+	// The inspector sends {"reason":"<short reason>"} (~handful of bytes); 64 KiB is
+	// generously above that and below any memory-pressure point. Body content is advisory
+	// only — the authenticated POST itself is the failure signal (v4.1 contract).
+	provisionFailedMaxBodyBytes = 64 << 10
+
+	// provisionFailedReasonMaxLen is the maximum length of the sanitized failure reason
+	// that will be stored in PhysicalHost.Status.ErrorMessage. Longer strings are truncated.
+	// 256 chars is enough for a descriptive error message while preventing unbounded growth
+	// in status (which is persisted to etcd).
+	provisionFailedReasonMaxLen = 256
+
+	// provisionFailedReasonPrefix is prepended to all failure reasons stored in
+	// PhysicalHost.Status.ErrorMessage so operators know the message originated from
+	// the inspector, not from a Redfish or controller-internal error.
+	provisionFailedReasonPrefix = "inspector reported deploy failure: "
+
+	// provisionFailedReasonGeneric is used when the inspector does not supply a reason or
+	// the reason is empty after sanitization.
+	provisionFailedReasonGeneric = "inspector reported deploy failure (no details provided)"
+)
+
+// ProvisionFailedHandler handles POST /api/v1/provision-failed/{namespace}/{hostName}
+// from the inspector, signalling that OS deployment has failed and cannot proceed.
+//
+// Authentication: callers must present "Authorization: Bearer <token>" with the same
+// per-host bearer token used for inspection POST, bootstrap GET, and the provisioned
+// callback (newBearerTokenVerifier + auth.RequireBearer; D-004). ServeHTTP assumes the
+// request has already passed the bearer middleware.
+//
+// Signal: the handler extracts and sanitizes the "reason" field from the advisory JSON
+// body, then patches ProvisionFailedRequestAnnotation carrying the sanitized message
+// onto the PhysicalHost metadata. The PhysicalHostReconciler reads this on its next
+// pass, transitions State from Deploying to Error, sets Status.ErrorMessage, and clears
+// the annotation (v4.1 / D-005 pattern). This handler does NOT write
+// PhysicalHost.Status directly.
+//
+// The reason is attacker-influenceable (it rides the inspector→controller wire under
+// the host's own token, but the inspector is on an untrusted provisioning network).
+// It is sanitized: control characters and newlines stripped, capped at
+// provisionFailedReasonMaxLen, and prefixed with provisionFailedReasonPrefix.
+type ProvisionFailedHandler struct {
+	Client client.Client
+	Log    logr.Logger
+}
+
+// provisionFailedBody is the JSON payload shape for the provision-failed callback.
+// The reason field is advisory only; the authenticated POST itself is the signal.
+type provisionFailedBody struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+// ServeHTTP handles provision-failure callbacks from the inspector.
+// It is invoked only after the bearer-auth middleware has validated the caller.
+func (h *ProvisionFailedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	namespace := r.PathValue("namespace")
+	hostName := r.PathValue("hostName")
+	log := h.Log.WithValues("method", r.Method, "namespace", namespace, "host", hostName, "remote", r.RemoteAddr)
+
+	if r.Method != http.MethodPost {
+		log.Info("Method not allowed", "method", r.Method)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract the advisory reason from the body. Cap + discard after decode so a
+	// slow-loris body cannot keep a goroutine alive unbounded.
+	reason := h.extractReason(log, r, w)
+
+	ctx := r.Context()
+
+	if err := h.signalProvisionFailed(ctx, log, namespace, hostName, reason); err != nil {
+		log.Error(err, "Failed to signal provision-failed state")
+		// Opaque error response — do not leak internal resource names or k8s details.
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	log.Info("Provision-failed callback accepted; signalled reconciler via annotation")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	if _, err := w.Write([]byte(`{"status":"accepted"}`)); err != nil {
+		log.V(1).Info("Failed to write response body", "err", err.Error())
+	}
+}
+
+// extractReason reads and parses the advisory JSON body, sanitizes the "reason" field,
+// and returns a non-empty message suitable for storage. Body is always fully consumed and
+// closed before returning so the connection can be reused. Never returns the raw
+// unsanitized value from the body — always sanitized.
+func (h *ProvisionFailedHandler) extractReason(log logr.Logger, r *http.Request, w http.ResponseWriter) string {
+	if r.Body == nil {
+		return provisionFailedReasonGeneric
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, provisionFailedMaxBodyBytes)
+	defer func() { _ = r.Body.Close() }()
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		// Body was too large or unreadable. Advisory body only — still accept the signal.
+		log.V(1).Info("Could not read provision-failed body (advisory only); proceeding", "err", err.Error())
+		return provisionFailedReasonGeneric
+	}
+
+	var payload provisionFailedBody
+	if err := json.Unmarshal(bodyBytes, &payload); err != nil {
+		// Body is not valid JSON. Advisory only — still accept the signal.
+		log.V(1).Info("Could not decode provision-failed body (advisory only); proceeding", "err", err.Error())
+		return provisionFailedReasonGeneric
+	}
+
+	return sanitizeFailureReason(payload.Reason)
+}
+
+// sanitizeFailureReason strips control characters (including newlines) from reason,
+// caps it to provisionFailedReasonMaxLen, and prepends provisionFailedReasonPrefix.
+// Returns provisionFailedReasonGeneric when reason is empty after stripping.
+//
+// The reason comes from an inspector running on an untrusted provisioning L2 network.
+// While it is bearer-authenticated (the token is per-host and short-lived), the
+// inspector binary could be replaced or the host could be compromised. Stripping
+// control characters prevents log-injection; capping prevents etcd bloat.
+func sanitizeFailureReason(reason string) string {
+	// Strip control characters (including \n, \r, \t) and non-printable Unicode.
+	var b strings.Builder
+	b.Grow(len(reason))
+	for _, r := range reason {
+		if r != unicode.ReplacementChar && unicode.IsPrint(r) {
+			b.WriteRune(r)
+		}
+	}
+	cleaned := strings.TrimSpace(b.String())
+	if cleaned == "" {
+		return provisionFailedReasonGeneric
+	}
+	// Cap to provisionFailedReasonMaxLen before prepending the prefix.
+	if len(cleaned) > provisionFailedReasonMaxLen {
+		cleaned = cleaned[:provisionFailedReasonMaxLen]
+	}
+	return provisionFailedReasonPrefix + cleaned
+}
+
+// signalProvisionFailed fetches the PhysicalHost and patches the
+// ProvisionFailedRequestAnnotation so the PhysicalHostReconciler can drive the
+// Deploying→Error transition. It does NOT write PhysicalHost.Status (D-005 invariant).
+//
+// Guard: only act when the host is in StateDeploying. If the host is in Error already
+// (idempotent delivery) or in another state, log and return nil — we do not force a
+// non-Deploying host into Error. The Beskar7Machine controller will observe the
+// ErrorMessage on its next reconcile regardless of which path set it.
+func (h *ProvisionFailedHandler) signalProvisionFailed(ctx context.Context, log logr.Logger, namespace, hostName, sanitizedReason string) error {
+	ph := &infrastructurev1beta1.PhysicalHost{}
+	key := types.NamespacedName{Namespace: namespace, Name: hostName}
+	if err := h.Client.Get(ctx, key, ph); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("PhysicalHost %s/%s not found", namespace, hostName)
+		}
+		return fmt.Errorf("failed to get PhysicalHost: %w", err)
+	}
+
+	switch ph.Status.State {
+	case infrastructurev1beta1.StateDeploying:
+		// Expected path: host is mid-deploy; set the failure annotation.
+	case infrastructurev1beta1.StateError:
+		// Already in error (idempotent delivery or a second POST after reconcile acted).
+		// Clear any stale annotation so the reconciler doesn't double-process, then return.
+		log.V(1).Info("Provision-failed callback on already-errored host; clearing annotation idempotently", "host", hostName)
+		if _, ok := ph.Annotations[ProvisionFailedRequestAnnotation]; ok {
+			base := ph.DeepCopy()
+			delete(ph.Annotations, ProvisionFailedRequestAnnotation)
+			if err := h.Client.Patch(ctx, ph, client.MergeFrom(base)); err != nil {
+				log.V(1).Info("Failed to clear stale provision-failed annotation; continuing", "err", err.Error())
+			}
+		}
+		return nil
+	default:
+		// Unexpected state — cannot safely force-error a host not in Deploying.
+		log.Info("Provision-failed callback received but host is not in Deploying state; ignoring",
+			"host", hostName, "state", ph.Status.State)
+		return nil
+	}
+
+	base := ph.DeepCopy()
+	if ph.Annotations == nil {
+		ph.Annotations = map[string]string{}
+	}
+	ph.Annotations[ProvisionFailedRequestAnnotation] = sanitizedReason
+
+	// Plain MergeFrom (no optimistic lock). Same reasoning as signalProvisioned:
+	// this annotation key is unique to this handler; no other writer can collide on it.
+	if err := h.Client.Patch(ctx, ph, client.MergeFrom(base)); err != nil {
+		return fmt.Errorf("patch PhysicalHost provision-failed annotation: %w", err)
+	}
+	log.V(1).Info("Provision-failed annotation set", "host", hostName)
+	return nil
+}

--- a/docs/inspector-contract.md
+++ b/docs/inspector-contract.md
@@ -1,6 +1,6 @@
 # Beskar7 Controller ↔ Inspector Contract
 
-**Contract version: `v4`**
+**Contract version: `v4.1`**
 
 This document is the single source of truth for the wire contract between the
 Beskar7 controller (`github.com/projectbeskar/beskar7`) and the inspection
@@ -9,13 +9,14 @@ change to the wire format, auth, endpoints, or cmdline parameters is a contract
 version bump and requires updating this document and the golden fixture
 (see [Versioning and anti-drift](#versioning-and-anti-drift)).
 
-> **v4 in one line:** adds a provisioning-complete callback —
-> `POST /api/v1/provisioned/{ns}/{host}` — that the inspector calls after the
-> verified whole-disk write and `COS_OEM` inject, and before `reboot(2)`. This
-> signal drives a new `StateDeploying` phase on the host and moves `ProviderID` /
-> `Ready` / `Initialization.Provisioned` onto the provisioned signal instead of
-> the inspection signal. The inspection report schema (§6), the golden fixture,
-> and all v3 cmdline parameters are **unchanged**. See
+> **v4.1 in one line:** adds an explicit deploy-failure callback —
+> `POST /api/v1/provision-failed/{ns}/{host}` — so a failing inspector reports
+> the failure promptly instead of silently aborting and waiting out the
+> deployment-timeout (20 min, `--deployment-timeout`). Backward-compatible: a
+> v4 controller without this endpoint returns 404; the v4.1 inspector MUST
+> tolerate that and treat it as if the endpoint were unavailable. A v4.1
+> controller with a v4 inspector simply leaves the new endpoint unused.
+> **No §5 cmdline, §6 report, or existing endpoint change.** See
 > [Version history](#101-version-history) for the full delta.
 
 Requirement keywords (MUST, MUST NOT, SHOULD, MAY) are used per RFC 2119.
@@ -73,6 +74,10 @@ inspector ramdisk — Phase 2: provision (when bootstrap data is available)
   ├─ re-read the partition table; mount the image's COS_OEM partition
   ├─ inject a per-host cloud-config embedding the fetched user-data into COS_OEM
   ├─ sync, unmount — zero the in-memory user-data
+  │  (on any step failure above)
+  │  └─ POST provision-failed → {api}/api/v1/provision-failed/{ns}/{host}
+  │         (Bearer token, TLS-verified)  → 202
+  │         body: {"reason":"<short description>"}   [advisory, v4.1 fast-fail path]
   ├─ POST provisioned → {api}/api/v1/provisioned/{ns}/{host}  (Bearer token, TLS-verified)  → 202
   └─ reboot(2) → host firmware boots the provisioned OS
   │
@@ -89,6 +94,16 @@ that OS deployment completed. The controller sets `StateReady` / `ProviderID` /
 receiving this signal — not at inspection completion. A deployment-timeout guard
 (`--deployment-timeout`, default 20 min) converts a silent abort into a terminal
 `DeploymentTimedOut` failure.
+
+**Deploy failure is reported promptly (v4.1).** When Phase 2 fails (image fetch,
+digest-verify, disk write, `COS_OEM` mount/inject), the inspector SHOULD POST
+`/api/v1/provision-failed/{ns}/{host}` with an advisory `{"reason":"..."}` body
+before exiting. The controller transitions the `PhysicalHost` to `StateError`
+immediately (fast-fail path) and marks the `Beskar7Machine` with
+`FailureReason=DeploymentFailed`, surfacing the error to `kubectl describe machine`
+without waiting out the deployment-timeout. If the inspector cannot reach the
+endpoint (404 on a v4 controller, or a network failure), the host falls back to
+timing out at `--deployment-timeout`.
 
 The *real* proof the host joined the workload cluster correctly is the CAPI
 `Machine` advancing to `Running` — that requires the Kubernetes node to appear
@@ -237,6 +252,41 @@ The inspector MUST call this endpoint after zeroing the in-memory user-data buff
 and before `reboot(2)`. After the reboot the inspector is gone; a silent reboot
 would leave the controller unable to confirm that OS deployment completed and the
 host would eventually fail with `DeploymentTimedOut`.
+
+### 4.5 `POST /api/v1/provision-failed/{namespace}/{hostName}` — deploy-failure signal
+
+Added in v4.1. The inspector SHOULD call this endpoint when Phase 2 fails at any
+step (image fetch, digest verify, disk write, `COS_OEM` mount/inject, user-data
+injection) so the controller can fail the host promptly instead of waiting out the
+deployment-timeout.
+
+- **Auth**: `Authorization: Bearer <token>`; same per-host bearer token as §4.2–§4.4.
+- **Body**: advisory JSON `{"reason":"<short failure description>"}`. The body
+  content is a human-readable hint for the operator; it is not trusted for control
+  flow. The controller sanitizes the reason before storage: strips control
+  characters and newlines, caps to 256 characters, and prepends a fixed prefix
+  (`"inspector reported deploy failure: "`) so the operator knows the message
+  origin. A missing, empty, or non-JSON body results in a generic error message.
+  The body is capped at 64 KiB; an oversized body does not cause a rejection.
+- **Success**: **`202 Accepted`** with body `{"status":"accepted"}`.
+- **Failure**: opaque `401` on expired/invalid bearer; opaque `500` on internal
+  error; opaque `404` if the controller is v4 (does not implement this endpoint).
+- **Controller action**: only acts when the `PhysicalHost` is in `StateDeploying`.
+  On a valid call, patches `ProvisionFailedRequestAnnotation` carrying the
+  sanitized reason onto the `PhysicalHost` metadata. The `PhysicalHostReconciler`
+  reads this on its next pass, transitions `State` from `StateDeploying` to
+  `StateError`, sets `Status.ErrorMessage`, and clears the annotation (D-005
+  invariant). The `Beskar7MachineReconciler` then marks a terminal failure with
+  `FailureReason=DeploymentFailed`. A non-`Deploying` host returns 202 but
+  receives no state transition (no-op guard).
+- **Inspector MUST**: call this endpoint on any Phase 2 error, then exit (do NOT
+  continue to the provisioned POST or `reboot(2)` after a failure).
+- **Inspector MUST**: tolerate a `404` response (v4 controller without this
+  endpoint). Treat `404` as "endpoint unavailable" — the failure is still visible
+  to the operator via the deployment-timeout; do not retry as an error.
+- **Backward compatibility**: a v4.1 controller + v4 inspector → endpoint simply
+  unused (host times out at `--deployment-timeout`). A v4 controller + v4.1
+  inspector → 404, which the inspector tolerates.
 
 ---
 
@@ -674,6 +724,7 @@ apart. The inspector therefore MUST treat the GET as a **poll**, not a one-shot:
 | **v2** | **Handoff redesign — §6 report schema unchanged.** Replaces kexec with whole-disk image deployment: the inspector writes a Kairos whole-disk raw image (`beskar7.target`) to the target disk, injects the per-host config (with CAPI user-data) as a numbered Kairos cloud-config (`99_beskar7.yaml`) into the image's `COS_OEM` partition, and reboots. Adds required cmdline param `beskar7.target-digest` (`sha256:<hex>`) plus optional `beskar7.disk` (operator disk-selection override), the §8.1 digest-pinning trust model (target image over plain HTTP, integrity by content digest, not TLS), and a specified disk-selection policy (smallest eligible disk by default). Reframes §9 around the two-phase enroll/provision role model (§9.0–9.2). **Report path:** the §6 schema and golden fixture are untouched, so the bump forces **no** inspector report-code or fixture change. **Controller side:** the CRD delta is **implemented** in this repo — the required `Beskar7Machine.Spec.TargetImageDigest` field and the `/boot` render of `beskar7.target` + `beskar7.target-digest`, plus the optional `Beskar7Machine.Spec.TargetDisk` field and its `beskar7.disk` render. The inspector deploy path (§9.1 step 5) is a new, separately-tested drift surface (§10). |
 | **v3** | **Static-network override — §6 report schema and golden fixture unchanged.** Un-reserves the optional `beskar7.ip` cmdline param (§5): adds `Beskar7Machine.Spec.StaticIP` (optional `*string`, CRD validation pattern for the `<ip>::[<gw>]:<mask>[:<dns>]` shape); `/boot` renders `beskar7.ip=<value>` after `beskar7.disk` (or after `beskar7.ca` when `beskar7.disk` is absent) when set. The inspector configures the selected NIC statically and skips DHCP when `beskar7.ip` is present; a multi-NIC host with `beskar7.ip` and no `BOOTIF` is rejected. Handler-side `validateStaticIP` / `formatStaticIP` guard (C-1a, SEC-7 omit-on-invalid) mirrors `formatBootif`. **No inspector report-code or fixture change.** The v2 whole-disk deploy flow (§9.1 steps 4–5) is unchanged. |
 | **v4** | **Provisioning-complete callback — §6 report schema and golden fixture unchanged.** Adds a fourth HTTPS endpoint: `POST /api/v1/provisioned/{ns}/{host}` (§4.4), bearer-gated with the same per-host token as §4.2/§4.3, advisory body `{"status":"provisioned"}`, success response `202 Accepted`. The inspector calls it after the verified whole-disk write + `COS_OEM` inject, and **before** `reboot(2)` (§9.1 step 5 renumbered). Adds a new `StateDeploying` phase on `PhysicalHost` (entered at inspection-complete, exited at provisioned-callback or deployment-timeout). `Beskar7Machine.Spec.ProviderID`, `Status.Ready`, and `Status.Initialization.Provisioned` are now set only upon the provisioned callback, not at inspection completion — aligning what "infrastructure provisioned" means with what CAPI's `infrastructureProvisioned` field is supposed to mean. Also fixes `ClearBootSourceOverride` to send `Target=NoneBootSourceOverrideTarget` (Redfish-canonical clear); previously it sent `Enabled=Disabled` with no `Target` which caused a `400` on real BMCs. `TokenLifetime` increased from 30 min to 60 min (SEC-D015-1: `InspectionTimeout(10m) + DeploymentTimeout(20m) = 30m` could expire the token during a slow deploy). **No §5 cmdline or §6 report change.** Controller side: `controllers/provisioned_handler.go` (new); route registered in `SetupCallbackServer`. Inspector side: `CONTRACT_VERSION="v4"`, `client::provisioned()` in `src/client.rs`, called from `src/run.rs` before `reboot(2)`. |
+| **v4.1** | **Deploy-failure fast-fail callback — §5 cmdline, §6 report schema, and golden fixture unchanged. Backward-compatible additive endpoint.** Adds a fifth HTTPS endpoint: `POST /api/v1/provision-failed/{ns}/{host}` (§4.5), bearer-gated with the same per-host token as §4.2–§4.4, advisory body `{"reason":"<short description>"}`, success response `202 Accepted`. The inspector SHOULD call it when Phase 2 fails (image fetch, digest verify, disk write, `COS_OEM` inject) before exiting, so the controller can fail the `Beskar7Machine` promptly (via `FailureReason=DeploymentFailed`) instead of waiting out the 20-min `--deployment-timeout`. The `PhysicalHost` transitions `StateDeploying → StateError` immediately with `Status.ErrorMessage` carrying the sanitized reason. A `404` response (v4 controller without the endpoint) MUST be tolerated by the inspector — the host falls back to timing out. A v4.1 controller with a v4 inspector leaves the endpoint unused. **Controller side**: `controllers/provision_failed_handler.go` (new); `ProvisionFailedRequestAnnotation` (new); `applyProvisionFailedRequestAnnotation` in `PhysicalHostReconciler`; `DeploymentFailedReason` constant; `handlePhysicalHostState` `StateError` case updated to attribute the failure to `DeploymentFailed` vs. `PhysicalHostError` based on `ErrorMessage` prefix; route registered in `SetupCallbackServer`. Inspector side: `CONTRACT_VERSION="v4.1"`, `client::provision_failed()`, called from `src/run.rs` on Phase 2 errors. |
 
 ---
 
@@ -744,6 +795,6 @@ apart. The inspector therefore MUST treat the GET as a **poll**, not a one-shot:
   An image that writes and injects cleanly but never boots into a joining Kubernetes
   node is still a timeout at the CAPI level (the `Machine` stays `Pending` until
   the node registers with `ProviderID=b7://...`). The exact retry policy and
-  node-join timeout are not specified in v4 and must be defined before GA. A v4.1
-  fast-follow may add `POST /api/v1/provision-failed` so a *failed* deploy is
-  reported promptly instead of waiting out the deployment-timeout (planned).
+  node-join timeout are not specified in v4.1 and must be defined before GA.
+  **The `POST /api/v1/provision-failed` fast-fail path is now implemented (v4.1,
+  §4.5)** — a deploy failure is reported promptly instead of timing out.


### PR DESCRIPTION
## What & why
Adds the contract-**v4.1** fast-fail callback `POST /api/v1/provision-failed/{ns}/{host}` (architect-flagged D-015 fast-follow; D-016). In v4, a host that finishes inspection sits in `StateDeploying` until `/provisioned` (→ Ready) or the 20-minute `--deployment-timeout`; if the inspector's OS deploy **fails**, there was no fast path. This reports the failure promptly so the `Beskar7Machine` fails with `FailureReason=DeploymentFailed` instead of waiting out the timeout.

## Changes
- New bearer-gated `ProvisionFailedHandler` (mirrors `/provisioned`): advisory body capped, signals the PhysicalHost controller via `ProvisionFailedRequestAnnotation` (D-005), 202, guarded to `StateDeploying`.
- **Reason sanitization**: control-char/newline strip + 256-char cap + fixed prefix before the reason lands in `Status.ErrorMessage`/`FailureMessage` (the authenticated POST is the signal; the reason is a hint).
- PhysicalHost `StateDeploying → StateError`; Beskar7Machine `StateError` now routes through `markTerminalFailure` — **fixes a latent bug** where `StateError` set neither `FailureReason` nor `FailureMessage` — attributing `DeploymentFailed` (provision-failed) vs `PhysicalHostError` (Redfish) by the reason prefix.
- Contract doc → **v4.1** (§4.5, §2 fast-fail, §10.1), CHANGELOG.

## Tests
`make test` green (controllers 68.9%), `golangci-lint` 0 issues. New `d016_provision_failed_test.go` (14 specs).

## Merge order
Additive + backward-compatible. **Merge this before the beskar7-inspector v4.1 PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
