### PR TITLE
test(redfish): DMTF public-rackmount1 read-robustness corpus (TEST-1)

### DIFF
--- a/internal/redfish/corpus_robustness_test.go
+++ b/internal/redfish/corpus_robustness_test.go
@@ -1,0 +1,229 @@
+package redfish
+
+// Tests in this file exercise the real gofish client against the vendored
+// DMTF public-rackmount1 corpus served as a static HTTP tree. The goal is
+// read/parse robustness: does our wrapper survive real DMTF JSON that carries
+// OEM blocks, extra enum values, and a richer link graph than our hand-rolled
+// mock emits? Stateful operations (SetBootSourcePXE, power cycles) are NOT
+// tested here — those belong in the mock-based state-machine tests that can
+// assert "was called / was cleared". This lane is corpus = read only.
+//
+// The corpus is vendored at testdata/corpus/public-rackmount1/ (BSD-3-Clause,
+// see testdata/corpus/LICENSE). It is a curated subset of the DMTF
+// Redfish-Mockup-Server repository; only the files that gofish actually GETs
+// for our 9-method interface are included.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gofishredfish "github.com/stmcginnis/gofish/redfish"
+)
+
+// corpusRoot is the filesystem path to the vendored DMTF mockup subtree.
+// Using os.ReadFile rather than embed because testdata/ is already excluded
+// from the binary by Go convention, and runtime.Callers-based path lookup is
+// fragile. The test binary's working directory is the package directory under
+// `go test`, so a relative path resolves correctly.
+const corpusRoot = "testdata/corpus/public-rackmount1"
+
+// newCorpusHandler returns an http.Handler that serves the vendored DMTF
+// corpus. URL→file mapping mirrors the DMTF mockup server convention:
+//
+//	/redfish/v1/            → <corpusRoot>/redfish/v1/index.json
+//	/redfish/v1/Systems     → <corpusRoot>/redfish/v1/Systems/index.json
+//	/redfish/v1/odata       → <corpusRoot>/redfish/v1/odata/index.json
+//
+// Path traversal (any segment containing "..") is rejected with 400.
+// Anything not in the corpus returns 404. gofish uses BasicAuth here, so
+// there is no SessionService handshake — the handler needs no auth logic.
+func newCorpusHandler(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := path.Clean(r.URL.Path)
+
+		// Reject any path that still contains ".." after cleaning — defence
+		// against traversal even though path.Clean already handles most forms.
+		for _, seg := range strings.Split(p, "/") {
+			if seg == ".." {
+				http.Error(w, "path traversal rejected", http.StatusBadRequest)
+				return
+			}
+		}
+
+		// Map URL path to filesystem path: strip the leading "/" and append
+		// "index.json". The corpus root is relative to the package directory.
+		rel := strings.TrimPrefix(p, "/")
+		fsPath := filepath.Join(corpusRoot, filepath.FromSlash(rel), "index.json")
+
+		data, err := os.ReadFile(fsPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				http.NotFound(w, r)
+				return
+			}
+			t.Logf("corpus handler: unexpected read error for %s: %v", fsPath, err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	})
+}
+
+// TestCorpusReadRobustness_GetSystemInfo verifies that the real gofish client
+// parses the DMTF public-rackmount1 ComputerSystem document and that our
+// GetSystemInfo wrapper returns the verbatim values from the corpus JSON.
+// Expected values are read from the vendored index.json — not invented.
+//   - Manufacturer: "Contoso"
+//   - Model:        "3500"
+//   - SerialNumber: "437XR1138R2"
+func TestCorpusReadRobustness_GetSystemInfo(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(newCorpusHandler(t))
+	defer server.Close()
+
+	httpClient := server.Client()
+	httpClient.Timeout = 10 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := NewClientWithHTTPClient(ctx, server.URL, "u", "p", false, httpClient)
+	if err != nil {
+		t.Fatalf("NewClientWithHTTPClient: %v", err)
+	}
+	defer client.Close(ctx)
+
+	info, err := client.GetSystemInfo(ctx)
+	if err != nil {
+		t.Fatalf("GetSystemInfo: %v", err)
+	}
+
+	// Values are verbatim from
+	// testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/index.json
+	if info.Manufacturer != "Contoso" {
+		t.Errorf("Manufacturer: want %q, got %q", "Contoso", info.Manufacturer)
+	}
+	if info.Model != "3500" {
+		t.Errorf("Model: want %q, got %q", "3500", info.Model)
+	}
+	if info.SerialNumber != "437XR1138R2" {
+		t.Errorf("SerialNumber: want %q, got %q", "437XR1138R2", info.SerialNumber)
+	}
+}
+
+// TestCorpusReadRobustness_GetPowerState verifies that gofish parses the
+// PowerState field from the DMTF corpus and that GetPowerState returns it
+// correctly. The corpus system has PowerState = "On".
+func TestCorpusReadRobustness_GetPowerState(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(newCorpusHandler(t))
+	defer server.Close()
+
+	httpClient := server.Client()
+	httpClient.Timeout = 10 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := NewClientWithHTTPClient(ctx, server.URL, "u", "p", false, httpClient)
+	if err != nil {
+		t.Fatalf("NewClientWithHTTPClient: %v", err)
+	}
+	defer client.Close(ctx)
+
+	state, err := client.GetPowerState(ctx)
+	if err != nil {
+		t.Fatalf("GetPowerState: %v", err)
+	}
+
+	// Value is verbatim from
+	// testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/index.json
+	// "PowerState": "On"
+	if state != gofishredfish.OnPowerState {
+		t.Errorf("PowerState: want %q, got %q", gofishredfish.OnPowerState, state)
+	}
+}
+
+// TestCorpusReadRobustness_GetNetworkAddresses verifies that the
+// EthernetInterfaces walk succeeds against the real DMTF tree structure
+// (collection → members → per-interface IPv4/IPv6 arrays) and that we parse
+// at least the two physical NICs' addresses. This is the most complex read
+// path: gofish fetches the collection, iterates members, fetches each
+// interface, and our extractor walks IPv4Addresses + IPv6Addresses.
+//
+// Asserted values come from the corpus JSON:
+//   - NIC 12446A3B0411: IPv4 192.168.0.10, MAC 12:44:6A:3B:04:11
+//   - NIC 12446A3B8890: IPv4 192.168.0.11, MAC AA:BB:CC:DD:EE:00
+func TestCorpusReadRobustness_GetNetworkAddresses(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(newCorpusHandler(t))
+	defer server.Close()
+
+	httpClient := server.Client()
+	httpClient.Timeout = 10 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client, err := NewClientWithHTTPClient(ctx, server.URL, "u", "p", false, httpClient)
+	if err != nil {
+		t.Fatalf("NewClientWithHTTPClient: %v", err)
+	}
+	defer client.Close(ctx)
+
+	addrs, err := client.GetNetworkAddresses(ctx)
+	if err != nil {
+		t.Fatalf("GetNetworkAddresses: %v", err)
+	}
+
+	if len(addrs) == 0 {
+		t.Fatal("GetNetworkAddresses: returned no addresses")
+	}
+
+	// Index the returned addresses by IP for order-independent assertions.
+	byIP := make(map[string]NetworkAddress, len(addrs))
+	for _, a := range addrs {
+		byIP[a.Address] = a
+	}
+
+	// Physical NIC 1 — values from
+	// testdata/corpus/…/EthernetInterfaces/12446A3B0411/index.json
+	a0, ok := byIP["192.168.0.10"]
+	if !ok {
+		t.Errorf("expected address 192.168.0.10 from NIC 12446A3B0411, not found in %v", addrs)
+	} else {
+		if a0.MACAddress != "12:44:6A:3B:04:11" {
+			t.Errorf("NIC 12446A3B0411 MAC: want %q, got %q", "12:44:6A:3B:04:11", a0.MACAddress)
+		}
+		if a0.Type != IPv4AddressType {
+			t.Errorf("NIC 12446A3B0411 type: want IPv4, got %q", a0.Type)
+		}
+	}
+
+	// Physical NIC 2 — values from
+	// testdata/corpus/…/EthernetInterfaces/12446A3B8890/index.json
+	a1, ok := byIP["192.168.0.11"]
+	if !ok {
+		t.Errorf("expected address 192.168.0.11 from NIC 12446A3B8890, not found in %v", addrs)
+	} else {
+		if a1.MACAddress != "AA:BB:CC:DD:EE:00" {
+			t.Errorf("NIC 12446A3B8890 MAC: want %q, got %q", "AA:BB:CC:DD:EE:00", a1.MACAddress)
+		}
+		if a1.Type != IPv4AddressType {
+			t.Errorf("NIC 12446A3B8890 type: want IPv4, got %q", a1.Type)
+		}
+	}
+}

--- a/internal/redfish/testdata/corpus/LICENSE
+++ b/internal/redfish/testdata/corpus/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2016-2024, Contributing Member(s) of Distributed Management Task
+Force, Inc.. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/internal/redfish/testdata/corpus/README.md
+++ b/internal/redfish/testdata/corpus/README.md
@@ -1,0 +1,53 @@
+# Redfish corpus — DMTF public-rackmount1
+
+## Provenance
+
+Upstream repo: https://github.com/DMTF/Redfish-Mockup-Server  
+Commit: `2d39eb14122337ceab0712a9610b1cd37c65f487`  
+License: BSD-3-Clause (see `LICENSE`)
+
+## What is vendored
+
+Only the subtree that gofish walks when beskar7 calls its 9 read methods
+(`GetSystemInfo`, `GetPowerState`, `GetNetworkAddresses`) against a single-system
+endpoint with `BasicAuth: true` (no SessionService handshake). The minimal-complete
+set was established empirically: write the test, run it, copy each 404'd resource,
+repeat until the reads pass.
+
+| File | Why included |
+|---|---|
+| `redfish/v1/index.json` | ServiceRoot — gofish's connect entry point |
+| `redfish/v1/odata/index.json` | `/redfish/v1/odata` — fetched by gofish during service-root parse |
+| `redfish/v1/Systems/index.json` | ComputerSystemCollection |
+| `redfish/v1/Systems/437XR1138R2/index.json` | The one ComputerSystem: Manufacturer/Model/SerialNumber/PowerState/Boot |
+| `redfish/v1/Systems/437XR1138R2/EthernetInterfaces/index.json` | EthernetInterfaceCollection (4 members) |
+| `redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/index.json` | Physical NIC 1 — has IPv4 + IPv6 + OEM block |
+| `redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890/index.json` | Physical NIC 2 — has VLAN flag + different MAC |
+| `redfish/v1/Systems/437XR1138R2/EthernetInterfaces/VLAN1/index.json` | Virtual VLAN interface |
+| `redfish/v1/Systems/437XR1138R2/EthernetInterfaces/ToManager/index.json` | Management NIC |
+
+## What is pruned
+
+Everything else (AccountService, CertificateService, Chassis, ComponentIntegrity,
+EventService, KeyService, Managers, Registries, TaskService, UpdateService,
+SessionService, `$metadata`) — none of these are fetched by beskar7's read-only
+interface surface. Vendoring them would add ~255 files / ~2 MB of irrelevant data
+that the test never touches.
+
+## How to refresh
+
+If the upstream mockup changes and you want to update the corpus:
+
+1. Re-clone or pull the upstream repo.
+2. Verify the system UUID is still `437XR1138R2` (or update the test constants).
+3. Copy the files listed in the table above verbatim — do not minimize fields,
+   the realism of the OEM blocks and extra enum values is the point.
+4. Update the commit SHA in this file.
+5. Run `go test ./internal/redfish/... -race` to confirm the corpus is still valid.
+
+## Sanitization note
+
+This is the DMTF *reference* mockup. It uses synthetic data (Contoso manufacturer,
+made-up serials/MACs). No real BMC identifiers are present. Any corpus contributed
+from real hardware must be scrubbed of serial numbers, asset tags, MACs, BMC
+hostnames, and private IP addresses before merging.

--- a/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/index.json
+++ b/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/index.json
@@ -1,0 +1,48 @@
+{
+    "@odata.type": "#EthernetInterface.v1_12_0.EthernetInterface",
+    "Id": "12446A3B0411",
+    "Name": "Ethernet Interface",
+    "Description": "System NIC 1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "EthernetInterfaceType": "Physical",
+    "LinkStatus": "LinkUp",
+    "PermanentMACAddress": "12:44:6A:3B:04:11",
+    "MACAddress": "12:44:6A:3B:04:11",
+    "SpeedMbps": 1000,
+    "FullDuplex": true,
+    "HostName": "web483",
+    "FQDN": "web483.contoso.com",
+    "IPv6DefaultGateway": "fe80::3ed9:2bff:fe34:600",
+    "NameServers": [
+        "names.contoso.com"
+    ],
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.10",
+            "SubnetMask": "255.255.252.0",
+            "AddressOrigin": "Static",
+            "Gateway": "192.168.0.1"
+        }
+    ],
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 64,
+            "AddressOrigin": "Static",
+            "AddressState": "Preferred"
+        }
+    ],
+    "TeamMode": "None",
+    "Links": {
+        "AffiliatedInterfaces": [
+            {
+                "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/VLAN1"
+            }
+        ]
+    },
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890/index.json
+++ b/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890/index.json
@@ -1,0 +1,45 @@
+{
+    "@odata.type": "#EthernetInterface.v1_12_0.EthernetInterface",
+    "Id": "12446A3B8890",
+    "Name": "Ethernet Interface",
+    "Description": "System NIC 2",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "EthernetInterfaceType": "Physical",
+    "LinkStatus": "LinkUp",
+    "PermanentMACAddress": "12:44:6A:3B:88:90",
+    "MACAddress": "AA:BB:CC:DD:EE:00",
+    "SpeedMbps": 1000,
+    "FullDuplex": true,
+    "HostName": "backup-web483",
+    "FQDN": "backup-web483.contoso.com",
+    "IPv6DefaultGateway": "fe80::3ed9:2bff:fe34:600",
+    "NameServers": [
+        "names.contoso.com"
+    ],
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.11",
+            "SubnetMask": "255.255.255.0",
+            "AddressOrigin": "Static",
+            "Gateway": "192.168.0.1"
+        }
+    ],
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e33",
+            "PrefixLength": 64,
+            "AddressOrigin": "Static",
+            "AddressState": "Preferred"
+        }
+    ],
+    "VLAN": {
+        "VLANEnable": true,
+        "VLANId": 101
+    },
+    "TeamMode": "None",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/ToManager/index.json
+++ b/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/ToManager/index.json
@@ -1,0 +1,55 @@
+{
+    "@odata.type": "#EthernetInterface.v1_12_0.EthernetInterface",
+    "Id": "ToManager",
+    "Name": "Host Ethernet Interface",
+    "Description": "Host Network Interface",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "InterfaceEnabled": true,
+    "PermanentMACAddress": "AA:BB:CC:DD:EE:FE",
+    "MACAddress": "AA:BB:CC:DD:EE:FE",
+    "SpeedMbps": 100,
+    "AutoNeg": true,
+    "FullDuplex": true,
+    "MTUSize": 1500,
+    "MaxIPv6StaticAddresses": 1,
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.20.56",
+            "SubnetMask": "255.255.255.0",
+            "AddressOrigin": "Static",
+            "Gateway": "192.168.20.1"
+        }
+    ],
+    "IPv6AddressPolicyTable": [
+        {
+            "Prefix": "::1/128",
+            "Precedence": 50,
+            "Label": 0
+        }
+    ],
+    "IPv6StaticAddresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e25",
+            "PrefixLength": 64
+        }
+    ],
+    "IPv6DefaultGateway": "fe80::1ec1:deff:fe6f:1e24",
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e25",
+            "PrefixLength": 64,
+            "AddressOrigin": "Static",
+            "AddressState": "Preferred"
+        }
+    ],
+    "Links": {
+        "HostInterface": {
+            "@odata.id": "/redfish/v1/Managers/BMC/HostInterfaces/1"
+        }
+    },
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/ToManager",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/VLAN1/index.json
+++ b/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/VLAN1/index.json
@@ -1,0 +1,52 @@
+{
+    "@odata.type": "#EthernetInterface.v1_12_0.EthernetInterface",
+    "Id": "VLAN1",
+    "Name": "Ethernet Interface",
+    "Description": "VLAN from System NIC 1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "EthernetInterfaceType": "Virtual",
+    "LinkStatus": "LinkUp",
+    "PermanentMACAddress": "12:44:6A:3B:04:11",
+    "MACAddress": "12:44:6A:3B:04:11",
+    "SpeedMbps": 1000,
+    "FullDuplex": true,
+    "HostName": "web483",
+    "FQDN": "web483.contoso.com",
+    "IPv6DefaultGateway": "fe80::3ed9:2bff:fe34:600",
+    "NameServers": [
+        "names.contoso.com"
+    ],
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.150.236",
+            "SubnetMask": "255.255.252.0",
+            "AddressOrigin": "Static",
+            "Gateway": "192.168.150.1"
+        }
+    ],
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 64,
+            "AddressOrigin": "Static",
+            "AddressState": "Preferred"
+        }
+    ],
+    "VLAN": {
+        "VLANEnable": true,
+        "VLANId": 1000
+    },
+    "TeamMode": "None",
+    "Links": {
+        "RelatedInterfaces": [
+            {
+                "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411"
+            }
+        ]
+    },
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/VLAN1",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/index.json
+++ b/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/index.json
@@ -1,0 +1,22 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "Name": "Ethernet Interface Collection",
+    "Description": "System NICs on Contoso Servers",
+    "Members@odata.count": 4,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/VLAN1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/ToManager"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/index.json
+++ b/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/437XR1138R2/index.json
@@ -1,0 +1,162 @@
+{
+    "@odata.type": "#ComputerSystem.v1_22_0.ComputerSystem",
+    "Id": "437XR1138R2",
+    "Name": "WebFrontEnd483",
+    "SystemType": "Physical",
+    "AssetTag": "Chicago-45Z-2381",
+    "Manufacturer": "Contoso",
+    "Model": "3500",
+    "SubModel": "RX",
+    "SKU": "8675309",
+    "SerialNumber": "437XR1138R2",
+    "PartNumber": "224071-J23",
+    "Description": "Web Front End node",
+    "UUID": "38947555-7742-3448-3784-823347823834",
+    "HostName": "web483",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollup": "OK"
+    },
+    "HostingRoles": [
+        "ApplicationServer"
+    ],
+    "IndicatorLED": "Off",
+    "PowerState": "On",
+    "Boot": {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Cd",
+            "Usb",
+            "Hdd",
+            "BiosSetup",
+            "Utilities",
+            "Diags",
+            "SDCard",
+            "UefiTarget"
+        ],
+        "BootSourceOverrideMode": "UEFI",
+        "UefiTargetBootSourceOverride": "/0x31/0x33/0x01/0x01"
+    },
+    "TrustedModules": [
+        {
+            "FirmwareVersion": "1.13b",
+            "InterfaceType": "TPM1_2",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            }
+        }
+    ],
+    "Oem": {
+        "Contoso": {
+            "@odata.type": "#Contoso.ComputerSystem",
+            "ProductionLocation": {
+                "FacilityName": "PacWest Production Facility",
+                "Country": "USA"
+            }
+        },
+        "Chipwise": {
+            "@odata.type": "#Chipwise.ComputerSystem",
+            "Style": "Executive"
+        }
+    },
+    "BootProgress": {
+        "LastState": "OSRunning",
+        "LastStateTime": "2021-03-13T04:14:13+06:00",
+        "LastBootTimeSeconds": 676
+    },
+    "LastResetTime": "2021-03-13T04:02:57+06:00",
+    "BiosVersion": "P79 v1.45 (12/06/2017)",
+    "ProcessorSummary": {
+        "Count": 2,
+        "Model": "Multi-Core Intel(R) Xeon(R) processor 7xxx Series",
+        "LogicalProcessorCount": 16,
+        "CoreCount": 8,
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        }
+    },
+    "MemorySummary": {
+        "TotalSystemMemoryGiB": 96,
+        "TotalSystemPersistentMemoryGiB": 0,
+        "MemoryMirroring": "None",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollup": "OK"
+        }
+    },
+    "Bios": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Bios"
+    },
+    "SecureBoot": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/SecureBoot"
+    },
+    "Processors": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors"
+    },
+    "Memory": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces"
+    },
+    "SimpleStorage": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices"
+    },
+    "GraphicsControllers": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/GraphicsControllers"
+    },
+    "USBControllers": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/USBControllers"
+    },
+    "Certificates": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Certificates"
+    },
+    "VirtualMedia": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/VirtualMedia"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1U"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ]
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/437XR1138R2/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PushPowerButton"
+            ]
+        },
+        "Oem": {
+            "#Contoso.Reset": {
+                "target": "/redfish/v1/Systems/437XR1138R2/Oem/Contoso/Actions/Contoso.Reset"
+            }
+        }
+    },
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/index.json
+++ b/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/Systems/index.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "Name": "Computer System Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Systems",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/index.json
+++ b/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/index.json
@@ -1,0 +1,63 @@
+{
+    "@odata.type": "#ServiceRoot.v1_16_1.ServiceRoot",
+    "Id": "RootService",
+    "Name": "Root Service",
+    "RedfishVersion": "1.15.0",
+    "UUID": "92384634-2938-2342-8820-489239905423",
+    "ProtocolFeaturesSupported": {
+        "ExpandQuery": {
+            "ExpandAll": true,
+            "Levels": true,
+            "MaxLevels": 6,
+            "Links": true,
+            "NoLinks": true
+        },
+        "SelectQuery": false,
+        "FilterQuery": false,
+        "OnlyMemberQuery": true,
+        "ExcerptQuery": true
+    },
+    "Systems": {
+        "@odata.id": "/redfish/v1/Systems"
+    },
+    "Chassis": {
+        "@odata.id": "/redfish/v1/Chassis"
+    },
+    "Managers": {
+        "@odata.id": "/redfish/v1/Managers"
+    },
+    "Tasks": {
+        "@odata.id": "/redfish/v1/TaskService"
+    },
+    "SessionService": {
+        "@odata.id": "/redfish/v1/SessionService"
+    },
+    "AccountService": {
+        "@odata.id": "/redfish/v1/AccountService"
+    },
+    "EventService": {
+        "@odata.id": "/redfish/v1/EventService"
+    },
+    "Registries": {
+        "@odata.id": "/redfish/v1/Registries"
+    },
+    "UpdateService": {
+        "@odata.id": "/redfish/v1/UpdateService"
+    },
+    "CertificateService": {
+        "@odata.id": "/redfish/v1/CertificateService"
+    },
+    "KeyService": {
+        "@odata.id": "/redfish/v1/KeyService"
+    },
+    "Links": {
+        "Sessions": {
+            "@odata.id": "/redfish/v1/SessionService/Sessions"
+        }
+    },
+    "ComponentIntegrity": {
+        "@odata.id": "/redfish/v1/ComponentIntegrity"
+    },
+    "@odata.id": "/redfish/v1/",
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/odata/index.json
+++ b/internal/redfish/testdata/corpus/public-rackmount1/redfish/v1/odata/index.json
@@ -1,0 +1,71 @@
+{
+    "@odata.context": "/redfish/v1/$metadata",
+    "value": [
+        {
+            "name": "Service",
+            "kind": "Singleton",
+            "url": "/redfish/v1/"
+        },
+        {
+            "name": "Systems",
+            "kind": "Singleton",
+            "url": "/redfish/v1/Systems"
+        },
+        {
+            "name": "Chassis",
+            "kind": "Singleton",
+            "url": "/redfish/v1/Chassis"
+        },
+        {
+            "name": "Managers",
+            "kind": "Singleton",
+            "url": "/redfish/v1/Managers"
+        },
+        {
+            "name": "TaskService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/TaskService"
+        },
+        {
+            "name": "AccountService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/AccountService"
+        },
+        {
+            "name": "SessionService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/SessionService"
+        },
+        {
+            "name": "EventService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/EventService"
+        },
+        {
+            "name": "Registries",
+            "kind": "Singleton",
+            "url": "/redfish/v1/Registries"
+        },
+        {
+            "name": "CertificateService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/CertificateService"
+        },
+        {
+            "name": "KeyService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/KeyService"
+        },
+        {
+            "name": "UpdateService",
+            "kind": "Singleton",
+            "url": "/redfish/v1/UpdateService"
+        },
+        {
+            "name": "Sessions",
+            "kind": "Singleton",
+            "url": "/redfish/v1/SessionService/Sessions"
+        }
+    ],
+    "@Redfish.Copyright": "Copyright 2014-2023 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}


### PR DESCRIPTION
## What

Adds a **read-robustness test lane** that exercises the real `gofish` client
against a **captured DMTF public Redfish mockup tree** (`public-rackmount1`),
served as a static HTTP tree from `httptest`. Complements — does not replace —
the programmatic fake in `internal/redfishmock/`.

## Why

beskar7's Redfish surface is the 9-method `internal/redfish/client.go` interface.
Today the controller's *read* paths (`GetSystemInfo`, `GetPowerState`, and the
fragile `GetNetworkAddresses` EthernetInterfaces→NetworkInterfaces walk) only ever
parse our own hand-generated JSON. Real Redfish trees carry OEM blocks, extra
fields, richer link graphs, and quirks our mock never emits. This corpus points
the real gofish client at real DMTF data and asserts our wrappers parse it
correctly — catching parse/navigation regressions the fake can't.

The fake stays for the **stateful** flows (claim → `SetBootSourcePXE` → power →
read-back-and-assert) that a static tree can't model. Two complementary lanes:
**corpus = read/parse robustness; fake = state machine.**

## What's asserted (verbatim from the corpus JSON, not invented)

| Method | Assertion |
|---|---|
| `GetSystemInfo` | Manufacturer `Contoso`, Model `3500`, SerialNumber `437XR1138R2` |
| `GetPowerState` | `On` |
| `GetNetworkAddresses` | NIC `12446A3B0411` → `192.168.0.10` / `12:44:6A:3B:04:11`; NIC `12446A3B8890` → `192.168.0.11` / `AA:BB:CC:DD:EE:00` |

That second NIC is a deliberate realism case: its live `MACAddress`
(`AA:BB:CC:DD:EE:00`) differs from both its `PermanentMACAddress` and its
interface Id — exactly the kind of real-world divergence the corpus exists to
exercise.

## Corpus footprint & provenance

- **9 JSON files (~76 KB)** — the minimal-complete set gofish actually GETs for
  the three read methods under `BasicAuth: true` (ServiceRoot → `/odata` →
  Systems collection → the one System → EthernetInterfaces collection + 4
  members). No SessionService/AccountService/TaskService/Chassis/`$metadata`.
- **Verbatim** from DMTF `Redfish-Mockup-Server` `public-rackmount1` at commit
  `2d39eb1` — confirmed byte-for-byte identical to upstream (no field edits).
- **BSD-3-Clause** (`testdata/corpus/LICENSE`); `testdata/corpus/README.md`
  records provenance, the include/prune rationale, refresh steps, and a
  sanitization note for any future *real-hardware* corpus contributions.

## Test infra

- Pure Go test (`internal/redfish/corpus_robustness_test.go`); a ~40-line
  test-only static handler (strip `/redfish/v1` → serve `<path>/index.json`,
  path-traversal-guarded, 404 on miss). Reuses the existing
  `NewClientWithHTTPClient` + `httptest.NewTLSServer` harness.
- Runs under `make test`; **no new CI job**. `testdata/` is excluded from the
  binary by Go convention, so the handler never ships.

## Gates

`go test ./internal/redfish/... -race` green (incl. all pre-existing tests);
`golangci-lint run --timeout=5m` 0 issues; `gofmt` clean.