### PR TITLE
docs(d014): ProviderID / Node-association contract (D-014 P1)

### DIFF
--- a/docs/beskar7machine.md
+++ b/docs/beskar7machine.md
@@ -85,7 +85,43 @@ The `infrastructure.cluster.x-k8s.io/force-release: "true"` annotation skips the
 
 ## ProviderID format
 
-The provider ID is `b7://<namespace>/<name>`. The parser uses `strings.CutPrefix` + `strings.SplitN(rest, "/", 2)` and rejects empty segments and multi-segment names. See `controllers/beskar7machine_controller.go:parseProviderID`.
+The provider ID is `b7://<namespace>/<name>`, where `<name>` is the **PhysicalHost** name (the controller builds it from `providerID(physicalHost.Namespace, physicalHost.Name)`). The parser uses `strings.CutPrefix` + `strings.SplitN(rest, "/", 2)` and rejects empty segments and multi-segment names. See `controllers/beskar7machine_controller.go:parseProviderID`.
+
+## ProviderID & Node association
+
+Setting `Beskar7Machine.Spec.ProviderID` marks the **infrastructure** ready, which advances the CAPI `Machine` to `Provisioned`. It does **not**, on its own, advance the Machine to `Running`. CAPI reaches `Running` only after it associates the Machine with a Kubernetes Node, and it does that by matching the Machine's `spec.providerID` against the Node's `spec.providerID` — **the two must be exactly equal**.
+
+A freshly provisioned node's kubelet, left to its defaults, registers a ProviderID that does **not** match `b7://...` (k3s, for example, uses `k3s://<hostname>`). So you must tell the node's kubelet to register with the value Beskar7 assigns:
+
+```
+b7://<namespace>/<physicalhost-name>
+```
+
+You set this in the **per-machine bootstrap config** (the `#cloud-config` / `KubeadmConfig` referenced by `Machine.Spec.Bootstrap.DataSecretName`), because the value is only known once you know which PhysicalHost the Machine uses.
+
+**k3s** (proven path — see [`examples/kairos-k3s-node.yaml`](../examples/kairos-k3s-node.yaml)):
+
+```yaml
+k3s:
+  enabled: true
+  args:
+    - "--kubelet-arg=provider-id=b7://<namespace>/<host-name>"
+```
+
+**kubeadm** (CAPI `KubeadmConfig` / `KubeadmConfigTemplate`):
+
+```yaml
+initConfiguration:    # use joinConfiguration for worker / secondary control-plane nodes
+  nodeRegistration:
+    kubeletExtraArgs:
+      provider-id: "b7://<namespace>/<host-name>"
+```
+
+**Other distros** (k0s, plain kubelet): set the kubelet `--provider-id` flag to the same value via your distro's kubelet-args mechanism.
+
+If you skip this, the node still comes up and is `Ready`, but the CAPI `Machine` stays at `Provisioned` and never reaches `Running` (the Node is never bound). See [Troubleshooting → CAPI Machine stuck at Provisioned](troubleshooting.md#12-capi-machine-stuck-at-provisioned-never-reaches-running-node-not-associated).
+
+> **Scaled deployments:** this manual wiring works when you author the per-machine bootstrap config and therefore know which PhysicalHost the Machine will use (a single node, or hosts pinned to specific machines). A templated `MachineDeployment` that claims hosts from a pool cannot pin a per-host ProviderID in one shared template; automatic provision-time delivery is planned future work.
 
 ## Example
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -525,6 +525,44 @@ resources:
     memory: 128Mi
 ```
 
+### 12. CAPI Machine stuck at `Provisioned`, never reaches `Running` (Node not associated)
+
+**Symptom:** Beskar7 finishes provisioning — `Beskar7Machine.status.phase` is `Provisioned`, `ProviderID` is set, and the workload node even shows up in the workload cluster's `kubectl get nodes` — but the **CAPI `Machine`** (not the `Beskar7Machine`) never advances from `Provisioned` to `Running`.
+
+```bash
+# The CAPI Machine, not the Beskar7Machine:
+kubectl get machine <machine-name> -o jsonpath='{.status.phase}'   # shows: Provisioned (not Running)
+kubectl get machine <machine-name> -o jsonpath='{.spec.providerID}' # b7://<namespace>/<host-name>
+
+# On the WORKLOAD cluster — what ProviderID did the node self-register?
+kubectl --kubeconfig <workload.kubeconfig> get node <node> -o jsonpath='{.spec.providerID}'
+# If this is e.g. "k3s://<hostname>" instead of "b7://<namespace>/<host-name>", that is the bug.
+```
+
+**Cause:** CAPI marks a `Machine` `Running` only after it matches the Machine's `spec.providerID` to a Node's `spec.providerID` (they must be **equal**). Beskar7 stamps `b7://<namespace>/<host-name>` on the Machine, but the node's kubelet, left to its defaults, self-registers a different value (k3s uses `k3s://<hostname>`). The mismatch means CAPI never associates the Node, so the Machine never reaches `Running` — even though the node itself is healthy and `Ready`.
+
+**Solution:** Tell the node's kubelet to register with the exact ProviderID Beskar7 assigns — `b7://<namespace>/<host-name>` (the `<host-name>` is the **PhysicalHost** name) — via the per-machine bootstrap config. For k3s, add to the `k3s.args` in the bootstrap `#cloud-config`:
+
+```yaml
+k3s:
+  enabled: true
+  args:
+    - "--kubelet-arg=provider-id=b7://<namespace>/<host-name>"
+```
+
+For kubeadm (CAPI `KubeadmConfig`/`KubeadmConfigTemplate`), set it under `nodeRegistration`:
+
+```yaml
+initConfiguration:    # (use joinConfiguration for worker/secondary nodes)
+  nodeRegistration:
+    kubeletExtraArgs:
+      provider-id: "b7://<namespace>/<host-name>"
+```
+
+For other distros (k0s, plain kubelet), set the kubelet's `--provider-id` flag to the same value by your distro's mechanism. See [docs/beskar7machine.md → ProviderID & Node association](beskar7machine.md#providerid--node-association) for the full contract.
+
+> **Scaled deployments:** this works when you author the per-machine bootstrap config and know which PhysicalHost the Machine will use (e.g. a single node, or hosts pinned to specific machines). A templated `MachineDeployment` that claims hosts from a pool can't yet pin the per-host ProviderID in a shared template — automatic provision-time delivery is planned (see the D-014 design).
+
 ## Getting Help
 
 If you can't resolve your issue:

--- a/examples/kairos-k3s-node.yaml
+++ b/examples/kairos-k3s-node.yaml
@@ -61,14 +61,15 @@ stringData:
 # native k3s integration. Adjust tls-san and node-ip to match your host's
 # provisioning-network address.
 #
-# Note on ProviderID / node association: k3s sets the Kubernetes Node's
-# ProviderID to "k3s://<nodename>" by default. CAPI matches the Machine to the
-# Node by ProviderID. To auto-associate, add
-#   --kubelet-arg=provider-id=b7://<namespace>/<host-name>
-# to the k3s args below. Without it, CAPI cannot match the Node to the Machine
-# and the Machine stays in Provisioned (infra ready) but the CAPI Machine never
-# advances to Running (node associated). This does not prevent the node from
-# working — it only affects the CAPI Machine status.
+# ProviderID / node association (REQUIRED for the CAPI Machine to reach Running):
+# k3s defaults the Node's ProviderID to "k3s://<nodename>", but Beskar7 stamps
+#   b7://<namespace>/<host-name>
+# on the Machine (the <host-name> is the PhysicalHost name below). CAPI binds the
+# Machine to the Node by matching these, so the k3s args MUST set the kubelet
+# provider-id to Beskar7's value (done by default below). Omit it and the node
+# still comes up Ready, but the CAPI Machine stays at Provisioned and never
+# advances to Running (Node never associated). See docs/beskar7machine.md
+# (ProviderID & Node association) and docs/troubleshooting.md #12.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -101,8 +102,9 @@ stringData:
       args:
         - "--tls-san=<node-ip>"
         - "--node-ip=<node-ip>"
-        # Uncomment to let CAPI auto-associate the Node with this Machine:
-        # - "--kubelet-arg=provider-id=b7://<namespace>/<host-name>"
+        # Required so CAPI associates the Node with this Machine (Machine -> Running).
+        # <host-name> is the PhysicalHost name defined below; <namespace> matches it.
+        - "--kubelet-arg=provider-id=b7://<namespace>/<host-name>"
 
 ---
 # PhysicalHost — one per bare-metal server.


### PR DESCRIPTION
## What

Documents the **ProviderID-match contract** so operators can take a provisioned
node all the way to a CAPI `Machine: Running` (and thus `Cluster: Available`).
**Docs only — no code, no contract bump.** This is **P1** of the D-014 design
(`.claude/context/D014-DESIGN.md`).

## Why

On the dome bare-metal e2e the node came up `Ready` but the CAPI `Machine` never
left `Provisioned`. Root cause: CAPI binds a Machine to its Node by **ProviderID
equality**. Beskar7 stamps `b7://<namespace>/<physicalhost-name>`
(`providerID(physicalHost.Namespace, physicalHost.Name)`), but a node's kubelet
self-registers a different value by default (k3s → `k3s://<hostname>`). The
mismatch means the Node is never associated, so the Machine stays at
`Provisioned` even though the node is healthy.

## Changes

- **`docs/beskar7machine.md`** — new **"ProviderID & Node association"** section:
  the exact value to register, per-distro kubelet-arg snippets (**k3s** proven,
  **kubeadm** via `nodeRegistration.kubeletExtraArgs`, **k0s**/generic), and the
  `Provisioned`-vs-`Running` consequence. Also clarifies `<name>` is the
  **PhysicalHost** name.
- **`docs/troubleshooting.md`** — new **issue #12**, "CAPI Machine stuck at
  `Provisioned`, never reaches `Running`", with the diagnosis (compare
  Machine.spec.providerID vs. the workload Node's providerID) and the fix.
- **`examples/kairos-k3s-node.yaml`** — the `--kubelet-arg=provider-id=...` line
  is now **default-on** (was commented out, which reproduced the exact gap).

## Scope / honesty

Covers the **explicitly-authored per-machine** case (single node, or hosts pinned
to specific machines) — which is what was validated on real hardware. A templated
`MachineDeployment` claiming from a host pool **cannot** pin a per-host ProviderID
in one shared template; that needs automatic provision-time delivery (**D-014
P2**, a contract bump) and is noted as future work, **not** documented as working.

## Validation

Example YAML parses (8 docs); cross-doc anchor links resolve; no code touched.