### PR TITLE
chore(release): v0.4.0-alpha.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,22 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [v0.4.0-alpha.8] - 2026-07-21
+
+The "contract v4.1 + hardening" release: adds the provision-failed fast-fail callback so a failed Phase-2 deploy is surfaced immediately instead of waiting out the deployment timeout, documents the ProviderID/Node-association contract that takes a provisioned node all the way to a CAPI `Machine: Running`, and adds two regression guards (a Redfish read-robustness corpus and a structural RBAC drift guard).
+
 ### Added
 - **`POST /api/v1/provision-failed/{namespace}/{hostName}` callback endpoint** (contract v4.1) — bearer-gated HTTPS endpoint on `:8082`; the inspector calls it when Phase 2 fails (image fetch, digest verify, disk write, or `COS_OEM` inject) before exiting, reporting the failure promptly instead of waiting out `--deployment-timeout` (up to 20 min). The `PhysicalHost` transitions `StateDeploying → StateError` immediately; the `Beskar7Machine` is marked `FailureReason=DeploymentFailed` with the sanitized inspector reason in `FailureMessage`. Backward-compatible: a v4 controller without the endpoint returns 404, which the v4.1 inspector tolerates. Implemented in `controllers/provision_failed_handler.go`; route registered in `SetupCallbackServer`.
 - **`DeploymentFailed` failure reason** — new `FailureReason` constant on `Beskar7Machine` (`DeploymentFailedReason = "DeploymentFailed"`), distinct from `DeploymentTimedOut` (timeout) and `PhysicalHostError` (Redfish/BMC-level error). The `StateError` handler in `Beskar7MachineReconciler` attributes the reason by inspecting the `PhysicalHost.Status.ErrorMessage` prefix set by the provision-failed handler.
 - **Inspector contract v4.1** — `docs/inspector-contract.md` bumped to v4.1; §4.5 documents the new `/provision-failed` endpoint; §2 provisioning sequence updated with the fast-fail path; §11 open item on provisioning-failure recovery closed.
+
+### Docs
+- **ProviderID / Node-association contract (D-014 P1)** (#128) — new "ProviderID & Node association" section in `docs/beskar7machine.md` with per-distro `kubelet` `--provider-id` snippets (k3s proven, kubeadm, k0s/generic), a troubleshooting entry ("CAPI Machine stuck at `Provisioned`, never reaches `Running`"), and the `provider-id` line made default-on in `examples/kairos-k3s-node.yaml`. Covers the explicitly-authored per-machine case; the scaled `MachineDeployment` case is noted as future work (D-014 P2).
+
+### Internal
+- **Structural RBAC drift guard** (SEC-2, #129) — `test/rbac` asserts the hand-authored RBAC copies (Helm chart both `watchNamespaces` branches + the `config/rbac/namespace-scoped/` kustomize overlay) carry the same `(apiGroup, resource, verb)` rule-set as the controller-gen `config/rbac/role.yaml`, failing CI on either over- or under-grant. CI installs `helm` in the unit-test job so the chart checks run rather than skip.
+- **Redfish read-robustness corpus** (TEST-1, #127) — vendored a curated subset of the DMTF `public-rackmount1` mockup under `internal/redfish/testdata/corpus/` plus a static handler and `corpus_robustness_test.go` that points the real gofish client at it, exercising the `GetSystemInfo`/`GetPowerState`/`GetNetworkAddresses` read paths. Complements (does not replace) the stateful `internal/redfishmock` fake.
+- **`defaultCloseTimeout` const** (MEDIUM-2, #126) — extracted the Redfish `Close`/logout timeout literal to a named const in `internal/redfish/gofish_client.go`; no behavior change.
 
 ## [v0.4.0-alpha.7] - 2026-06-07
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.0-alpha.7
+VERSION ?= v0.4.0-alpha.8
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0-alpha.7
-appVersion: "v0.4.0-alpha.7"
+version: 0.4.0-alpha.8
+appVersion: "v0.4.0-alpha.8"
 keywords:
   - cluster-api
   - infrastructure

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -273,8 +273,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.0-alpha.N`; bump N for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.0-alpha.7
-   git push origin v0.4.0-alpha.7
+   git tag v0.4.0-alpha.8
+   git push origin v0.4.0-alpha.8
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.7`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.8`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ The external SAN is added to both certificate paths: the cert-manager `Certifica
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.7/beskar7-manifests-v0.4.0-alpha.7.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.8/beskar7-manifests-v0.4.0-alpha.8.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -171,7 +171,7 @@ Memory Limit = (Host Count × 0.5MB) + (Webhook Concurrency × 10MB) + 100MB (ba
 Configure reconciliation intervals based on your needs:
 
 ```yaml
-# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.7.
+# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.8.
 args:
 - --leader-elect=true
 - --metrics-bind-address=:8443

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Operators
 
-This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.7. Each item is anchored to source code so you can verify the claim.
+This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.8. Each item is anchored to source code so you can verify the claim.
 
 If you are looking for hardening recommendations, see [Configuration](configuration.md). For RBAC details, see [RBAC Hardening](rbac-hardening.md). For incident debugging, see [Troubleshooting](troubleshooting.md).
 

--- a/examples/minimal-test-cluster.yaml
+++ b/examples/minimal-test-cluster.yaml
@@ -1,6 +1,6 @@
 # Minimal Test Cluster Example
 #
-# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.7
+# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.8
 # inspection workflow. NOT a working cluster — bring this up first to verify the
 # inspection round-trip, then graduate to examples/kairos-k3s-node.yaml.
 #

--- a/examples/security/README.md
+++ b/examples/security/README.md
@@ -1,6 +1,6 @@
 # Beskar7 Security Examples
 
-Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.7 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
+Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.8 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
 
 ## What's actually enforced
 

--- a/examples/security/development.yaml
+++ b/examples/security/development.yaml
@@ -1,4 +1,4 @@
-# Development-style security configuration for Beskar7 v0.4.0-alpha.7.
+# Development-style security configuration for Beskar7 v0.4.0-alpha.8.
 #
 # Loosens TLS verification for self-signed BMC certs typical in lab setups.
 # Do NOT use this configuration in production.

--- a/examples/security/production.yaml
+++ b/examples/security/production.yaml
@@ -1,4 +1,4 @@
-# Production-style security configuration for Beskar7 v0.4.0-alpha.7.
+# Production-style security configuration for Beskar7 v0.4.0-alpha.8.
 #
 # This file demonstrates the enforced security knobs only — the
 # beskar7-security-policy ConfigMap and the various "security framework"


### PR DESCRIPTION
## What

Cuts **v0.4.0-alpha.8**. Bumps `Makefile` VERSION, `charts/beskar7/Chart.yaml` (`version` + `appVersion`), and the doc/example version references; promotes the `CHANGELOG` `[Unreleased]` section into a dated `[v0.4.0-alpha.8]` entry.

## Scope — the 5 PRs merged since alpha.7

| PR | Summary |
|---|---|
| #125 | contract **v4.1** `/provision-failed` fast-fail callback (D-016) |
| #126 | extract `defaultCloseTimeout` const (MEDIUM-2) |
| #127 | DMTF `public-rackmount1` Redfish read-robustness corpus (TEST-1) |
| #128 | ProviderID / Node-association contract docs (D-014 P1) |
| #129 | structural RBAC drift guard (SEC-2) |

## Not in this PR

- **The publishing tag.** `release.yml` + `helm-publish.yml` trigger on `v*` tag push (container image + Helm chart publish). Per the alpha.7 precedent, the annotated `v0.4.0-alpha.8` tag is pushed **after** this merges — that step is intentionally left to the maintainer.
- `make release-manifests` output (`beskar7-manifests-v0.4.0-alpha.8.yaml`) is gitignored and generated at release time.

## Validation

- `helm lint charts/beskar7` — 0 failed.
- `go test ./test/rbac/...` — drift guard still green (Chart.yaml version bump doesn't touch RBAC rules).
- Repo-wide sweep confirms no stray `alpha.7` references remain outside historical CHANGELOG entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)