### PR TITLE
docs: declare v1beta1 API frozen for GA (D-018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.0-alpha.6  
-**Status:** Alpha - Under active development. API may still change before v0.4.0 GA.  
+**Version:** v0.4.0-alpha.8  
+**Status:** Alpha (pre-GA). The `v1beta1` API is **frozen** — no further breaking changes; the schema evolves **additive-only** until a future `v1beta2` (introduced with a conversion webhook) is needed.  
 **Breaking Changes:** v0.4.0 is NOT compatible with v0.3.x ([see CHANGELOG](CHANGELOG.md))
 
 ## Installation


### PR DESCRIPTION
## What

Declares the `v1beta1` API **frozen** for the v0.4.0 GA, per **D-018** (ratified). Updates the README status line and fixes the stale version (`alpha.6` → `alpha.8`).

## Context

The final pre-freeze breaking changes landed in #132 (removed dead `configurationURL` + `RedfishConnectionInfo`, normalized `caBundleSecretRef` → string, `int`→`int32`). The schema is now frozen — **additive-only** until a future `v1beta2` (introduced with a conversion webhook) is needed.

This is deliberately **not** "v1beta1 forever": beskar7's status surface still uses CAPI's v1beta1 helper types (`clusterv1.Conditions`, `FailureDomains`) that CAPI superseded in v1beta2 and is sunsetting ~April 2027, so a `v1beta2` + conversion is eventually inevitable — the migration happens there, with conversion, not days before GA.

## Remaining Gate-2 docs work (not in this PR)

`docs/api-reference.md` drift reconciliation (missing `targetImageDigest`/`targetDisk`/`staticIP`, kexec leakage, stale token TTL, missing `Deploying` state) — a separate tech-writer pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)