### PR TITLE
api(v1beta1): remove dead MachineProvisionedCondition constant

### DIFF
--- a/api/v1beta1/beskar7machine_types.go
+++ b/api/v1beta1/beskar7machine_types.go
@@ -11,8 +11,6 @@ const (
 	// PhysicalHostAssociatedCondition indicates whether the Beskar7Machine has
 	// successfully associated with a PhysicalHost.
 	PhysicalHostAssociatedCondition clusterv1.ConditionType = "PhysicalHostAssociated"
-	// MachineProvisionedCondition indicates whether the machine has been provisioned
-	MachineProvisionedCondition clusterv1.ConditionType = "MachineProvisioned"
 	// BootstrapDataReadyCondition indicates the bootstrap data secret named by
 	// Machine.Spec.Bootstrap.DataSecretName is present and the per-host bootstrap
 	// URL has been signaled to the PhysicalHost.


### PR DESCRIPTION
## What

Removes the `MachineProvisionedCondition` constant (`clusterv1.ConditionType = "MachineProvisioned"`) from `api/v1beta1/beskar7machine_types.go`.

## Why

It was **declared but never `Set`** by any reconciler — verified zero non-declaration references across the codebase (incl. tests). An operator scripting a wait against that condition type would wait forever. The provider signals infrastructure readiness through `InfrastructureReady` + `Status.Ready` + `Status.Initialization.Provisioned` (the CAPI v1beta2 status contract). Removing the dead condition aligns with the **latest CAPI api/model** and the repo's "no dead code" rule.

## Not a schema change

Condition *types* are runtime values, not part of the CRD OpenAPI schema — `make manifests` produces no diff (verified). This is a Go-symbol removal only, done now while still pre-GA.

Doc references to the condition (`architecture.md`, `beskar7machine.md`, the `api-reference.md` note) are cleaned up in the docs reconciliation pass, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)