### PR TITLE
docs: sweep removed kexec/v0.3 model from docs + examples (GA readiness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Changed
 - **BREAKING (API): v1beta1 pre-freeze cleanup toward v0.4.0 GA** — removed the dead `Beskar7Machine.Spec.configurationURL` field (consumed nowhere); normalized `PhysicalHost.Spec.redfishConnection.caBundleSecretRef` from an object (`{name: <secret>}`) to a bare `string`, matching the sibling `credentialsSecretRef`; changed `Beskar7Machine.Spec.hardwareRequirements` (`minCPUCores`/`minMemoryGB`/`minDiskGB`) and the `PhysicalHost` inspection ints (`cores`/`threads`/`sizeGB`) from `int` to `int32` (Kubernetes API convention); removed the dead `RedfishConnectionInfo` Go type; and corrected the `inspectionImageURL` field description (it is the base URL under which `vmlinuz`/`initrd.img` are served, not an iPXE boot script). **Action required:** any existing CR using `configurationURL` or the object-form `caBundleSecretRef` must be updated. Part of the API-stability freeze work.
 
+### Removed
+- **`MachineProvisionedCondition` constant** — removed from `api/v1beta1/beskar7machine_types.go`. It was declared but never set by any reconciler (verified: zero non-declaration references), so a caller scripting against it would wait forever. Use `InfrastructureReady`, `Status.Ready`, and `Status.Initialization.Provisioned` instead. Not a CRD-schema change (condition types are runtime values, not schema); no `make manifests` diff.
+
 ## [v0.4.0-alpha.8] - 2026-07-21
 
 The "contract v4.1 + hardening" release: adds the provision-failed fast-fail callback so a failed Phase-2 deploy is surfaced immediately instead of waiting out the deployment timeout, documents the ProviderID/Node-association contract that takes a provisioned node all the way to a CAPI `Machine: Running`, and adds two regression guards (a Redfish read-robustness corpus and a structural RBAC drift guard).

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -2,20 +2,20 @@
 
 > **Audience:** Operators
 
-This page covers Beskar7 features beyond the basic "register a host, claim a host" flow. The v0.3 `RemoteConfig`/`PreBakedISO`/`UefiTargetBootSourceOverride` approaches were removed in v0.4 — the only provisioning path now is iPXE network boot to an inspection image, followed by kexec into the target OS.
+This page covers Beskar7 features beyond the basic "register a host, claim a host" flow. The v0.3 `RemoteConfig`/`PreBakedISO`/`UefiTargetBootSourceOverride` approaches were removed in v0.4 — the only provisioning path now is iPXE network boot to an inspection image, which writes a digest-pinned whole-disk image to the target disk and injects a per-host cloud-config into the image's `COS_OEM` partition before rebooting (no `kexec`; see [Architecture](architecture.md#inspection-workflow) and `docs/inspector-contract.md`).
 
 ## Bootstrap data flow
 
-Beskar7 honours the CAPI bootstrap-provider contract: every `Beskar7Machine` requires its owning `Machine` to expose a `Spec.Bootstrap.DataSecretName`. The Secret's `value` key holds the user-data the target OS consumes (cloud-init, ignition, or whatever your bootstrap provider produces).
+Beskar7 honours the CAPI bootstrap-provider contract: every `Beskar7Machine` requires its owning `Machine` to expose a `Spec.Bootstrap.DataSecretName`. The Secret's `value` key holds the user-data the host applies — and because the inspector writes those bytes byte-verbatim into the target image's `COS_OEM` partition (never transcoding them, decision D-014), the value **must already be a valid Kairos `#cloud-config`**. See `examples/kairos-k3s-node.yaml` for a proven Kairos k3s cloud-config.
 
 End-to-end:
 
-1. The bootstrap provider (e.g. `kubeadm` via `KubeadmConfig` or `KubeadmConfigTemplate`) writes a Secret in the workload namespace with key `value`.
+1. The bootstrap provider (e.g. a hand-authored Kairos `#cloud-config` Secret, or a Kairos-aware bootstrap provider) writes a Secret in the workload namespace with key `value`.
 2. The `Beskar7Machine` reconciler reads `Machine.Spec.Bootstrap.DataSecretName` to confirm the Secret exists. It does NOT read the bytes — that's the manager's bootstrap GET endpoint's job.
 3. The reconciler computes the deterministic per-host URL `<--bootstrap-url-base>/api/v1/bootstrap/<ns>/<host>` and signals it to the PhysicalHost via the `infrastructure.cluster.x-k8s.io/bootstrap-url` annotation. The PhysicalHost reconciler persists it to `Status.Bootstrap.URL`.
-4. The reconciler mints a per-host bearer token (`internal/auth/token.go`), stores the plaintext in a per-host Secret named `<host>-bootstrap-token`, and signals the SHA-256 hash + 30-minute lifetime to the PhysicalHost via `infrastructure.cluster.x-k8s.io/bootstrap-token`. The PhysicalHost reconciler persists the hash and lifetime to `Status.Bootstrap.{TokenHash,IssuedAt,ExpiresAt}`.
-5. The iPXE infrastructure renders the URL and the plaintext token into the kernel cmdline (see [iPXE Setup](ipxe-setup.md)).
-6. After kexec into the target OS, cloud-init / ignition fetches `https://<manager>:8082/api/v1/bootstrap/<ns>/<host>` with `Authorization: Bearer <plaintext>`. The manager validates the token (`controllers/inspection_handler.go:newBearerTokenVerifier`), walks `PhysicalHost → ConsumerRef → Beskar7Machine → owner Machine → Spec.Bootstrap.DataSecretName → Secret`, and serves `secret.data["value"]` with `Cache-Control: no-store`.
+4. The reconciler mints a per-host bearer token (`internal/auth/token.go`), stores the plaintext in a per-host Secret named `<host>-bootstrap-token`, and signals the SHA-256 hash + 60-minute lifetime to the PhysicalHost via `infrastructure.cluster.x-k8s.io/bootstrap-token`. The PhysicalHost reconciler persists the hash and lifetime to `Status.Bootstrap.{TokenHash,IssuedAt,ExpiresAt}`.
+5. The controller's nonce-gated `/boot` endpoint renders the bearer token — along with the API base, target image URL, and target image digest — into the inspector's kernel cmdline (see [iPXE Setup](ipxe-setup.md) and `docs/inspector-contract.md` §4.1/§5).
+6. Once hardware inspection passes, the **inspector itself** — not the target OS — fetches the bootstrap data: `GET https://<manager>:8082/api/v1/bootstrap/<ns>/<host>` with `Authorization: Bearer <plaintext>`. The manager validates the token (`controllers/inspection_handler.go:newBearerTokenVerifier`), walks `PhysicalHost → ConsumerRef → Beskar7Machine → owner Machine → Spec.Bootstrap.DataSecretName → Secret`, and serves `secret.data["value"]` with `Cache-Control: no-store`. The inspector writes those bytes byte-verbatim as `99_beskar7.yaml` (mode `0600`, root-owned) on the target image's `COS_OEM` partition, then reboots the host via host firmware into the provisioned OS, which applies the config on first boot (no `kexec`).
 
 If the named Secret does not exist when the Beskar7Machine reconciles, `BootstrapDataReady=False (BootstrapDataUnavailable)` is set and the reconciler stops requeueing — operator must intervene (the bootstrap provider failed or the name is wrong).
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -224,7 +224,7 @@ If the inspection report does not meet any of these, the controller sets `Status
 | `PhysicalHostAssociated` | `Beskar7Machine` | True after a host is claimed. False reasons: `PhysicalHostAssociationFailed`, `WaitingForPhysicalHost`. |
 | `BootstrapDataReady` | `Beskar7Machine` | True after `Machine.Spec.Bootstrap.DataSecretName` is set and the bootstrap URL has been signalled to the host. False reasons: `WaitingForBootstrapData`, `BootstrapDataUnavailable`. |
 
-`MachineProvisionedCondition` (`"MachineProvisioned"`) is declared in `api/v1beta1/beskar7machine_types.go` but the reconciler never calls `conditions.MarkTrue`/`MarkFalse` on it — it is not set by any code path and will not appear on a `Beskar7Machine` object. Treat `InfrastructureReady` as the provisioned signal until this is wired up or removed.
+There is no `MachineProvisionedCondition` — the dead constant (declared but never set by any reconciler) has been removed from `api/v1beta1/beskar7machine_types.go`. `InfrastructureReady`, backed by `Status.Ready` and `Status.Initialization.Provisioned`, is the provisioned signal.
 
 ### Example
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,11 +65,11 @@ graph TD
 2. These trigger the creation of corresponding `Beskar7Cluster` and `Beskar7Machine` resources
 3. Beskar7Machine controller claims an available PhysicalHost
 4. PhysicalHost is powered on with PXE boot flag via Redfish
-5. Server network boots to inspection image via iPXE
+5. Server network boots to the inspection image via iPXE
 6. Inspection image collects hardware details and reports back
 7. Controller validates hardware meets requirements
-8. Inspection image kexecs into final operating system
-9. Machine becomes ready and joins the cluster
+8. Inspection image fetches the machine's bootstrap data, streams a digest-verified whole-disk image to the target disk, injects the bootstrap data into the image's `COS_OEM` partition, and reboots the host into the provisioned OS (no `kexec` — host firmware boots it)
+9. Inspector confirms the write with a provisioned callback; the machine becomes ready and joins the cluster
 
 ## Controllers
 
@@ -91,7 +91,8 @@ graph TD
 - `Available` - Ready to be claimed by a machine
 - `InUse` - Claimed by a Beskar7Machine
 - `Inspecting` - Running hardware inspection
-- `Ready` - Inspection complete and validated
+- `Deploying` - Inspection passed; the inspector is writing the OS image to disk
+- `Ready` - OS deployment complete (the inspector's provisioned callback was received)
 - `Error` - Problem occurred
 
 **Note:** This controller does NOT handle provisioning. It only manages power and tracks state.
@@ -129,9 +130,11 @@ graph TD
 - Rejects machine if requirements not met
 
 **Phase 5: Provisioning**
-- Inspection image kexecs into final OS
-- Waits for final OS to report ready
-- Sets `providerID` and marks `InfrastructureReady` condition as `True`
+- Once bootstrap data is ready, the inspector fetches it over the bearer-gated `/bootstrap` endpoint
+- Inspector streams the digest-pinned whole-disk image to the target disk, verifying SHA-256 after the write
+- Inspector injects the bootstrap data into the image's `COS_OEM` partition as a per-host Kairos cloud-config, then reboots the host into the provisioned OS via host firmware (no `kexec`)
+- Inspector confirms success with `POST /api/v1/provisioned/{namespace}/{hostName}` before rebooting; a `--deployment-timeout` (default 20 min) bounds how long the host may stay in `Deploying` waiting for that signal
+- Controller sets `providerID`, `Status.Ready`, `Status.Initialization.Provisioned`, and marks `InfrastructureReady` condition as `True` on receiving the provisioned callback
 
 **Cleanup:**
 - When deleted, releases the claimed PhysicalHost by clearing `spec.consumerRef`
@@ -215,7 +218,7 @@ This minimal interface ensures vendor-agnostic operation and reduces complexity.
 
 ## Inspection Workflow
 
-The inspection workflow is the core innovation in Beskar7 v0.4.0+. It provides reliable hardware discovery without vendor-specific code.
+The inspection workflow is the core innovation in Beskar7. It provides reliable hardware discovery and OS deployment without vendor-specific code, and without a kexec handoff — see `docs/inspector-contract.md` for the full normative wire contract this section summarizes.
 
 ### Workflow Steps
 
@@ -223,37 +226,42 @@ The inspection workflow is the core innovation in Beskar7 v0.4.0+. It provides r
 1. Beskar7Machine created, claims PhysicalHost
    |
    v
-2. Controller sets PXE boot flag via Redfish
-   Controller powers on server via Redfish
+2. Controller mints a per-host bearer token and a single-use boot nonce
+   Controller sets PXE boot flag via Redfish, powers on server
    |
    v
 3. Server network boots (DHCP -> iPXE chainload)
+   The operator's first-stage iPXE fetches the per-host boot script from the
+   controller's nonce-gated GET /api/v1/boot/{ns}/{host}/{nonce} endpoint
    |
    v
-4. iPXE fetches boot script from HTTP server
-   Boot script includes: API URL, token, namespace, host name
+4. The controller's /boot handler consumes the nonce (single-use) and
+   renders the inspector's kernel cmdline: beskar7.api, beskar7.namespace,
+   beskar7.host, beskar7.token, beskar7.target, beskar7.target-digest,
+   beskar7.ca (docs/inspector-contract.md §5)
    |
    v
-5. iPXE boots inspection image (Alpine Linux)
-   Kernel parameters: beskar7.api=URL beskar7.token=XXX
+5. iPXE boots the inspector image (beskar7-inspector, a static Rust/musl
+   binary used directly as initramfs /init)
    |
    v
-6. Inspection scripts run automatically:
-   - Detect CPUs (lscpu, /proc/cpuinfo)
-   - Detect Memory (free, /proc/meminfo)
-   - Detect Disks (lsblk, smartctl)
-   - Detect NICs (ip link, ethtool)
-   - Collect system info (dmidecode)
+6. Inspector Phase 1 runs automatically:
+   - Bring up the provisioning NIC (native one-shot DHCP, or a static
+     address from beskar7.ip)
+   - Probe hardware natively from SMBIOS/DMI + /sys + /proc — no external
+     tools
+   - Select the target disk (beskar7.disk override, or auto-select the
+     smallest eligible whole disk)
    |
    v
-7. Inspection image POSTs report to Beskar7 API
-   POST /api/v1/inspection/{namespace}/{host}
-   Body: JSON with all hardware details
+7. Inspector POSTs the report to the Beskar7 API
+   POST /api/v1/inspection/{namespace}/{host}   (Bearer token, TLS-verified)
+   Body: JSON with all hardware details -> 202 Accepted
    |
    v
 8. Inspection Handler validates the report, writes it to a per-host
    ConfigMap (`<host>-inspection-result`), and patches an
-   `infrastructure.cluster.x-k8s.io/inspection-result` annotation onto
+   `infrastructure.cluster.x-k8s.io/inspection-result-ref` annotation onto
    the PhysicalHost. The handler itself does NOT touch PhysicalHost
    status (D-005: each controller owns its resource's status).
    |
@@ -266,47 +274,59 @@ The inspection workflow is the core innovation in Beskar7 v0.4.0+. It provides r
    v
 9. Beskar7Machine controller validates hardware
    Checks minCPUCores, minMemoryGB, minDiskGB
-   If validation fails: mark machine as failed
-   If validation passes: continue to provisioning
+   If validation fails: mark machine as failed (terminal)
+   If validation passes: signal inspect-complete; PhysicalHost -> Deploying
    |
    v
-10. Inspection image downloads final OS
-    Downloads target image (e.g., Kairos tar.gz)
-    Extracts kernel and initrd
-    Prepares kexec command
+10. Inspector Phase 2 (polls until the bootstrap Secret is ready):
+    - GET /api/v1/bootstrap/{ns}/{host}  (Bearer token, TLS-verified) ->
+      the CAPI bootstrap user-data (a Kairos #cloud-config, see D-014)
+    - Stream the digest-pinned whole-disk image (beskar7.target) to the
+      selected disk, computing SHA-256 incrementally
+    - Verify the computed digest against beskar7.target-digest; abort with
+      no mount/inject/reboot on any mismatch
+    - Mount the image's COS_OEM partition and write the fetched user-data
+      as 99_beskar7.yaml (0600, root-owned); unmount and zero the
+      in-memory user-data buffer
     |
     v
-11. Kexec into final OS
-    Server reboots directly into production OS
-    No additional network boot needed
+11. Inspector POSTs the provisioning-complete signal, then reboots
+    POST /api/v1/provisioned/{namespace}/{host}  (Bearer token) -> 202
+    reboot(2) — host firmware boots the provisioned OS directly (no kexec)
     |
     v
-12. Final OS boots and joins cluster
-    Beskar7Machine marked as Ready
-    Node appears in cluster
+12. Controller receives the provisioned callback
+    PhysicalHost transitions Deploying -> Ready; Beskar7Machine sets
+    ProviderID, Status.Ready, Status.Initialization.Provisioned
+    |
+    v
+13. Provisioned OS boots, applies the injected COS_OEM config, and joins
+    the cluster
 ```
 
 ### Inspection Image
 
-The inspection image is a lightweight Alpine Linux environment with hardware detection tools. It is maintained in a separate repository: https://github.com/projectbeskar/beskar7-inspector
+The inspection image (`beskar7-inspector`) is a static, single-purpose binary written in Rust and statically linked against musl, used directly as the initramfs `/init` — no shell, no package manager, no external tools. It is maintained in a separate repository: https://github.com/projectbeskar/beskar7-inspector
 
 **Components:**
-- Base: Alpine Linux 3.19
-- Tools: dmidecode, lshw, lsblk, smartctl, ethtool, kexec-tools
-- Scripts: Hardware detection, report generation, kexec boot
-- Size: <100 MB
+- A curated, dependency-resolved set of kernel modules (NIC, disk, filesystem drivers) loaded natively via `finit_module(2)` — no `udev`/`modprobe`/`busybox`
+- Native hardware probing from SMBIOS/DMI (`/sys/firmware/dmi/tables`), `/sys`, and `/proc` — no `dmidecode`/`lshw`/`smartctl`/`ethtool`
+- A hand-rolled DHCP client and RTNETLINK layer for network bring-up — no `dhclient`/`udhcpc`
+- A whole-disk image writer with incremental SHA-256 verification and `COS_OEM` cloud-config injection — no `kexec-tools`
 
-**Kernel Parameters** (the iPXE infrastructure renders these per host — see [iPXE Setup](ipxe-setup.md)):
+**Kernel Parameters** (rendered per host by the controller's nonce-gated `GET /api/v1/boot/{namespace}/{hostName}/{nonce}` endpoint — see [iPXE Setup](ipxe-setup.md) and `docs/inspector-contract.md` §4.1/§5):
 
 ```
-beskar7.api=https://beskar7-controller-manager.beskar7-system.svc:8082
+beskar7.api=https://<externally-reachable-address>:8082
 beskar7.namespace=default
 beskar7.host=server-01
-beskar7.bootstrap-url=https://beskar7-controller-manager.beskar7-system.svc:8082/api/v1/bootstrap/default/server-01
 beskar7.token=<plaintext-bearer-token>
+beskar7.target=http://<image-server>/kairos-k3s.raw
+beskar7.target-digest=sha256:<64-hex-digest>
+beskar7.ca=<base64-encoded-callback-CA>
 ```
 
-The inspector POSTs to `${beskar7.api}/api/v1/inspection/${beskar7.namespace}/${beskar7.host}` with `Authorization: Bearer ${beskar7.token}`. The target OS, after kexec, fetches bootstrap data from `${beskar7.bootstrap-url}` with the same `Authorization` header.
+There is no `beskar7.bootstrap-url` parameter — the bootstrap endpoint's path is fixed (`{beskar7.api}/api/v1/bootstrap/{beskar7.namespace}/{beskar7.host}`); only the coordinates to build it are on the cmdline. The inspector POSTs the hardware report to `${beskar7.api}/api/v1/inspection/${beskar7.namespace}/${beskar7.host}` with `Authorization: Bearer ${beskar7.token}`. Once bootstrap data is ready, the **inspector itself** — not the target OS — fetches it from `${beskar7.api}/api/v1/bootstrap/${beskar7.namespace}/${beskar7.host}` with the same header, injects it into the target image's `COS_OEM` partition, and reboots the host via host firmware (no `kexec`). See the full parameter list in `docs/inspector-contract.md` §5.
 
 ## API Types
 
@@ -327,7 +347,7 @@ spec:
     namespace: default
 
 status:
-  state: Available  # Enrolling, Available, InUse, Inspecting, Ready, Error
+  state: Available  # Enrolling, Available, InUse, Inspecting, Deploying, Ready, Error
   ready: true
   inspectionPhase: Complete  # Pending, Booting, InProgress, Complete, Failed, Timeout
   inspectionReport:
@@ -380,20 +400,23 @@ status:
 
 ```yaml
 spec:
-  inspectionImageURL: "http://boot-server/ipxe/inspect.ipxe"   # iPXE boot script or kernel/initrd
-  targetImageURL:     "http://boot-server/images/kairos-v2.8.1.tar.gz"
+  inspectionImageURL: "https://boot-server/inspector"              # base URL serving vmlinuz + initrd.img
+  targetImageURL:     "http://boot-server/images/kairos-k3s.raw"   # Kairos whole-disk raw image
+  targetImageDigest:  "sha256:<64-hex-digest-of-the-bytes-at-targetImageURL>"
   hardwareRequirements:
     minCPUCores: 4
     minMemoryGB: 8
     minDiskGB:   50
 
 status:
-  phase: Provisioned   # Pending, Inspecting, Provisioned, Failed
+  phase: Provisioned   # Pending, Inspecting, Provisioning, Provisioned, Failed
   ready: true
   conditions:
-    - type: MachineProvisioned
+    - type: InfrastructureReady
       status: "True"
 ```
+
+There is no `MachineProvisioned` condition — it was declared but never set by any reconciler and has been removed. `InfrastructureReady` (backed by `Status.Ready` and `Status.Initialization.Provisioned`) is the provisioned signal.
 
 ### Beskar7Cluster
 
@@ -498,7 +521,7 @@ The same per-host bearer token authenticates the inspection POST and the bootstr
 - 32 bytes from `crypto/rand`, encoded as base64-raw-url (43 chars).
 - SHA-256 hash persisted on `PhysicalHost.Status.Bootstrap.TokenHash` (64 hex chars).
 - Plaintext stored in a per-host Secret named `<host>-bootstrap-token` (data key `plaintext-token`); GC'd on host delete via owner-ref.
-- Lifetime: 30 minutes (`auth.TokenLifetime` in `internal/auth/token.go`).
+- Lifetime: 60 minutes (`auth.TokenLifetime` in `internal/auth/token.go`).
 - Constant-time SHA-256 compare (`crypto/subtle`) on every request.
 - The plaintext travels on the iPXE kernel cmdline as `beskar7.token=<plaintext>`. See [iPXE Setup](ipxe-setup.md).
 

--- a/docs/beskar7machine.md
+++ b/docs/beskar7machine.md
@@ -17,8 +17,9 @@ For the full field reference, see [API Reference: Beskar7Machine](api-reference.
 
 ```yaml
 spec:
-  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
-  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  inspectionImageURL: "https://boot-server.local/inspector"              # base URL serving vmlinuz + initrd.img
+  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.raw"  # Kairos whole-disk raw image
+  targetImageDigest:  "sha256:<64-hex-digest-of-the-bytes-at-targetImageURL>"
   hardwareRequirements:                                                 # optional
     minCPUCores: 4
     minMemoryGB: 8
@@ -26,7 +27,7 @@ spec:
   # providerID is set by the controller on claim — do not set manually
 ```
 
-Both URL fields must match `^https?://.*`. There is no `osFamily`, `imageURL`, `bootMode`, `provisioningMode`, `configURL` (removed v0.3 fields), or `configurationURL` (a dead, never-wired v0.4 field removed before GA).
+`inspectionImageURL` and `targetImageURL` must match `^https?://[^\s]+$`; `targetImageDigest` is required and must match `^sha256:[a-f0-9]{64}$` — the inspector refuses to mount, inject user-data, or reboot on a digest mismatch (`docs/inspector-contract.md` §8.1). There is no `osFamily`, `imageURL`, `bootMode`, `provisioningMode`, `configURL` (removed v0.3 fields), or `configurationURL` (a dead, never-wired v0.4 field removed before GA).
 
 ## Reconcile flow
 
@@ -54,10 +55,11 @@ The reconciler runs through these phases. Each phase corresponds to a state of t
 
 | Type | Meaning | Common reasons |
 |---|---|---|
-| `InfrastructureReady` | Standard CAPI infra-ready condition. Summary across the others. | – |
+| `InfrastructureReady` | Standard CAPI infra-ready condition. Summary across the others; True once the host reaches `Ready` (the inspector's provisioned callback was received) and `ProviderID` is set. | – |
 | `PhysicalHostAssociated` | A host has been claimed. | `WaitingForPhysicalHost`, `PhysicalHostAssociationFailed`. |
-| `MachineProvisioned` | Host is `Ready` and `ProviderID` is set. | – |
 | `BootstrapDataReady` | `Machine.Spec.Bootstrap.DataSecretName` is set and the URL has been signalled. | `WaitingForBootstrapData`, `BootstrapDataUnavailable`. |
+
+There is no `MachineProvisioned` condition — it was declared but never set by any reconciler and has been removed from the API. Use `InfrastructureReady` (backed by `Status.Ready` and `Status.Initialization.Provisioned`) as the provisioned signal.
 
 ## Terminal failures
 
@@ -134,8 +136,9 @@ metadata:
     cluster.x-k8s.io/cluster-name: production-cluster
     cluster.x-k8s.io/control-plane: "true"
 spec:
-  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
-  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  inspectionImageURL: "https://boot-server.local/inspector"
+  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.raw"
+  targetImageDigest:  "sha256:0000000000000000000000000000000000000000000000000000000000000000"
   hardwareRequirements:
     minCPUCores: 4
     minMemoryGB: 16

--- a/docs/beskar7machinetemplate.md
+++ b/docs/beskar7machinetemplate.md
@@ -25,6 +25,7 @@ spec:
       # Identical to Beskar7Machine.spec
       inspectionImageURL: ...
       targetImageURL: ...
+      targetImageDigest: ...
       hardwareRequirements:
         minCPUCores: ...
         minMemoryGB: ...
@@ -62,8 +63,9 @@ metadata:
 spec:
   template:
     spec:
-      inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
-      targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+      inspectionImageURL: "https://boot-server.local/inspector"
+      targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.raw"
+      targetImageDigest:  "sha256:0000000000000000000000000000000000000000000000000000000000000000"
       hardwareRequirements:
         minCPUCores: 4
         minMemoryGB: 16
@@ -111,8 +113,9 @@ metadata:
 spec:
   template:
     spec:
-      inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
-      targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+      inspectionImageURL: "https://boot-server.local/inspector"
+      targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.raw"
+      targetImageDigest:  "sha256:0000000000000000000000000000000000000000000000000000000000000000"
       hardwareRequirements:
         minCPUCores: 4
         minMemoryGB: 8

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -10,7 +10,7 @@ Beskar7 is a Cluster API (CAPI) infrastructure provider for bare-metal machines.
 
 ## Beskar7Machine
 
-`Beskar7Machine` is the CAPI infrastructure-machine resource. One `Beskar7Machine` maps to one Kubernetes node. It finds a compatible `PhysicalHost`, claims it, triggers the inspection boot via Redfish + iPXE, validates the returned hardware report against `spec.hardwareRequirements`, and — once validation passes — kexecs into the target OS image. The provisioning workflow is driven by `spec.inspectionImageURL` and `spec.targetImageURL`. `Beskar7Machine` gets its bootstrap data (kubeadm join token, cloud-init, etc.) from the CAPI `Machine` object's `spec.bootstrap.dataSecretName`; the manager serves that data over HTTPS at `GET /api/v1/bootstrap/{namespace}/{name}`.
+`Beskar7Machine` is the CAPI infrastructure-machine resource. One `Beskar7Machine` maps to one Kubernetes node. It finds a compatible `PhysicalHost`, claims it, triggers the inspection boot via Redfish + iPXE, validates the returned hardware report against `spec.hardwareRequirements`, and — once validation passes — writes a digest-pinned whole-disk image to the target disk and injects a per-host cloud-config into the image's `COS_OEM` partition before rebooting into it. The provisioning workflow is driven by `spec.inspectionImageURL`, `spec.targetImageURL`, and `spec.targetImageDigest`. `Beskar7Machine` gets its bootstrap data (a Kairos `#cloud-config` carrying the cluster-join directives) from the CAPI `Machine` object's `spec.bootstrap.dataSecretName`; the manager serves that data over HTTPS at `GET /api/v1/bootstrap/{namespace}/{name}`, which the inspector — not the target OS — fetches and embeds into the image.
 
 ## Beskar7MachineTemplate
 
@@ -27,7 +27,7 @@ Beskar7 is a Cluster API (CAPI) infrastructure provider for bare-metal machines.
 3. It mints a per-host bearer token and sets a one-time PXE boot flag via Redfish, then powers on the host.
 4. The host PXE-boots the inspection image (`beskar7-inspector`), which posts hardware details to `POST /api/v1/inspection/{namespace}/{name}` on the manager.
 5. The controller validates the report against requirements. On failure it releases the host and tries another.
-6. On success the host kexecs into the target OS image. The machine fetches its bootstrap data from `GET /api/v1/bootstrap/{namespace}/{name}`, joins the cluster, and the `Beskar7Machine` sets `Status.Ready = true`.
+6. On success the inspector fetches the machine's bootstrap data from `GET /api/v1/bootstrap/{namespace}/{name}`, streams the digest-verified whole-disk image to the target disk, injects the bootstrap data into the image's `COS_OEM` partition, and reboots the host into the provisioned OS via host firmware (no `kexec`). Once the inspector confirms the write with `POST /api/v1/provisioned/{namespace}/{name}`, the `Beskar7Machine` sets `Status.Ready = true` and the node joins the cluster.
 
 ## Where to go next
 

--- a/docs/physicalhost.md
+++ b/docs/physicalhost.md
@@ -35,14 +35,15 @@ When `caBundleSecretRef` is set, the manager builds an HTTP client whose TLS roo
 The reconciler drives `Status.State` through these transitions:
 
 ```
-created → Available           (BMC reachable, no consumer)
-Available → InUse             (Beskar7Machine claims via spec.consumerRef)
-InUse → Inspecting            (Beskar7Machine sets the inspection-request annotation)
-Inspecting → Ready            (inspection report consumed from ConfigMap)
-Ready → InUse                 (back to InUse after the host stays claimed)
-any → Error                   (BMC unreachable, TLS conflict, inspection timeout)
-Error → Available             (operator fixes spec, BMC recovers)
-Ready/InUse → Available       (Beskar7Machine deletion clears consumerRef)
+created → Available                            (BMC reachable, no consumer)
+Available → InUse                              (Beskar7Machine claims via spec.consumerRef)
+InUse → Inspecting                             (Beskar7Machine sets the inspection-request annotation)
+Inspecting → Deploying                         (inspection report consumed from ConfigMap, validated)
+Deploying → Ready                              (inspector POSTs /api/v1/provisioned; see contract §4.4)
+Deploying → Error                              (deployment timeout, default 20 min)
+any → Error                                    (BMC unreachable, TLS conflict, inspection timeout)
+Error → Available                              (operator fixes spec, BMC recovers)
+InUse/Inspecting/Deploying/Ready → Available   (Beskar7Machine deletion clears consumerRef)
 ```
 
 For the diagram and the full transition table, see [State Management](state-management.md).

--- a/examples/minimal-test-cluster.yaml
+++ b/examples/minimal-test-cluster.yaml
@@ -64,6 +64,6 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test-cluster
 spec:
-  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
-  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  inspectionImageURL: "https://boot-server.local/inspector"
+  targetImageURL:     "http://boot-server.local/images/kairos-alpine-v2.8.1.raw"
   targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL

--- a/examples/minimal-test.yaml
+++ b/examples/minimal-test.yaml
@@ -36,8 +36,8 @@ metadata:
   name: test-machine
   namespace: default
 spec:
-  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
-  targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  inspectionImageURL: "https://boot-server.local/inspector"
+  targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.raw"
   targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
   # staticIP is optional. Set it only when the provisioning network has no DHCP
   # server (DHCP-less or VLAN-pinned environments). When set, /boot renders

--- a/examples/simple-cluster.yaml
+++ b/examples/simple-cluster.yaml
@@ -121,10 +121,11 @@ metadata:
     cluster.x-k8s.io/control-plane: "true"
 spec:
   # Inspector boot via iPXE
-  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
-  
-  # Final OS (Kairos example)
-  targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  inspectionImageURL: "https://boot-server.local/inspector"
+
+  # Final OS (Kairos whole-disk raw image, written to the target disk and
+  # digest-verified by the inspector — see docs/inspector-contract.md §8.1)
+  targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.raw"
   targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
 
   # Hardware requirements for control plane
@@ -144,8 +145,8 @@ metadata:
     cluster.x-k8s.io/cluster-name: test-cluster
     cluster.x-k8s.io/worker: "true"
 spec:
-  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
-  targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  inspectionImageURL: "https://boot-server.local/inspector"
+  targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.raw"
   targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
   hardwareRequirements:
     minCPUCores: 4
@@ -162,8 +163,8 @@ metadata:
     cluster.x-k8s.io/cluster-name: test-cluster
     cluster.x-k8s.io/worker: "true"
 spec:
-  inspectionImageURL: "http://boot-server.local/ipxe/inspect.ipxe"
-  targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.tar.gz"
+  inspectionImageURL: "https://boot-server.local/inspector"
+  targetImageURL: "http://boot-server.local/images/kairos-alpine-v2.8.1.raw"
   targetImageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"  # sha256 of the bytes at targetImageURL
   hardwareRequirements:
     minCPUCores: 4


### PR DESCRIPTION
## What

Sweeps the **removed kexec / v0.3 provisioning model** out of the docs and examples — a GA docs-readiness blocker. The v2 model is iPXE boot → inspection image → **digest-pinned whole-disk raw image write** + `COS_OEM` cloud-config inject + reboot. No kexec.

## Changes

- **`docs/{introduction, architecture, advanced-usage, physicalhost, beskar7machine, beskar7machinetemplate}.md`** — replace kexec language with the whole-disk-image flow; add the `Deploying` state; fix bearer-token lifetime (30 → **60 min**, matches `auth.TokenLifetime`); drop the fictional `beskar7.bootstrap-url` param; correct the `targetImageURL` pattern (`^https?://[^\s]+$`); remove dead `MachineProvisioned` condition references.
- **`examples/{simple-cluster, minimal-test, minimal-test-cluster}.yaml`** — base-URL `inspectionImageURL` + `.raw` `targetImageURL` + the required `targetImageDigest` (matching the validated `kairos-k3s-node.yaml`).
- **`docs/api-reference.md`** — only the `MachineProvisioned` note (now removed → point at `InfrastructureReady`).
- **`CHANGELOG.md`** — `[Unreleased] / Removed` entry for `MachineProvisionedCondition` (the #136 removal landed without one).

Docs/examples only; examples regex-validated against the frozen CRD patterns + YAML-parsed.

## Known follow-ups (not in this PR)

- `docs/architecture.md` "Error Handling" still says a timed-out/failed host "transitions back to Available" — per `state-management.md` it actually lands in `StateError` (lifecycle-accuracy fix, separate concern).
- `internal/auth/token.go:135` has a stale "30 min" code comment (trivial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)