### PR TITLE
docs+comment: fix stale lifecycle/timeout accuracy (kexec-sweep follow-ups)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -494,14 +494,14 @@ If no inspection report received within 10 minutes:
 1. PhysicalHost.status.inspectionPhase set to `Timeout`
 2. Beskar7Machine marked as Failed with appropriate condition
 3. PhysicalHost powered off
-4. Host transitions back to Available (can be retried)
+4. `PhysicalHost` transitions to `StateError` (terminal); the `Beskar7Machine` is failed with `FailureReason=InspectionTimedOut`. There is no automatic retry — the operator deletes and recreates the `Beskar7Machine`.
 
 ### Hardware Validation Failure
 
 If inspection report doesn't meet requirements:
 1. Beskar7Machine condition updated with validation error
 2. PhysicalHost powered off
-3. Host transitions back to Available
+3. `PhysicalHost` transitions to `StateError` (terminal); the `Beskar7Machine` is failed with `FailureReason=HardwareRequirementsNotMet`
 4. User must adjust requirements or use different hardware
 
 ### Redfish Connection Failure

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -132,7 +132,7 @@ func LifetimeFor(now time.Time) (issuedAt, expiresAt metav1.Time) {
 // PhysicalHost.Status.Bootstrap when a boot nonce is minted at the given
 // instant. The nonce has no issuedAt field in Status — only expiresAt and the
 // consumed marker matter for the validity check. Uses BootNonceLifetime (10 min)
-// rather than TokenLifetime (30 min) because the nonce is single-use.
+// rather than TokenLifetime (60 min) because the nonce is single-use.
 func NonceLifetimeFor(now time.Time) (expiresAt metav1.Time) {
 	return metav1.NewTime(now.Add(BootNonceLifetime))
 }


### PR DESCRIPTION
Two accuracy fixes flagged during the kexec docs sweep (#137):

- **`docs/architecture.md` "Error Handling"** — a timed-out or hardware-invalid host lands in **`StateError`** (terminal) and requires the operator to delete + recreate the `Beskar7Machine`; it does **not** auto-return to `Available`. Matches `state-management.md` (authoritative) and `markTerminalFailure`. Corrects the Inspection Timeout and Hardware Validation Failure subsections.
- **`internal/auth/token.go`** — the `NonceLifetimeFor` comment said `TokenLifetime` is 30 min; it's **60 min** (SEC-D015-1). Comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)