### PR TITLE
docs(readme): fix CRD-invalid example, stale pins, kexec leftover

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 5. Inspection image collects hardware details
 6. Reports back to Beskar7
 7. Validates hardware requirements
-8. Kexecs into target OS
-9. Machine joins cluster
+8. Writes the digest-verified whole-disk OS image and injects the bootstrap config
+9. Reboots into the provisioned OS; the machine joins the cluster
 
 ## Current Status
 
@@ -38,7 +38,7 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 2. Cluster API v1.10+ ([install with clusterctl](https://cluster-api.sigs.k8s.io/user/quick-start.html))
 3. cert-manager v1.16+ ([installation guide](https://cert-manager.io/docs/installation/))
 4. iPXE infrastructure - DHCP + HTTP server ([setup guide](docs/ipxe-setup.md))
-5. Inspection image - beskar7-inspector ([repository](https://github.com/projectbeskar/beskar7-inspector))
+5. Inspection image - `vmlinuz` + `initrd.img` from [beskar7-inspector releases](https://github.com/projectbeskar/beskar7-inspector/releases), served by your boot server. Match the inspector to the contract version your controller speaks (see [iPXE Setup](docs/ipxe-setup.md)).
 
 ### Quick Install
 
@@ -51,12 +51,12 @@ helm install --devel beskar7 beskar7/beskar7 \
   --namespace beskar7-system --create-namespace
 ```
 
-The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.6`); drop it once a non-prerelease tag is cut.
+The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.8`); drop it once a non-prerelease tag is cut.
 
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.6/beskar7-manifests-v0.4.0-alpha.6.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.8/beskar7-manifests-v0.4.0-alpha.8.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.
@@ -84,12 +84,25 @@ kind: Beskar7Machine
 metadata:
   name: worker-01
 spec:
-  inspectionImageURL: "http://boot-server/beskar7-inspector/boot"
-  targetImageURL: "http://boot-server/kairos/v2.8.1.tar.gz"
+  # Directory the boot server serves the inspector from; the controller
+  # appends /vmlinuz and /initrd.img when it renders the iPXE script.
+  inspectionImageURL: "http://boot-server/beskar7-inspector"
+  # A whole-disk raw OS image (not a tarball or ISO) with a bootstrap agent
+  # baked in — see docs/beskar7machine.md for the image requirements.
+  targetImageURL: "http://boot-server/images/kairos-k3s.raw"
+  # Required. The inspector verifies the downloaded bytes against this and
+  # refuses to write the disk on a mismatch — it is the integrity anchor.
+  #   sha256sum kairos-k3s.raw
+  targetImageDigest: "sha256:<64-hex-digest-of-the-bytes-at-targetImageURL>"
   hardwareRequirements:
     minCPUCores: 4
     minMemoryGB: 16
 ```
+
+> These snippets assume the boot infrastructure from the prerequisites is already
+> in place (DHCP/TFTP + iPXE, a boot server serving the inspector and the OS
+> image, and the controller's callback endpoint reachable from the host network).
+> [Quick Start](docs/quick-start.md) walks the first provisioning flow end to end.
 
 **Complete examples:** See [examples/](examples/) directory for full cluster configurations.
 


### PR DESCRIPTION
## Why

The README's `Beskar7Machine` example **could not be applied**. `targetImageDigest` is a required CRD field (`required: [inspectionImageURL, targetImageDigest, targetImageURL]`) and was missing, and `targetImageURL` still used the removed `.tar.gz` format. An adopter copying the first YAML in the project hit an admission error within five minutes.

## What

- **The example** — add the required `targetImageDigest` (plus the `sha256sum` command that produces it), switch to a `.raw` whole-disk image, and correct `inspectionImageURL` to the *directory* form the controller appends `/vmlinuz` + `/initrd.img` to. Added a note that these snippets assume the boot infrastructure listed in the prerequisites.
- **Prerequisite 5** — now points at downloadable [beskar7-inspector releases](https://github.com/projectbeskar/beskar7-inspector/releases) and the contract-version match, rather than just linking the repo and leaving adopters to infer they must build it themselves. (Pairs with beskar7-inspector#30, which creates those releases.)
- **"How It Works" step 8** still said *"Kexecs into target OS"* — the kexec sweep (#137) covered `docs/` and `examples/` but missed the README. Now describes the v2 flow: digest-verified whole-disk write + bootstrap inject, then reboot.
- **Stale pins** — `alpha.6` → `alpha.8` in the `--devel` note and the release-manifest URL.

## Verification

Wrote a checker over every `Beskar7Machine`/`Beskar7MachineTemplate` snippet in `README.md`, `docs/**`, and `examples/**`:

- Before: 1 snippet missing required fields (README).
- After: **0**. `docs/` and `examples/` were already correct — the earlier sweep did its job; only the README was stale.

All relative links in the README resolve (checked programmatically).

## Not in this PR

`README.md:121` says *"Tested with Dell, HPE, Lenovo, Supermicro, and generic BMCs"*, and `docs/hardware-compatibility.md` marks five vendors "Tested". The only in-tree evidence is a mock (`internal/redfishmock`), a synthetic DMTF fixture, and sushy-tools emulation — no real BMC has been validated. That correction is tracked separately since it needs a decision on the honest claim.