### PR TITLE
ci(release): sign images with cosign + attest SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,36 @@ jobs:
         name: sbom
         path: sbom.spdx.json
 
+    - name: Install cosign
+      uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+    # Keyless (OIDC) signature bound to this workflow's identity. Verify with:
+    #   cosign verify $IMAGE --certificate-identity-regexp \
+    #     'https://github.com/{owner}/{repo}/.github/workflows/release.yml@refs/tags/.*' \
+    #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+    - name: Sign controller image (keyless)
+      env:
+        DIGEST: ${{ steps.build.outputs.digest }}
+      run: |
+        set -euo pipefail
+        image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+        image="$(echo "$image" | tr '[:upper:]' '[:lower:]')"
+        cosign sign --yes "${image}@${DIGEST}"
+        echo "signed ${image}@${DIGEST}"
+
+    # Bind the SBOM to the image as a signed, verifiable attestation rather than
+    # leaving it as a loose release artifact. Verify with:
+    #   cosign verify-attestation --type spdxjson $IMAGE ...
+    - name: Attest SBOM to the image (keyless)
+      env:
+        DIGEST: ${{ steps.build.outputs.digest }}
+      run: |
+        set -euo pipefail
+        image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+        image="$(echo "$image" | tr '[:upper:]' '[:lower:]')"
+        cosign attest --yes --type spdxjson --predicate sbom.spdx.json "${image}@${DIGEST}"
+        echo "attested SBOM to ${image}@${DIGEST}"
+
   # Job 2: Build and Push Mock Redfish Image (parallel with build-and-push)
   build-and-push-mock-redfish:
     name: Build and Push Mock Redfish Image
@@ -107,6 +137,7 @@ jobs:
           type=semver,pattern={{major}}
 
     - name: Build and push mock-redfish image
+      id: build
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -117,6 +148,23 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         provenance: false
         sbom: false
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+    # Keyless (OIDC) signature bound to this workflow's identity. Verify with:
+    #   cosign verify $IMAGE --certificate-identity-regexp \
+    #     'https://github.com/{owner}/{repo}/.github/workflows/release.yml@refs/tags/.*' \
+    #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+    - name: Sign mock-redfish image (keyless)
+      env:
+        DIGEST: ${{ steps.build.outputs.digest }}
+      run: |
+        set -euo pipefail
+        image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+        image="$(echo "$image" | tr '[:upper:]' '[:lower:]')"
+        cosign sign --yes "${image}@${DIGEST}"
+        echo "signed ${image}@${DIGEST}"
 
   # Job 3: Build and Push Mock Inspector Image (parallel with build-and-push and build-and-push-mock-redfish)
   build-and-push-mock-inspector:
@@ -154,6 +202,7 @@ jobs:
           type=semver,pattern={{major}}
 
     - name: Build and push mock-inspector image
+      id: build
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -164,6 +213,23 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         provenance: false
         sbom: false
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+    # Keyless (OIDC) signature bound to this workflow's identity. Verify with:
+    #   cosign verify $IMAGE --certificate-identity-regexp \
+    #     'https://github.com/{owner}/{repo}/.github/workflows/release.yml@refs/tags/.*' \
+    #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+    - name: Sign mock-inspector image (keyless)
+      env:
+        DIGEST: ${{ steps.build.outputs.digest }}
+      run: |
+        set -euo pipefail
+        image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+        image="$(echo "$image" | tr '[:upper:]' '[:lower:]')"
+        cosign sign --yes "${image}@${DIGEST}"
+        echo "signed ${image}@${DIGEST}"
 
   # Job 4: Security Scan Released Image
   security-scan:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,6 +75,37 @@ kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.
 
+## Verify release artifacts (supply chain)
+
+Container images are signed with [cosign](https://docs.sigstore.dev/) using keyless
+(OIDC) signing bound to the release workflow's identity — there is no long-lived
+signing key. The controller image also carries a signed SPDX SBOM attestation.
+
+Verify an image before deploying it:
+
+```bash
+IMAGE=ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.8
+
+cosign verify "$IMAGE" \
+  --certificate-identity-regexp '^https://github.com/projectbeskar/beskar7/\.github/workflows/release\.yml@refs/tags/.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Inspect the SBOM attestation:
+
+```bash
+cosign verify-attestation --type spdxjson "$IMAGE" \
+  --certificate-identity-regexp '^https://github.com/projectbeskar/beskar7/\.github/workflows/release\.yml@refs/tags/.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+A failed verification means the image was not produced by this project's release
+workflow — do not deploy it.
+
+> The `beskar7-inspector` boot artifacts (`vmlinuz`, `initrd.img`) ship with
+> `sha256sums.txt` on each inspector release; verify them with
+> `sha256sum -c sha256sums.txt --ignore-missing`.
+
 ## Verify the installation
 
 ```bash


### PR DESCRIPTION
## Why

Released images are **unsigned**, and the SBOM is published as a loose release artifact — which proves nothing about the image it claims to describe. Plenty of organizations will not deploy unsigned images at all, so this is a hard gate for enterprise adoption.

## What

- **Sign all three images** (`beskar7`, `mock-redfish`, `mock-inspector`) with **cosign keyless (OIDC)** signing, bound **by digest** to the release workflow's identity. No long-lived key to manage or leak.
- **Attest the SBOM** — the SPDX SBOM is already generated for the controller image; it's now bound to the image as a signed cosign attestation rather than left detached.
- The mock build steps gained an `id` so their digests are referenceable. All three jobs already had `id-token: write`, so **no permission changes were needed**.
- **`docs/installation.md`** — new "Verify release artifacts" section with the exact `cosign verify` / `verify-attestation` commands, pinned to this repo's workflow identity and the GitHub OIDC issuer, plus a note that a failed verification means "do not deploy".

## Notes

- `sigstore/cosign-installer` is pinned by **commit SHA** (`d58896d…`, v3.9.2) — I verified that SHA against upstream via the GitHub API rather than assuming it.
- I deliberately **left `provenance:`/`sbom:` on `build-push-action` unchanged**. Enabling buildx attestations converts a single-platform image into an index with attestation manifests; that's a separate, riskier change and cosign signing is what the requirement actually calls for. Happy to flip them as a follow-up if you want native buildx provenance too.
- Signing cannot be fully exercised until a tag is pushed (keyless OIDC only works in the real workflow context). The YAML is validated and the steps are digest-driven off existing outputs.

Companion: the same signing is being added to `beskar7-inspector`'s new release pipeline so its **first** published release ships signed.