### PR TITLE
docs: scope cosign verification guidance to signed releases

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,10 +81,14 @@ Container images are signed with [cosign](https://docs.sigstore.dev/) using keyl
 (OIDC) signing bound to the release workflow's identity — there is no long-lived
 signing key. The controller image also carries a signed SPDX SBOM attestation.
 
+> **Applies from `v0.4.0-alpha.9` onward.** Signing was enabled after
+> `v0.4.0-alpha.8` was published, so that and earlier alpha images carry no
+> signature and will not verify — this is expected, not a tampering signal.
+
 Verify an image before deploying it:
 
 ```bash
-IMAGE=ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.8
+IMAGE=ghcr.io/projectbeskar/beskar7/beskar7:<tag>   # a release from alpha.9 onward
 
 cosign verify "$IMAGE" \
   --certificate-identity-regexp '^https://github.com/projectbeskar/beskar7/\.github/workflows/release\.yml@refs/tags/.*$' \


### PR DESCRIPTION
Follow-up to #141.

Signing was enabled *after* `v0.4.0-alpha.8` was published, so the verification steps that shipped with #141 would **fail against every currently-published image** — the doc promised something impossible.

- States that signing applies from `v0.4.0-alpha.9` onward, and that earlier alphas carrying no signature is expected rather than a tampering signal.
- Replaces the concrete `:v0.4.0-alpha.8` example tag with a placeholder, so the snippet can't be copy-pasted into a guaranteed failure.

A failed `cosign verify` should mean tampering. It should never mean the documentation was wrong.