### PR TITLE
chore(release): v0.4.0-alpha.9 + honest hardware-compatibility claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,20 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [v0.4.0-alpha.9] - 2026-08-31
+
+The "adoption readiness" release: the `v1beta1` API is **frozen**, the
+controller↔inspector contract moves to **v4.2** with per-host `ProviderID`
+delivery, release images are **signed**, and the `beskar7-inspector` is now
+**distributable** — published as versioned, checksummed, signed artifacts
+instead of something every adopter had to build from source.
+
+**Upgrading from alpha.8 requires action** — see the BREAKING entry under
+Changed: `configurationURL` was removed and `caBundleSecretRef` changed shape.
+
 ### Added
 - **Per-host `ProviderID` delivery for templated pools/HA control planes** (contract v4.2, D-014 P2) — `/boot` now always renders a new required cmdline param `beskar7.provider-id=b7://<namespace>/<host>` (`controllers/boot_handler.go`), positioned immediately after `beskar7.target-digest` and before `beskar7.ca`. The value is `providerID(ph.Namespace, ph.Name)` — the exact call `handleReadyHost` already uses to stamp `Beskar7Machine.Spec.ProviderID` — so the rendered and stamped values cannot diverge. New `validateProviderID` injection guard (SEC-7 defence-in-depth, anchored `^b7://[a-z0-9.-]+/[a-z0-9.-]+$`). This closes the gap where a *shared* `Beskar7MachineTemplate`/bootstrap config could not pin a *per-host* `ProviderID`, blocking `MachineDeployment` worker pools and multi-replica control planes; the inspector writes the value verbatim to a new `COS_OEM` artifact `/oem/beskar7/provider-id` (no trailing newline, mode `0600`, root-owned) that a shared boot-time stage reads to set a per-host kubelet `--provider-id`. Additive and backward-compatible: a v4.1 inspector ignores the unknown param and never writes the artifact.
-- **Deploy-path golden fixtures** (`test/contract/golden_boot_cmdline_v4_2.txt`, `test/contract/golden_provider_id_artifact.json`) and `controllers/deploy_contract_test.go` — byte-exact `/boot` cmdline render guard, a language-neutral descriptor of the `COS_OEM` provider-id artifact cross-checked against the real `providerID()`, and an injection-guard table test for `validateProviderID`. `controllers/boot_handler_test.go` adds the regression guard proving the render-time and stamp-time `ProviderID` values are identical and that `beskar7.provider-id` renders unconditionally, even before the host reaches `Ready`.
+- **Deploy-path golden fixtures** (`test/contract/golden_boot_cmdline.txt`, `test/contract/golden_provider_id_artifact.json`) and `controllers/deploy_contract_test.go` — byte-exact `/boot` cmdline render guard, a language-neutral descriptor of the `COS_OEM` provider-id artifact cross-checked against the real `providerID()`, and an injection-guard table test for `validateProviderID`. `controllers/boot_handler_test.go` adds the regression guard proving the render-time and stamp-time `ProviderID` values are identical and that `beskar7.provider-id` renders unconditionally, even before the host reaches `Ready`.
 - **Contract version bumped to v4.2** — `test/contract/VERSION`, `contract.Version`, and `docs/inspector-contract.md` all bumped; `TestContractVersion` unaffected (self-consistency check only).
 
 ### Changed
@@ -16,6 +27,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Removed
 - **`MachineProvisionedCondition` constant** — removed from `api/v1beta1/beskar7machine_types.go`. It was declared but never set by any reconciler (verified: zero non-declaration references), so a caller scripting against it would wait forever. Use `InfrastructureReady`, `Status.Ready`, and `Status.Initialization.Provisioned` instead. Not a CRD-schema change (condition types are runtime values, not schema); no `make manifests` diff.
+
+### Security
+- **Release images are signed with cosign** (keyless/OIDC, bound by digest to the release workflow identity — no long-lived key). The controller image additionally carries its SPDX SBOM as a **signed attestation** rather than a detached artifact. Verification instructions in `docs/installation.md`. Signing applies from this release onward; `v0.4.0-alpha.8` and earlier are unsigned and will not verify.
+- **RBAC binding/subject-graph guard** (SEC-2, #131) — `test/rbac` now also asserts every `Role`/`ClusterRole` in each topology (cluster-wide kustomize, namespace-scoped overlay, both Helm branches) is bound to the manager ServiceAccount by exactly one binding with a matching `roleRef`, catching unbound roles, dangling `roleRef`s, and wrong-identity subjects that the rule-content guard cannot see.
+
+### Documentation
+- **v1beta1 declared frozen** (D-018, #133) — stable and **additive-only** until a future `v1beta2` introduced with a conversion webhook.
+- **`docs/api-reference.md` reconciled** against the frozen types (#135) — added the missing `targetImageDigest`/`targetDisk`/`staticIP`, the `Deploying` state and `Provisioning` phase, all seven terminal `failureReason` values, corrected the bearer-token lifetime (30 → 60 min), and fixed two embedded examples that were CRD-invalid.
+- **Removed-kexec sweep** (#137, #140) — `docs/` and `examples/` reconciled to the v2 whole-disk-image model, and the README's "How It Works" and `Beskar7Machine` example corrected (the example was **CRD-invalid**: it omitted the required `targetImageDigest` and used the removed `.tar.gz` format).
+- **Honest hardware-compatibility claims** — five vendors were marked "Tested" with per-vendor experience claims; no physical vendor BMC has ever been validated. The doc now separates the *design* property (no vendor-specific code paths) from *validation status*, states exactly what has been exercised (a stateful fake, the DMTF `public-rackmount1` mockup, and sushy-tools emulation), and invites real-hardware reports.
+- **Cross-repo contract sync documented** (D-019, #134) — `test/contract/` is the single source of truth; the inspector vendors byte-copies pinned to an immutable `contract/<version>` tag and gates on drift in its own CI.
 
 ## [v0.4.0-alpha.8] - 2026-07-21
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.0-alpha.8
+VERSION ?= v0.4.0-alpha.9
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.0-alpha.8  
+**Version:** v0.4.0-alpha.9  
 **Status:** Alpha (pre-GA). The `v1beta1` API is **frozen** — no further breaking changes; the schema evolves **additive-only** until a future `v1beta2` (introduced with a conversion webhook) is needed.  
 **Breaking Changes:** v0.4.0 is NOT compatible with v0.3.x ([see CHANGELOG](CHANGELOG.md))
 
@@ -51,12 +51,12 @@ helm install --devel beskar7 beskar7/beskar7 \
   --namespace beskar7-system --create-namespace
 ```
 
-The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.8`); drop it once a non-prerelease tag is cut.
+The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.9`); drop it once a non-prerelease tag is cut.
 
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.8/beskar7-manifests-v0.4.0-alpha.8.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.9/beskar7-manifests-v0.4.0-alpha.9.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.
@@ -118,7 +118,9 @@ Beskar7 consists of three main controllers:
 
 ## Hardware Compatibility
 
-Works with **any Redfish-compliant BMC**. Tested with Dell, HPE, Lenovo, Supermicro, and generic BMCs.
+Designed for **any Redfish-compliant BMC** — one code path, no vendor-specific
+handling. Validated against emulated BMCs and the DMTF reference mockup; **no
+physical vendor BMC has been validated yet**, so pilot before committing a fleet.
 
 **Details:** See [docs/hardware-compatibility.md](docs/hardware-compatibility.md)
 

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0-alpha.8
-appVersion: "v0.4.0-alpha.8"
+version: 0.4.0-alpha.9
+appVersion: "v0.4.0-alpha.9"
 keywords:
   - cluster-api
   - infrastructure

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -273,8 +273,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.0-alpha.N`; bump N for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.0-alpha.8
-   git push origin v0.4.0-alpha.8
+   git tag v0.4.0-alpha.9
+   git push origin v0.4.0-alpha.9
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.8`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.9`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/hardware-compatibility.md
+++ b/docs/hardware-compatibility.md
@@ -35,45 +35,63 @@ That's it! These are universally supported across all Redfish implementations.
 
 See [iPXE Setup Guide](ipxe-setup.md) for network architecture examples.
 
-## Tested Vendors
+## Vendor compatibility
 
-While Beskar7 works with any Redfish BMC, we've specifically tested:
+Beskar7 has **no vendor-specific code paths** — one code path drives every BMC
+through the small Redfish subset listed above. Any BMC that implements those
+operations to spec is expected to work.
 
-| Vendor | BMC Type | Redfish Version | Status | Notes |
-|--------|----------|-----------------|--------|-------|
-| **Dell** | iDRAC 8/9 | 1.4+ | Tested | no special handling |
-| **HPE** | iLO 4/5/6 | 1.2+ | Tested | Redfish compliance |
-| **Lenovo** | XCC | 1.6+ | Tested | Clean implementation |
-| **Supermicro** | BMC | 1.4+ | Tested | Newer BMC versions recommended |
-| **Generic** | AMI MegaRAC | 1.4+ | Tested | Used by many whitebox vendors |
-| **Generic** | Aspeed OpenBMC | 1.0+ | Partial | Some implementations incomplete |
+That expectation is a design property, not a test result. Be precise about the
+difference when planning a deployment:
 
-### Notes on Tested Hardware
+| Vendor | BMC | Redfish | Expected | Validated on real hardware |
+|---|---|---|---|---|
+| Dell | iDRAC 8/9 | 1.4+ | Yes | Not yet |
+| HPE | iLO 4/5/6 | 1.2+ | Yes | Not yet |
+| Lenovo | XCC | 1.6+ | Yes | Not yet |
+| Supermicro | BMC (X12+ recommended) | 1.4+ | Yes | Not yet |
+| Generic | AMI MegaRAC | 1.4+ | Yes | Not yet |
+| Generic | Aspeed OpenBMC | 1.0+ | Varies — see below | Not yet |
 
-**Dell (iDRAC):**
-- Excellent Redfish implementation
-- No quirks or workarounds needed
-- Power management very reliable
+### What has actually been validated
 
-**HPE (iLO):**
-- Industry-leading Redfish compliance
-- All tested features work flawlessly
-- Highly recommended
+Beskar7's Redfish surface is exercised against three things today, none of which
+is a physical vendor BMC:
 
-**Lenovo (XCC):**
-- Clean, standards-compliant implementation
-- No issues encountered
-- Good documentation
+- **A stateful fake** (`internal/redfishmock`) that emulates Dell/HPE/Lenovo/
+  Supermicro/Generic service roots, used for claim → power → boot-override →
+  release state-machine tests.
+- **The DMTF reference mockup** (`public-rackmount1`, vendored under
+  `internal/redfish/testdata/corpus/`), walked by the *real* gofish client to
+  catch parsing and link-navigation regressions.
+- **sushy-tools** (libvirt-backed Redfish emulator), used for the full
+  end-to-end provisioning loop: claim → PXE → inspect → whole-disk write →
+  callback → `Ready` node.
 
-**Supermicro:**
-- Quality varies by BMC version
-- Update to latest BMC firmware for best results
-- X12+ series recommended
+**No physical vendor BMC has been validated.** Emulators are faithful to the
+spec, which is exactly why they cannot surface the firmware quirks real BMCs
+have. Treat the table above as "should work, unverified" and pilot on a small
+number of hosts before committing a fleet.
 
-**Whitebox/Generic:**
-- AMI MegaRAC generally works well
-- OpenBMC implementations vary by vendor
-- Test thoroughly before production use
+### Known spec-conformance caveats
+
+General Redfish guidance, not Beskar7 findings:
+
+- **Supermicro** — Redfish completeness varies by firmware revision; update to
+  current BMC firmware before testing.
+- **OpenBMC/Aspeed** — implementation coverage differs significantly between
+  vendors shipping it; verify boot-source override in particular.
+- **One-time boot override** — Beskar7 sets `BootSourceOverrideEnabled=Once` and
+  relies on firmware to consume it after the provisioning boot. Real BMCs honor
+  this; note that the sushy-tools emulator does **not** (it persists the boot
+  device), which is a harness limitation rather than a product behavior.
+
+### Reporting real-hardware results
+
+Validation reports are welcome and are the fastest way to move a row from
+"Not yet" to a real result — please
+[open an issue](https://github.com/projectbeskar/beskar7/issues) with the vendor,
+BMC model, firmware revision, and what did or did not work.
 
 ## What's Different from Other Bare-Metal Tools?
 
@@ -311,20 +329,23 @@ Submit to: https://github.com/projectbeskar/beskar7/issues
 
 ## Feature Support Matrix
 
-| Feature | Requirement | All Vendors |
-|---------|-------------|-------------|
+| Feature | Requirement | Mandated by the Redfish spec |
+|---------|-------------|------------------------------|
 | **Power On/Off** | `/redfish/v1/Systems/{id}/Actions/ComputerSystem.Reset` | Yes |
 | **Power Status** | `/redfish/v1/Systems/{id}` -> `PowerState` | Yes |
 | **Set PXE Boot** | `/redfish/v1/Systems/{id}` -> `Boot.BootSourceOverrideTarget = Pxe` | Yes |
 | **System Info** | `/redfish/v1/Systems/{id}` -> Manufacturer, Model, Serial | Yes |
 | **Network Info** | `/redfish/v1/Systems/{id}/EthernetInterfaces` | Yes |
 
-Everything Beskar7 needs is universally supported!
+Everything Beskar7 needs is part of the base Redfish specification, which is
+why no vendor-specific handling is required. Whether a given BMC *implements*
+the spec correctly is a firmware question — see "What has actually been
+validated" above.
 
 ## FAQ
 
 **Q: Do I need vendor-specific configuration?**
-A: No! Beskar7 works the same on all vendors.
+A: No — Beskar7 uses the same code path on every vendor, with no vendor-specific branches.
 
 **Q: Do I need to update BMC firmware?**
 A: Recommended but not required. Latest firmware usually has best Redfish compliance.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ The external SAN is added to both certificate paths: the cert-manager `Certifica
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.8/beskar7-manifests-v0.4.0-alpha.8.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.9/beskar7-manifests-v0.4.0-alpha.9.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -171,7 +171,7 @@ Memory Limit = (Host Count × 0.5MB) + (Webhook Concurrency × 10MB) + 100MB (ba
 Configure reconciliation intervals based on your needs:
 
 ```yaml
-# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.8.
+# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.9.
 args:
 - --leader-elect=true
 - --metrics-bind-address=:8443

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Operators
 
-This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.8. Each item is anchored to source code so you can verify the claim.
+This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.9. Each item is anchored to source code so you can verify the claim.
 
 If you are looking for hardening recommendations, see [Configuration](configuration.md). For RBAC details, see [RBAC Hardening](rbac-hardening.md). For incident debugging, see [Troubleshooting](troubleshooting.md).
 

--- a/examples/minimal-test-cluster.yaml
+++ b/examples/minimal-test-cluster.yaml
@@ -1,6 +1,6 @@
 # Minimal Test Cluster Example
 #
-# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.8
+# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.9
 # inspection workflow. NOT a working cluster — bring this up first to verify the
 # inspection round-trip, then graduate to examples/kairos-k3s-node.yaml.
 #

--- a/examples/security/README.md
+++ b/examples/security/README.md
@@ -1,6 +1,6 @@
 # Beskar7 Security Examples
 
-Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.8 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
+Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.9 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
 
 ## What's actually enforced
 

--- a/examples/security/development.yaml
+++ b/examples/security/development.yaml
@@ -1,4 +1,4 @@
-# Development-style security configuration for Beskar7 v0.4.0-alpha.8.
+# Development-style security configuration for Beskar7 v0.4.0-alpha.9.
 #
 # Loosens TLS verification for self-signed BMC certs typical in lab setups.
 # Do NOT use this configuration in production.

--- a/examples/security/production.yaml
+++ b/examples/security/production.yaml
@@ -1,4 +1,4 @@
-# Production-style security configuration for Beskar7 v0.4.0-alpha.8.
+# Production-style security configuration for Beskar7 v0.4.0-alpha.9.
 #
 # This file demonstrates the enforced security knobs only — the
 # beskar7-security-policy ConfigMap and the various "security framework"


### PR DESCRIPTION
Two changes shipping together, because the second shouldn't be published in yet another release.

## 1. Hardware compatibility — remove the overclaim

`docs/hardware-compatibility.md` marked **five vendors "Tested"** and carried per-vendor experience claims: *"All tested features work flawlessly"* (HPE), *"No issues encountered"* (Lenovo), *"Power management very reliable"* (Dell).

**No physical vendor BMC has ever been validated.** The only evidence in-tree is:
- a stateful fake (`internal/redfishmock`) that emulates vendor service roots,
- the DMTF `public-rackmount1` mockup walked by the real gofish client,
- sushy-tools emulation for the e2e loop.

A company evaluating Beskar7 would reasonably read that table as "my iDRAC fleet is covered." It isn't — and emulators are faithful to the spec, which is exactly why they can't surface the firmware quirks real BMCs have.

**What changed**
- Separates the **design property** (no vendor-specific code paths — verifiable in the 9-method client) from **validation status** (not yet done on real hardware — now stated plainly).
- "Tested" column → **Expected** / **Validated on real hardware** (all "Not yet").
- Fabricated per-vendor prose → a **"What has actually been validated"** section naming the three emulated surfaces exactly.
- Keeps genuinely useful guidance, reframed as general Redfish expectation rather than Beskar7 findings; documents the sushy `Once` boot-override behavior as a harness limitation, not a product one.
- Adds a "Reporting real-hardware results" path — the fastest way to turn a "Not yet" into a real result.
- Feature matrix column *"All Vendors"* → *"Mandated by the Redfish spec"* (a spec claim, not a test claim). Same correction to the README one-liner.

## 2. Release v0.4.0-alpha.9

The adoption-readiness release: `v1beta1` frozen, contract **v4.2** (per-host `ProviderID`), **signed** images, and a **distributable** inspector.

- CHANGELOG `[Unreleased]` promoted to `[v0.4.0-alpha.9]` with a summary and an explicit **"upgrading requires action"** pointer to the breaking API entry. Added the previously-unrecorded docs/security/supply-chain work (#131, #133–#135, #137, #140–#142) and fixed a stale fixture filename (`golden_boot_cmdline_v4_2.txt` → `golden_boot_cmdline.txt`).
- Version bumped across `Makefile`, `Chart.yaml`, docs and examples.

**Signing takes effect at this tag**, which makes the verification guidance added in #141/#142 actually true for the controller image.

> Caught during the bump: the blanket version sed rewrote a *historical* reference ("signing was enabled after alpha.8") into "after alpha.9", making the note self-contradictory. Corrected — flagging it as the kind of thing blanket version bumps break.

## Verification

`make manifests` + `sync-chart-crds` idempotent (no drift), `helm lint` clean, `go build` clean, `golangci-lint` 0 issues, contract/rbac/webhook tests pass.