### PR TITLE
feat(manager): add --max-concurrent-reconciles (default 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+- **`--max-concurrent-reconciles` manager flag** — sets the reconcile worker count for all three controllers. Defaults to `1`, matching controller-runtime, so deployments that do not set it are unaffected. The motivation is fault isolation more than throughput: with a single worker, one unreachable BMC can occupy it for a full 30s Redfish timeout and stall reconciles for healthy hosts. Raising it is safe with respect to BMC load because controller-runtime never reconciles the same object concurrently, so distinct workers always act on distinct `PhysicalHost`s. Supersedes the earlier MEDIUM-1 decision to leave concurrency code-only, which assumed operators could patch and rebuild — no longer true once external adopters run fleets. Documented in `docs/{troubleshooting,resource-planning,deployment-best-practices}.md`.
+
+### Fixed
+- **`Beskar7ClusterReconciler.SetupWithManager` silently discarded its `options` argument** — the `controller.Options` parameter was accepted and never applied, so any caller-supplied controller configuration was dropped. The options are now passed through to the builder (with the worker count overlaid). No behaviour change today, since the only caller passed an empty struct.
+
+
 ## [v0.4.0-alpha.9] - 2026-08-31
 
 The "adoption readiness" release: the `v1beta1` API is **frozen**, the

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -48,8 +48,9 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme                  = runtime.NewScheme()
+	setupLog                = ctrl.Log.WithName("setup")
+	maxConcurrentReconciles int
 )
 
 func init() {
@@ -128,6 +129,12 @@ func main() {
 		"How long a host may stay in the Deploying phase before the Beskar7Machine is "+
 			"marked terminally failed (DeploymentTimedOut). Raise this for hardware with "+
 			"slow storage or very large OS images (D-015).")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", controllers.DefaultMaxConcurrentReconciles,
+		"Number of concurrent reconcile workers per controller. The default (1) matches "+
+			"controller-runtime and preserves historical behaviour. Raise it when a fleet is "+
+			"large enough that a single unreachable BMC's 30s Redfish timeout stalls reconciles "+
+			"for healthy hosts; controller-runtime never reconciles the same object "+
+			"concurrently, so distinct workers always act on distinct BMCs.")
 
 	// Default to production-safe zap config: structured JSON output, no stack
 	// traces below Error, level-based encoding. Operators who want
@@ -209,6 +216,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if maxConcurrentReconciles < 1 {
+		setupLog.Info("--max-concurrent-reconciles below 1; using the default",
+			"requested", maxConcurrentReconciles, "effective", controllers.DefaultMaxConcurrentReconciles)
+		maxConcurrentReconciles = controllers.DefaultMaxConcurrentReconciles
+	}
+	setupLog.Info("Reconciler concurrency", "maxConcurrentReconciles", maxConcurrentReconciles)
+
 	// Setup controllers
 	// RedfishClientFactory is intentionally omitted; SetupWithManager defaults it to
 	// internalredfish.NewClient and returns an error if it remains nil after defaulting.
@@ -219,24 +233,28 @@ func main() {
 		BootstrapURLBase:  bootstrapURLBase,
 		InspectionTimeout: inspectionTimeout,
 		DeploymentTimeout: deploymentTimeout,
+
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Beskar7Machine")
 		os.Exit(1)
 	}
 
 	if err = (&controllers.Beskar7ClusterReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(context.Background(), mgr, controller.Options{}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Beskar7Cluster")
 		os.Exit(1)
 	}
 
 	if err = (&controllers.PhysicalHostReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Log:      ctrl.Log.WithName("controllers").WithName("PhysicalHost"),
-		Recorder: mgr.GetEventRecorderFor("beskar7-physicalhost-controller"),
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Log:                     ctrl.Log.WithName("controllers").WithName("PhysicalHost"),
+		Recorder:                mgr.GetEventRecorderFor("beskar7-physicalhost-controller"),
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PhysicalHost")
 		os.Exit(1)

--- a/controllers/beskar7cluster_controller.go
+++ b/controllers/beskar7cluster_controller.go
@@ -54,6 +54,9 @@ type Beskar7ClusterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	Log    logr.Logger
+	// MaxConcurrentReconciles is the worker count for this controller. Zero
+	// means DefaultMaxConcurrentReconciles (1).
+	MaxConcurrentReconciles int
 }
 
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=beskar7clusters,verbs=get;list;watch;create;update;patch;delete
@@ -435,6 +438,12 @@ func (r *Beskar7ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctr
 			&infrastructurev1beta1.PhysicalHost{},
 			handler.EnqueueRequestsFromMapFunc(r.PhysicalHostToBeskar7Clusters),
 		).
+		// options was previously accepted and silently discarded; apply it, with
+		// the worker count overlaid from the reconciler's own configuration.
+		WithOptions(func() controller.Options {
+			options.MaxConcurrentReconciles = maxConcurrentOrDefault(r.MaxConcurrentReconciles)
+			return options
+		}()).
 		Complete(r)
 }
 

--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -93,6 +94,9 @@ type Beskar7MachineReconciler struct {
 	// <BootstrapURLBase>/api/v1/bootstrap/<namespace>/<name>. Must be non-empty;
 	// validated in SetupWithManager.
 	BootstrapURLBase string
+	// MaxConcurrentReconciles is the worker count for this controller. Zero
+	// means DefaultMaxConcurrentReconciles (1).
+	MaxConcurrentReconciles int
 	// InspectionTimeout bounds how long a host may stay in Inspecting before the
 	// machine is marked terminally failed (InspectionTimedOut). Zero means use
 	// DefaultInspectionTimeout. Set from the --inspection-timeout manager flag so
@@ -1468,6 +1472,9 @@ func (r *Beskar7MachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&infrastructurev1beta1.PhysicalHost{},
 			handler.EnqueueRequestsFromMapFunc(r.PhysicalHostToBeskar7Machine),
 		).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentOrDefault(r.MaxConcurrentReconciles),
+		}).
 		Complete(r)
 }
 

--- a/controllers/max_concurrent_reconciles_test.go
+++ b/controllers/max_concurrent_reconciles_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import "testing"
+
+// TestMaxConcurrentOrDefault pins the normalisation rule the three
+// SetupWithManager implementations rely on: an unset (zero) or nonsensical
+// worker count must collapse to the historical single-worker behaviour rather
+// than to controller-runtime's "0 means default" implicit handling, so the
+// value we pass is always explicit and auditable.
+func TestMaxConcurrentOrDefault(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"unset zero value falls back to the default", 0, DefaultMaxConcurrentReconciles},
+		{"negative is treated as unset", -1, DefaultMaxConcurrentReconciles},
+		{"large negative is treated as unset", -9999, DefaultMaxConcurrentReconciles},
+		{"one is preserved", 1, 1},
+		{"explicit higher value is preserved", 8, 8},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := maxConcurrentOrDefault(tc.in); got != tc.want {
+				t.Errorf("maxConcurrentOrDefault(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDefaultMaxConcurrentReconcilesMatchesControllerRuntime documents why the
+// default is 1: it is the value controller-runtime itself uses, so adding this
+// flag is a no-op for every existing deployment. A change here is a behaviour
+// change for operators who never set the flag, and should be deliberate.
+func TestDefaultMaxConcurrentReconcilesMatchesControllerRuntime(t *testing.T) {
+	if DefaultMaxConcurrentReconciles != 1 {
+		t.Fatalf("DefaultMaxConcurrentReconciles = %d, want 1 — raising the default "+
+			"silently changes concurrency for deployments that never set the flag",
+			DefaultMaxConcurrentReconciles)
+	}
+}

--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -62,6 +62,9 @@ type PhysicalHostReconciler struct {
 	Scheme               *runtime.Scheme
 	Recorder             record.EventRecorder
 	RedfishClientFactory internalredfish.RedfishClientFactory
+	// MaxConcurrentReconciles is the worker count for this controller. Zero
+	// means DefaultMaxConcurrentReconciles (1).
+	MaxConcurrentReconciles int
 }
 
 // NewPhysicalHostReconciler creates a new PhysicalHostReconciler
@@ -769,6 +772,7 @@ func (r *PhysicalHostReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.SecretToPhysicalHosts),
 		).
 		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentOrDefault(r.MaxConcurrentReconciles),
 			// Exponential backoff for transient Redfish failures. The previous
 			// fixed RequeueAfter: 1*time.Minute on every error path meant a
 			// persistently-misconfigured BMC was pinged every 60s forever; now

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -36,3 +36,23 @@ func isClusterPaused(cluster *clusterv1.Cluster) bool {
 	}
 	return annotations.HasPaused(cluster)
 }
+
+// DefaultMaxConcurrentReconciles is the per-controller worker count used when
+// none is configured. It matches controller-runtime's own default, so the
+// zero value preserves historical single-worker behaviour exactly.
+//
+// Raising it is safe with respect to BMC load: controller-runtime never
+// reconciles the same object key concurrently, so distinct workers always act
+// on distinct PhysicalHosts — and therefore distinct BMCs. The reason to raise
+// it is head-of-line blocking: a single unreachable BMC can occupy the only
+// worker for a full 30s Redfish timeout, stalling reconciles for healthy hosts.
+const DefaultMaxConcurrentReconciles = 1
+
+// maxConcurrentOrDefault normalises an unset (zero) or negative worker count to
+// DefaultMaxConcurrentReconciles.
+func maxConcurrentOrDefault(n int) int {
+	if n < 1 {
+		return DefaultMaxConcurrentReconciles
+	}
+	return n
+}

--- a/docs/deployment-best-practices.md
+++ b/docs/deployment-best-practices.md
@@ -734,14 +734,20 @@ args:
 - --leader-elect-renew-deadline=10s   # default 10s
 - --leader-elect-retry-period=2s      # default 2s
 - --inspection-timeout=10m            # raise for slow-POST hardware
+- --max-concurrent-reconciles=1       # default 1; raise for larger fleets
 ```
 
-There is **no** `--concurrent-reconciles`, `--max-concurrent-reconciles`,
-`--worker-count`, or `--resync-period` flag. Each controller runs with
-controller-runtime's default `MaxConcurrentReconciles = 1`. Raising
-per-controller concurrency is a code change in
-`controllers/<kind>_controller.go:SetupWithManager`, not configuration — open
-an issue with your scaling profile if the serial default is a real constraint.
+`--max-concurrent-reconciles` sets the reconcile worker count for all three
+controllers; the default `1` matches controller-runtime, so leaving it unset
+preserves the historical serial behaviour exactly. There is no `--worker-count`
+or `--resync-period` flag.
+
+Raising it is safe with respect to BMC load — controller-runtime never
+reconciles the same object concurrently, so distinct workers always act on
+distinct `PhysicalHost`s and therefore distinct BMCs. The usual reason to raise
+it is fault isolation rather than throughput: with one worker, a single
+unreachable BMC can occupy it for a full 30s Redfish timeout and stall
+reconciles for healthy hosts.
 
 ### 2. Caching and rate limiting
 

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -185,9 +185,21 @@ args:
 # Optional: how long a host may stay Inspecting before InspectionTimedOut.
 # Default 10m; raise for hardware with slow BIOS POST / slow first-boot inspection.
 - --inspection-timeout=10m
+# Optional: reconcile workers per controller. Default 1. Raise for larger fleets
+# or to stop one unreachable BMC's 30s timeout blocking healthy hosts.
+- --max-concurrent-reconciles=4
 ```
 
-There is no `--max-concurrent-reconciles*` or `--reconciliation-interval` flag; the controller-runtime defaults apply (one reconciler per controller; per-resource requeue intervals encoded in the controllers themselves). Per-controller concurrency would have to be raised in code in `controllers/<kind>_controller.go:SetupWithManager`.
+`--max-concurrent-reconciles` sets the worker count for **all three** controllers
+(default `1`, matching controller-runtime). There is no `--reconciliation-interval`
+flag; per-resource requeue intervals are encoded in the controllers themselves
+(steady-state `PhysicalHost` resync is 5 minutes).
+
+Sizing: a healthy `PhysicalHost` reconcile makes a Redfish connect plus three reads,
+so it is dominated by BMC latency rather than CPU. The single-worker default is
+adequate for small fleets; raise it when either the 5-minute resync cannot keep up
+with your host count, or — more commonly — when unreachable BMCs burning 30s timeouts
+would otherwise block reconciles for healthy hosts.
 
 ### Health Check Tuning
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -501,7 +501,29 @@ kubectl get beskar7machine -o custom-columns=NAME:.metadata.name,PHASE:.status.p
 
 **Symptom:** Resources take long time to update.
 
-There is no per-controller `--max-concurrent-reconciles-*` flag in v0.4. The reconcilers use controller-runtime's default (`MaxConcurrentReconciles = 1`). If you genuinely need to raise concurrency, the change is in code — `controllers/<kind>_controller.go:SetupWithManager` — not configuration. Open an issue with your scaling profile if the default is a real constraint.
+Each controller runs **one reconcile worker by default** (`--max-concurrent-reconciles=1`,
+matching controller-runtime). With a single worker, reconciles are serialised — and
+because every Redfish call carries a 30s timeout, **one unreachable BMC can occupy the
+only worker and stall reconciles for healthy hosts**. That head-of-line blocking, not
+raw throughput, is usually what "slow reconciliation" turns out to be.
+
+Check whether a few unreachable BMCs are consuming the worker:
+
+```bash
+kubectl get physicalhosts -A -o custom-columns=\
+NAME:.metadata.name,STATE:.status.state,ERROR:.status.errorMessage | grep -iv '<none>'
+```
+
+If so, raise concurrency so healthy hosts are not queued behind failing ones:
+
+```yaml
+- --max-concurrent-reconciles=4
+```
+
+This is safe with respect to BMC load: controller-runtime never reconciles the same
+object concurrently, so distinct workers always act on distinct `PhysicalHost`s — and
+therefore distinct BMCs. Size it to your fleet; there is no benefit to setting it far
+above the number of hosts you expect to reconcile in parallel.
 
 ### High CPU/Memory Usage
 


### PR DESCRIPTION
Item (a) of the #6 scale recommendation.

## Why now — and why this reverses MEDIUM-1

All three controllers run **one reconcile worker**, changeable only by patching Go and rebuilding. `MEDIUM-1` deliberately closed this as speculative config surface, and that was **correct for its moment**: with the maintainer as the only operator, *"raise it in code / open an issue with your scaling profile"* was a reasonable answer.

That premise died with external adoption. Adopters run fleets and cannot fork the operator.

**The decisive argument is fault isolation, not throughput.** Every Redfish call carries a 30s timeout, so with a single worker one unreachable BMC can occupy it and stall reconciles for *healthy* hosts. Backoff (BUG-14) helps after failures, but each retry still costs a full timeout in the only worker there is.

**Raising it is safe with respect to BMC load** — controller-runtime never reconciles the same object key concurrently, so distinct workers always act on distinct `PhysicalHost`s, and therefore distinct BMCs.

## What

- `MaxConcurrentReconciles` on all three reconcilers, normalised via `maxConcurrentOrDefault` (unset/negative → 1).
- `--max-concurrent-reconciles` in `cmd/manager`, **defaulting to 1** — so this is a **no-op for every existing deployment**. Sub-1 values are corrected with a logged warning; the effective value is logged at startup.
- **Bug fix found along the way:** `Beskar7ClusterReconciler.SetupWithManager` accepted a `controller.Options` argument and **silently discarded it**. Any caller-supplied configuration was dropped. Now applied, with the worker count overlaid. No behaviour change today (the only caller passed `controller.Options{}`), but it was a live trap for the next caller.
- Tests pin the normalisation rule and assert the default stays 1, so raising the default later must be deliberate rather than incidental.
- `docs/{troubleshooting,resource-planning,deployment-best-practices}.md` all stated no such flag existed and told operators to change code. All three now document the flag, sizing rationale, and — in troubleshooting — the head-of-line-blocking symptom with a command to spot it.

## Verification

`make manifests` + `sync-chart-crds` no drift, `go build` clean, `gofmt` clean, `golangci-lint` 0 issues, full `./controllers/...` suite passes.

Next: (b1) — a smoke layer provisioning two mock BMCs via a 2-replica `MachineDeployment` and asserting distinct per-host ProviderIDs, moving most of the P2 validation risk from the lab into CI.