### PR TITLE
chore(release): v0.4.0 — freeze the contract, drop -alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [v0.4.0] - 2026-09-07
+
+**First GA release.** `v1beta1` is stable and frozen, the controller↔inspector
+wire contract is frozen at **v4.2**, release images are signed, and the
+`beskar7-inspector` is distributed as versioned, checksummed, signed artifacts.
+
+Highlights since `v0.4.0-alpha.8`:
+
+- **Per-host `ProviderID` for templated pools (contract v4.2)** — a shared
+  `Beskar7MachineTemplate` cannot pin a per-host `ProviderID`, which blocked
+  `MachineDeployment` pools and multi-replica control planes. The controller now
+  renders `beskar7.provider-id` on `/boot`, the inspector writes it to
+  `/oem/beskar7/provider-id`, and an image-side stage turns it into the kubelet
+  flag. **Verified end-to-end on hardware**: `Node.spec.providerID` came up as
+  `b7://<ns>/<host>` and CAPI advanced the Machine past `Provisioned`.
+- **The distributable inspector** — `beskar7-inspector` now publishes releases
+  with `vmlinuz`, `initrd.img`, checksums, a cosign bundle, and an image tagged
+  by contract version. Adopters no longer clone a second repo and build it.
+- **Signed releases** — images signed with cosign (keyless), controller image
+  carries a signed SPDX SBOM attestation.
+- **`v1beta1` frozen**; **contract v4.2 frozen** with an explicit
+  backward-compatibility policy (contract §14).
+
+**Upgrading:** not compatible with `v0.3.x`; the alpha series contains breaking
+API changes. See [docs/upgrading.md](docs/upgrading.md). Pair the controller with a
+`contract-v4.2` inspector release.
+
+**Known limitation:** releasing a `PhysicalHost` does not sanitize its disk — the
+previous tenant's OS and injected bootstrap config (which may carry a cluster join
+secret) survive until re-provisioning. Wipe hosts before moving them between trust
+boundaries. See [SECURITY.md](SECURITY.md).
+
 ### Fixed
 - **The documented §2.4 ProviderID glue did not work, and now does.** `docs/troubleshooting.md` and `examples/kairos-k3s-node.yaml` presented the per-host ProviderID stage as a `stages:` block inside the `#cloud-config` bootstrap Secret. Kairos honors such a file's top-level keys (`hostname`, `users`, `k3s`) but **silently ignores its `stages:` block** — it is processed as `'<file>.0'` with `commands: 0` and nothing resembling an error is logged. Every `stages:` block shipped in beskar7's docs and examples was therefore inert, including the `enable-sshd` step (and, for the same reason, the Kairos image's own `90_custom.yaml` user setup, which is why SSH password auth failed on provisioned hosts).
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.0-alpha.9
+VERSION ?= v0.4.0
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.0-alpha.9  
-**Status:** Alpha (pre-GA). The `v1beta1` API is **frozen** — no further breaking changes; the schema evolves **additive-only** until a future `v1beta2` (introduced with a conversion webhook) is needed.  
-**Breaking Changes:** v0.4.0 is NOT compatible with v0.3.x ([see CHANGELOG](CHANGELOG.md))
+**Version:** v0.4.0 — **first GA release**  
+**API:** `v1beta1` is **stable and frozen**. The schema evolves **additive-only**; a breaking change requires a future `v1beta2` introduced with a conversion webhook.  
+**Contract:** controller↔inspector wire contract **v4.2, frozen** ([contract](docs/inspector-contract.md)). Pair with a `contract-v4.2` [inspector release](https://github.com/projectbeskar/beskar7-inspector/releases).  
+**Upgrading:** v0.4.0 is **not** compatible with v0.3.x, and the alpha series contains breaking API changes — see [Upgrading](docs/upgrading.md) and the [CHANGELOG](CHANGELOG.md).
 
 ## Installation
 
@@ -47,16 +48,15 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 ```bash
 helm repo add beskar7 https://projectbeskar.github.io/beskar7
 helm repo update
-helm install --devel beskar7 beskar7/beskar7 \
+helm install beskar7 beskar7/beskar7 \
   --namespace beskar7-system --create-namespace
 ```
 
-The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.9`); drop it once a non-prerelease tag is cut.
 
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.9/beskar7-manifests-v0.4.0-alpha.9.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0/beskar7-manifests-v0.4.0.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,18 +32,18 @@ unless you ask us not to, and coordinate disclosure timing with you.
 
 ## Supported versions
 
-Beskar7 is **pre-GA**. Only the latest release receives fixes; there is no
-backport branch.
+Only the latest release receives fixes; there is no backport branch. `v1beta1`
+is stable as of `v0.4.0`, so upgrades within the `v0.4.x` line are additive.
 
 | Version | Supported |
 |---|---|
-| latest `v0.4.0-alpha.*` | ✅ |
+| `v0.4.0` (latest) | ✅ |
 | earlier `v0.4.0-alpha.*` | ❌ upgrade first |
 | `v0.3.x` | ❌ end of life — not compatible with v0.4 ([CHANGELOG](CHANGELOG.md)) |
 
 ## Verifying what you run
 
-Container images published from `v0.4.0-alpha.9` onward are signed with
+Container images published from `v0.4.0` onward are signed with
 [cosign](https://docs.sigstore.dev/) keyless signing, and the controller image
 carries a signed SPDX SBOM attestation. Verification commands are in
 [docs/installation.md](docs/installation.md#verify-release-artifacts-supply-chain).

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0-alpha.9
-appVersion: "v0.4.0-alpha.9"
+version: 0.4.0
+appVersion: "v0.4.0"
 keywords:
   - cluster-api
   - infrastructure

--- a/charts/beskar7/README.md
+++ b/charts/beskar7/README.md
@@ -31,7 +31,7 @@ serving certificate. Two modes:
   Use this on clusters where you don't run cert-manager:
 
   ```bash
-  helm install --devel beskar7 beskar7/beskar7 \
+  helm install beskar7 beskar7/beskar7 \
     --namespace beskar7-system --create-namespace \
     --set certManager.enabled=false
   ```
@@ -41,16 +41,15 @@ serving certificate. Two modes:
 ```bash
 helm repo add beskar7 https://projectbeskar.github.io/beskar7
 helm repo update
-helm install --devel beskar7 beskar7/beskar7 \
+helm install beskar7 beskar7/beskar7 \
   --namespace beskar7-system --create-namespace
 ```
 
-The `--devel` flag is required while the chart version is a SemVer pre-release. Drop it once a non-prerelease version is published.
 
 **Bootstrap URL.** The default `bootstrap.urlBase` is `https://beskar7-controller-manager.beskar7-system.svc:8082`. This matches the Service name when the release is named `beskar7`. If you use a different release name, pass the matching URL:
 
 ```bash
-helm install --devel my-release beskar7/beskar7 \
+helm install my-release beskar7/beskar7 \
   --namespace beskar7-system --create-namespace \
   --set bootstrap.urlBase=https://my-release-controller-manager.beskar7-system.svc:8082
 ```
@@ -141,7 +140,7 @@ kubectl apply -f charts/beskar7/crds/
 Then upgrade the chart:
 
 ```bash
-helm upgrade --devel beskar7 beskar7/beskar7
+helm upgrade beskar7 beskar7/beskar7
 ```
 
 ## Uninstall

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -273,8 +273,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.0-alpha.N`; bump N for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.0-alpha.9
-   git push origin v0.4.0-alpha.9
+   git tag v0.4.0
+   git push origin v0.4.0
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0-alpha.9`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/inspector-contract.md
+++ b/docs/inspector-contract.md
@@ -1,6 +1,14 @@
 # Beskar7 Controller ↔ Inspector Contract
 
-**Contract version: `v4.2`**
+**Contract version: `v4.2` — FROZEN for v0.4.0 GA**
+
+> The wire contract is **frozen** as of `v0.4.0`. Within the `v4.x` line, changes
+> MUST be additive and backward-compatible, as specified in
+> [§14 Backward-compatibility policy](#14-backward-compatibility-policy).
+> Breaking changes — removing or retyping a field, changing an endpoint's
+> semantics, changing the **ProviderID format** (`b7://<ns>/<host>`) or the
+> **digest algorithm** (`sha256:`) — require a major bump (`v5`) with a
+> deprecation window, and are not permitted inside the GA `v0.4.x` line.
 
 This document is the single source of truth for the wire contract between the
 Beskar7 controller (`github.com/projectbeskar/beskar7`) and the inspection

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,16 +32,15 @@ kubectl get pods -n cert-manager
 ```bash
 helm repo add beskar7 https://projectbeskar.github.io/beskar7
 helm repo update
-helm install --devel beskar7 beskar7/beskar7 \
+helm install beskar7 beskar7/beskar7 \
   --namespace beskar7-system --create-namespace
 ```
 
-The `--devel` flag is required while the chart version is a SemVer pre-release (`0.4.0-alpha.*`). Drop it once a non-prerelease tag is published.
 
 **Release name and bootstrap URL.** The chart's default `bootstrap.urlBase` is `https://beskar7-controller-manager.beskar7-system.svc:8082`, which matches the Service name when the Helm release is named `beskar7`. If you install with a different release name, pass the matching URL:
 
 ```bash
-helm install --devel my-release beskar7/beskar7 \
+helm install my-release beskar7/beskar7 \
   --namespace beskar7-system --create-namespace \
   --set bootstrap.urlBase=https://my-release-controller-manager.beskar7-system.svc:8082
 ```
@@ -58,7 +57,7 @@ For a real deployment, two things must line up:
 2. **Cover the external address in the serving-cert SAN.** List the external DNS name(s) and/or IP(s) in `callback.externalNames` / `callback.externalIPs`. The host portion of `bootstrap.urlBase` **must** be one of these — the inspector verifies the callback certificate against the CA it is handed on the kernel cmdline and has no insecure-skip path, so a SAN mismatch is a hard failure.
 
 ```bash
-helm install --devel beskar7 beskar7/beskar7 \
+helm install beskar7 beskar7/beskar7 \
   --namespace beskar7-system --create-namespace \
   --set callback.service.type=LoadBalancer \
   --set bootstrap.urlBase=https://beskar7.example.com:8082 \
@@ -70,7 +69,7 @@ The external SAN is added to both certificate paths: the cert-manager `Certifica
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.9/beskar7-manifests-v0.4.0-alpha.9.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0/beskar7-manifests-v0.4.0.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.
@@ -81,9 +80,9 @@ Container images are signed with [cosign](https://docs.sigstore.dev/) using keyl
 (OIDC) signing bound to the release workflow's identity — there is no long-lived
 signing key. The controller image also carries a signed SPDX SBOM attestation.
 
-> **Applies from `v0.4.0-alpha.9` onward.** Signing was enabled after
-> `v0.4.0-alpha.8` was published, so that and earlier alpha images carry no
-> signature and will not verify — this is expected, not a tampering signal.
+> **Applies from `v0.4.0-alpha.9` onward** (including `v0.4.0`). Signing was
+> enabled after `v0.4.0-alpha.8` was published, so that and earlier alpha images
+> carry no signature and will not verify — expected, not a tampering signal.
 
 Verify an image before deploying it:
 

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -171,7 +171,7 @@ Memory Limit = (Host Count × 0.5MB) + (Webhook Concurrency × 10MB) + 100MB (ba
 Configure reconciliation intervals based on your needs:
 
 ```yaml
-# Real flags accepted by cmd/manager/main.go in v0.4.0-alpha.9.
+# Real flags accepted by cmd/manager/main.go in v0.4.0.
 args:
 - --leader-elect=true
 - --metrics-bind-address=:8443

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Operators
 
-This page documents the security controls Beskar7 actually enforces in v0.4.0-alpha.9. Each item is anchored to source code so you can verify the claim.
+This page documents the security controls Beskar7 actually enforces in v0.4.0. Each item is anchored to source code so you can verify the claim.
 
 If you are looking for hardening recommendations, see [Configuration](configuration.md). For RBAC details, see [RBAC Hardening](rbac-hardening.md). For incident debugging, see [Troubleshooting](troubleshooting.md).
 

--- a/docs/smoke-testing.md
+++ b/docs/smoke-testing.md
@@ -83,7 +83,7 @@ By default the runner tears down everything in the `beskar7-smoke` namespace on 
 
 Prerequisites on the target cluster:
 
-- Beskar7 controller installed (`helm install --devel beskar7 beskar7/beskar7 -n beskar7-system --create-namespace`)
+- Beskar7 controller installed (`helm install beskar7 beskar7/beskar7 -n beskar7-system --create-namespace`)
 - cert-manager installed (the chart depends on it for the webhook serving cert)
 - Cluster API core installed (so the CAPI `Machine` controller is present and won't block reconciliation on a missing webhook)
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -2,9 +2,9 @@
 
 > **Audience:** Operators
 
-Beskar7 is **pre-GA**: the `v1beta1` API is frozen and evolves additive-only, but
-alpha releases before that freeze contain breaking changes. Read the section for
-your starting version before upgrading.
+`v0.4.0` is the first GA release. `v1beta1` is stable and evolves additive-only
+from here, but the **alpha series leading up to it contains breaking changes** —
+read the section for your starting version before upgrading.
 
 ## Before you start
 
@@ -31,6 +31,7 @@ from the release you deployed:
 
 | beskar7 release | contract |
 |---|---|
+| `v0.4.0` (GA) | `v4.2` **frozen** |
 | `v0.4.0-alpha.9` | `v4.2` |
 | `v0.4.0-alpha.8` | `v4.1` |
 | `v0.4.0-alpha.7` | `v4` |
@@ -39,7 +40,7 @@ From a source checkout of the matching tag:
 
 ```bash
 # alpha.9 and later carry a machine-readable marker:
-git show v0.4.0-alpha.9:test/contract/VERSION      # -> v4.2
+git show v0.4.0:test/contract/VERSION      # -> v4.2
 
 # earlier tags predate that file — read the contract doc header instead:
 git show v0.4.0-alpha.8:docs/inspector-contract.md | head -5
@@ -59,7 +60,29 @@ Within a frozen `v4.x` line the changes are additive, so a controller tolerates 
 inspector one minor version behind — it simply does not get the newer capability
 (see `docs/inspector-contract.md` §14). Do not rely on that across a major bump.
 
-## `v0.4.0-alpha.8` → `v0.4.0-alpha.9` — **breaking**
+## `v0.4.0-alpha.9` → `v0.4.0` — no API changes
+
+`v0.4.0` is `alpha.9` plus documentation, examples and the contract freeze. There
+are **no API or wire-contract changes**, so this is a straight image + chart
+upgrade:
+
+```bash
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0/beskar7-manifests-v0.4.0.yaml
+helm repo update && helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.0
+```
+
+The `--devel` flag is no longer needed: `0.4.0` is not a SemVer pre-release.
+
+**One thing worth acting on even though nothing forces you to.** If you run
+templated `MachineDeployment` pools, the per-host ProviderID stage documented
+before `v0.4.0` **never executed** — Kairos silently ignores a `stages:` block in
+a `#cloud-config` file. The working form is a yip config baked into the target
+image: [`examples/kairos-providerid-stage.yaml`](../examples/kairos-providerid-stage.yaml).
+Existing nodes that joined without it kept their distro-default ProviderID
+(`k3s://<hostname>`), and because `Node.spec.providerID` is immutable they must be
+**re-provisioned** to pick up `b7://<ns>/<host>` — it cannot be fixed in place.
+
+## `v0.4.0-alpha.8` → `v0.4.0` — **breaking**
 
 Two API changes require editing existing CRs **before** the new CRDs are applied,
 or the objects will fail validation.
@@ -104,11 +127,11 @@ unaffected — this only matters if you generate manifests programmatically.
 
 ### Contract moves to v4.2
 
-alpha.9 speaks **contract v4.2**, which adds per-host `ProviderID` delivery for
-templated pools. Upgrade the inspector to a `contract-v4.2` build. A v4.1
-inspector keeps working (it ignores the new cmdline parameter) but will not write
-`/oem/beskar7/provider-id`, so `MachineDeployment` pools stay on the P1
-hand-authored pattern.
+`v0.4.0` speaks **contract v4.2** (frozen), which adds per-host `ProviderID`
+delivery for templated pools. Upgrade the inspector to a `contract-v4.2` build. A
+v4.1 inspector keeps working — it ignores the new cmdline parameter — but will not
+write `/oem/beskar7/provider-id`, so `MachineDeployment` pools stay on the
+hand-authored per-host pattern.
 
 ### Procedure
 
@@ -116,11 +139,11 @@ hand-authored pattern.
 # 1. Fix existing CRs FIRST (see above) — validation is applied on CRD upgrade.
 
 # 2. CRDs
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0-alpha.9/beskar7-manifests-v0.4.0-alpha.9.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0/beskar7-manifests-v0.4.0.yaml
 
 # 3. Controller
 helm repo update
-helm upgrade --devel beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.0-alpha.9
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.0
 
 # 4. Inspector artifacts on your boot server
 REL=https://github.com/projectbeskar/beskar7-inspector/releases/latest/download

--- a/examples/minimal-test-cluster.yaml
+++ b/examples/minimal-test-cluster.yaml
@@ -1,6 +1,6 @@
 # Minimal Test Cluster Example
 #
-# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0-alpha.9
+# A simplified single-host scenario for quick testing of the Beskar7 v0.4.0
 # inspection workflow. NOT a working cluster — bring this up first to verify the
 # inspection round-trip, then graduate to examples/kairos-k3s-node.yaml.
 #

--- a/examples/security/README.md
+++ b/examples/security/README.md
@@ -1,6 +1,6 @@
 # Beskar7 Security Examples
 
-Two short examples demonstrating the security knobs Beskar7 v0.4.0-alpha.9 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
+Two short examples demonstrating the security knobs Beskar7 v0.4.0 actually enforces. The "comprehensive security framework" advertised in earlier drafts (a `beskar7-security-policy` ConfigMap, the `--enable-security-monitoring` flag, the `beskar7-security-monitor` CronJob, CIS/NIST/SOC 2 compliance scoring) was never implemented and has been removed.
 
 ## What's actually enforced
 

--- a/examples/security/development.yaml
+++ b/examples/security/development.yaml
@@ -1,4 +1,4 @@
-# Development-style security configuration for Beskar7 v0.4.0-alpha.9.
+# Development-style security configuration for Beskar7 v0.4.0.
 #
 # Loosens TLS verification for self-signed BMC certs typical in lab setups.
 # Do NOT use this configuration in production.

--- a/examples/security/production.yaml
+++ b/examples/security/production.yaml
@@ -1,4 +1,4 @@
-# Production-style security configuration for Beskar7 v0.4.0-alpha.9.
+# Production-style security configuration for Beskar7 v0.4.0.
 #
 # This file demonstrates the enforced security knobs only — the
 # beskar7-security-policy ConfigMap and the various "security framework"


### PR DESCRIPTION
**First GA release.** Freeze-checklist items **3** and **8**.

## Contract freeze (item 3)

`docs/inspector-contract.md` is now stamped **`v4.2 — FROZEN for v0.4.0 GA`**, with the compatibility rule stated up front: additive-only within `v4.x`; removing/retyping a field, changing endpoint semantics, the **ProviderID format**, or the **digest algorithm** requires a `v5` bump.

I deliberately **did not** stamp this in #147, because `GA-CONTRACT-FREEZE.md:441` makes the freeze contingent on checklist item 4 — and item 4 only went green once the per-host ProviderID glue was proven end-to-end on hardware in #149 (`Node.spec.providerID = b7://b7e2e/b7e2e-cp0`). It's legitimate now.

## Version + status (item 8)

`v0.4.0-alpha.9` → `v0.4.0` across `Makefile`, chart `version`+`appVersion`, docs and examples — plus the status language a version bump alone would have left wrong:

- **README**: "Alpha (pre-GA)" → first GA release; `v1beta1` stable and frozen; contract v4.2 frozen with a pointer to a matching inspector release.
- **`SECURITY.md`**, **`docs/upgrading.md`**: pre-GA wording removed.
- **`--devel` dropped from all six** install/upgrade snippets, and the explanatory sentences deleted. That flag exists *only* because the chart version was a SemVer pre-release; `0.4.0` isn't. Leaving it would teach a habit that stops making sense the moment it's copied.

**`docs/upgrading.md`** gains a real `alpha.9 → v0.4.0` section (no API or wire changes — straight image + chart upgrade) and extends the release→contract table. It also flags the one thing worth acting on: pool operators whose nodes joined under the never-working ProviderID stage must **re-provision** them, because `Node.spec.providerID` is immutable and can't be corrected in place.

**CHANGELOG** `[Unreleased]` → `[v0.4.0]` with release notes covering per-host ProviderID delivery, the distributable inspector, signed releases, both freezes, the upgrade path, and the disk-sanitization limitation.

## Two things I deliberately did NOT change

1. **`docs/installation.md`'s signing note** still reads *"applies from `v0.4.0-alpha.9` onward"*. The blanket version sed rewrote it to `v0.4.0`, which would have been **false** — alpha.9 *is* signed. Restored, and annotated "(including `v0.4.0`)". This is the same class of bug a blanket sed introduced during the alpha.9 bump, so I checked for it explicitly.
2. **`hack/smoke` fallback image tags** stay at `v0.4.0-alpha.3`. I bumped them, then reverted: the smoke runner derives the tag from the installed controller image and only *falls back* to these, so pointing a fallback at an unpublished `v0.4.0` tag would break smoke if derivation ever failed. `docs/beskar7cluster.md`'s "fixed in v0.4.0-alpha.4" is likewise historical and untouched.

## Verification

`make manifests` + `sync-chart-crds` no drift · `helm lint` clean, rendering `v0.4.0` · `go build` clean · `golangci-lint` 0 issues · all 10 test packages pass · every example parses · no dead relative links.

## After merge

Push the `v0.4.0` tag → `release.yml` publishes signed images + SBOM attestation + the manifest bundle, and `helm-publish.yml` pushes the chart. Then checklist **item 9** (final e2e on the tagged build) is the last thing standing.