### PR TITLE
fix(chart): survive `helm upgrade --reuse-values`

### DIFF
--- a/charts/beskar7/README.md
+++ b/charts/beskar7/README.md
@@ -140,8 +140,14 @@ kubectl apply -f charts/beskar7/crds/
 Then upgrade the chart:
 
 ```bash
-helm upgrade beskar7 beskar7/beskar7
+helm upgrade beskar7 beskar7/beskar7 --reset-then-reuse-values
 ```
+
+**Do not use `--reuse-values`.** It reconstructs values from the *old* chart's
+defaults, so value keys added since the release you installed are missing and the
+upgrade fails to render. `--reset-then-reuse-values` (Helm 3.14+) replays your
+overrides on top of the new chart's defaults; on older Helm, pass your own
+`-f values.yaml` every time. See [docs/upgrading.md](../../docs/upgrading.md).
 
 ## Uninstall
 

--- a/charts/beskar7/templates/NOTES.txt
+++ b/charts/beskar7/templates/NOTES.txt
@@ -21,9 +21,9 @@
 7. Monitoring is enabled - metrics are available at https://localhost:8443/metrics (HTTPS, requires auth)
 {{- end }}
 
-{{- if eq (.Values.callback.service.type | default "ClusterIP") "ClusterIP" }}
+{{- if eq (((.Values.callback | default dict).service | default dict).type | default "ClusterIP") "ClusterIP" }}
 
-NOTE: bootstrap.urlBase is "{{ .Values.bootstrap.urlBase }}".
+NOTE: bootstrap.urlBase is "{{ (.Values.bootstrap | default dict).urlBase }}".
    Bare-metal hosts must reach the callback server (:8082) DURING PXE boot, before
    they join the cluster network — a cluster-internal .svc address is NOT reachable
    from real hardware. Expose the callback Service externally (set
@@ -33,8 +33,8 @@ NOTE: bootstrap.urlBase is "{{ .Values.bootstrap.urlBase }}".
    them. See docs/installation.md (External reachability) and docs/inspector-contract.md.
 {{- else }}
 
-8. Callback Service is exposed as type {{ .Values.callback.service.type }}. Confirm
-   bootstrap.urlBase ({{ .Values.bootstrap.urlBase }}) resolves to that address and is
+8. Callback Service is exposed as type {{ ((.Values.callback | default dict).service | default dict).type | default "ClusterIP" }}. Confirm
+   bootstrap.urlBase ({{ (.Values.bootstrap | default dict).urlBase }}) resolves to that address and is
    listed in callback.externalNames / callback.externalIPs (serving-cert SAN), or the
    inspector will reject the callback TLS handshake.
    SECURITY: scope this exposure to the provisioning network — do NOT publish :8082

--- a/charts/beskar7/templates/_helpers.tpl
+++ b/charts/beskar7/templates/_helpers.tpl
@@ -129,8 +129,9 @@ install/upgrade path hits the cluster and is stable.
       callback names/IPs so the SAME cert validates for bare-metal hosts hitting
       :8082. genSignedCert signature is (CN, ipAddresses, dnsNames, days, ca).
     */ -}}
-    {{- $dnsNames := concat (list $cn) (.Values.callback.externalNames | default (list)) -}}
-    {{- $ipAddrs := .Values.callback.externalIPs | default (list) -}}
+    {{- $callback := .Values.callback | default dict -}}
+    {{- $dnsNames := concat (list $cn) ($callback.externalNames | default (list)) -}}
+    {{- $ipAddrs := $callback.externalIPs | default (list) -}}
     {{- $cert := genSignedCert $cn $ipAddrs $dnsNames 3650 $caCert -}}
     {{- $certs = dict "crt" (b64enc $cert.Cert) "key" (b64enc $cert.Key) "ca" (b64enc $caCert.Cert) -}}
   {{- end -}}

--- a/charts/beskar7/templates/certificate.yaml
+++ b/charts/beskar7/templates/certificate.yaml
@@ -18,10 +18,10 @@ spec:
   # In-cluster SAN for the webhook server (apiserver verifies against this).
   - {{ .Values.webhook.service.name }}.{{ include "beskar7.namespace" . }}.svc
   {{- /* External SANs for the callback server, reachable by bare-metal hosts. */}}
-  {{- range .Values.callback.externalNames }}
+  {{- range (.Values.callback | default dict).externalNames }}
   - {{ . | quote }}
   {{- end }}
-  {{- with .Values.callback.externalIPs }}
+  {{- with (.Values.callback | default dict).externalIPs }}
   ipAddresses:
     {{- range . }}
   - {{ . | quote }}

--- a/charts/beskar7/templates/deployment.yaml
+++ b/charts/beskar7/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8443
         - --leader-elect
-        - --bootstrap-url-base={{ .Values.bootstrap.urlBase | default "https://beskar7-controller-manager.beskar7-system.svc:8082" }}
+        - --bootstrap-url-base={{ (.Values.bootstrap | default dict).urlBase | default "https://beskar7-controller-manager.beskar7-system.svc:8082" }}
         # The callback server (inspection POST + bootstrap GET) shares the cert
         # mount with the webhook server because both run in the same Pod under
         # the same DNS name. The cert dir is therefore always required; it is

--- a/charts/beskar7/templates/service-callback.yaml
+++ b/charts/beskar7/templates/service-callback.yaml
@@ -7,6 +7,14 @@
 # the Helm release name is "beskar7" (release → "beskar7-controller-manager").
 # Operators using a different release name MUST override bootstrap.urlBase so
 # that hosts booting via iPXE can reach the manager at the correct address.
+#
+# `callback` is dereferenced through a defaulted local because `helm upgrade
+# --reuse-values` DISCARDS the incoming chart's values.yaml entirely (Helm's
+# reuseValues() sets chart.Values = {}) and renders against the previous
+# release's value set alone. Any key added since the installed release is then
+# absent, so a bare .Values.callback.service.* aborts the whole upgrade with a
+# nil-pointer error. See docs/upgrading.md.
+{{- $callbackSvc := ((.Values.callback | default dict).service) | default dict }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,22 +24,22 @@ metadata:
     {{- include "beskar7.labels" . | nindent 4 }}
     app.kubernetes.io/component: callback-server
     cluster.x-k8s.io/provider: beskar7
-  {{- with .Values.callback.service.annotations }}
+  {{- with $callbackSvc.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.callback.service.type | default "ClusterIP" }}
-  {{- if and (eq .Values.callback.service.type "LoadBalancer") .Values.callback.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.callback.service.loadBalancerIP | quote }}
+  type: {{ $callbackSvc.type | default "ClusterIP" }}
+  {{- if and (eq ($callbackSvc.type | default "ClusterIP") "LoadBalancer") $callbackSvc.loadBalancerIP }}
+  loadBalancerIP: {{ $callbackSvc.loadBalancerIP | quote }}
   {{- end }}
   ports:
   - name: callback
     port: 8082
     targetPort: 8082
     protocol: TCP
-    {{- if and (ne (.Values.callback.service.type | default "ClusterIP") "ClusterIP") .Values.callback.service.nodePort }}
-    nodePort: {{ .Values.callback.service.nodePort | int }}
+    {{- if and (ne ($callbackSvc.type | default "ClusterIP") "ClusterIP") $callbackSvc.nodePort }}
+    nodePort: {{ $callbackSvc.nodePort | int }}
     {{- end }}
   selector:
     {{- include "beskar7.selectorLabels" . | nindent 4 }}

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -21,6 +21,30 @@ and a host mid-inspection is picked up again on the next reconcile. Avoid
 upgrading while a host is in `Deploying` if you can — the inspector is writing a
 disk and reporting to the callback endpoint during that window.
 
+### Preserving your values across the upgrade
+
+Do **not** use `helm upgrade --reuse-values`. It discards the incoming chart's
+`values.yaml` entirely and renders against the previous release's value set, so
+any value key introduced since the release you installed is simply absent. The
+upgrade then fails to render, or worse, silently drops a setting. Use one of
+these instead:
+
+```bash
+# Helm 3.14+ — replays your overrides on top of the NEW chart's defaults.
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.0 \
+  --reset-then-reuse-values
+```
+
+```bash
+# Any Helm version — keep your settings in a file and pass it every time.
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.0 \
+  -f my-beskar7-values.yaml
+```
+
+Keeping a values file under version control is the recommended practice: it makes
+the upgrade reproducible and reviewable. Confirm the result before and after with
+`helm get values beskar7 -n beskar7-system`.
+
 ## Matching the inspector to the controller
 
 The controller and inspector share a **versioned wire contract**. A controller


### PR DESCRIPTION
## The bug

Upgrading an existing release to the v0.4.0 chart aborts before it renders anything:

```
Error: template: beskar7/templates/webhook-configuration.yaml:12:4:
... at <.Values.callback.externalNames>: nil pointer evaluating interface {}.externalNames
```

Helm's `reuseValues()` sets `chart.Values = {}` — it **discards the incoming chart's `values.yaml` entirely** and renders against the previous release's value set alone. Any key added since the installed release is therefore absent. `callback` (new in alpha.7) and `bootstrap` are dereferenced bare in five templates, so the whole upgrade dies on a nil map.

Found during the v0.4.0 GA validation, upgrading the dome lab from alpha.6 to the published chart with `--reuse-values` — which is what an adopter following the chart README would reach for.

## The fix

- Dereference `callback` / `bootstrap` through a defaulted local in `_helpers.tpl`, `certificate.yaml`, `deployment.yaml`, `NOTES.txt`, `service-callback.yaml`, so a missing map degrades to the documented defaults.
- Fixes a **latent second bug** in `service-callback.yaml`: `eq .Values.callback.service.type "LoadBalancer"` had no default, so an unset `type` failed the comparison outright.
- Documents the supported upgrade path in `docs/upgrading.md` and the chart README: `--reuse-values` is unsupported; use `--reset-then-reuse-values` (Helm 3.14+) or an explicit `-f values.yaml`.

## Verification

Replicated Helm's reuse-values coalescing exactly (alpha.6 chart defaults + the release's real overrides, with the incoming `values.yaml` wiped as `reuseValues()` does):

| chart | result |
|---|---|
| shipped v0.4.0 | fails with the error above |
| this PR | renders correctly, defaults applied |

- Default and fully-customized (LoadBalancer + SANs + annotations) renders are **byte-identical** to v0.4.0 apart from the added comment — no behavioral change.
- `helm lint` passes in all three value shapes; `test/rbac` drift guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)