### PR TITLE
chore(release): v0.4.1 — chart upgrade fix + /boot rate limiting behind a proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [v0.4.1] - 2026-09-07
+
+Chart-only patch. The controller, the CRDs and the wire contract (`v4.2`) are
+unchanged; the image is rebuilt from identical code so the chart's `appVersion`
+resolves to a real tag.
+
+### Fixed
+
+- **`helm upgrade --reuse-values` aborted against the `v0.4.0` chart.** Upgrading
+  an existing release failed before rendering anything:
+
+  ```
+  ... at <.Values.callback.externalNames>: nil pointer evaluating interface {}.externalNames
+  ```
+
+  Helm's `reuseValues()` sets `chart.Values = {}` — it discards the incoming
+  chart's `values.yaml` entirely and renders against the previous release's value
+  set alone, so every key added since the installed release is absent. `callback`
+  (added in alpha.7) and `bootstrap` were dereferenced bare in five templates.
+  They now go through a defaulted local and fall back to the documented defaults.
+  Found upgrading a real alpha.6 deployment to the published v0.4.0 chart. (#151)
+- **`callback.service.type` with no value broke the LoadBalancer branch.**
+  `eq .Values.callback.service.type "LoadBalancer"` had no default, so an unset
+  `type` failed the comparison outright instead of falling back to `ClusterIP`. (#151)
+
+### Changed
+
+- **`--reuse-values` is documented as unsupported.** `docs/upgrading.md` and the
+  chart README now direct operators to `--reset-then-reuse-values` (Helm 3.14+)
+  or an explicit `-f values.yaml`, and explain why. (#151)
+
 ## [v0.4.0] - 2026-09-07
 
 **First GA release.** `v1beta1` is stable and frozen, the controller↔inspector
@@ -878,7 +909,12 @@ For detailed implementation information, see the examples directory and document
 - CI: lint, tests, container build, CRD generation, Kind sanity checks.
 - Core controllers and CRDs for `PhysicalHost`, `Beskar7Machine`, `Beskar7Cluster`.
 
-[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.6...HEAD
+[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.1...HEAD
+[v0.4.1]: https://github.com/projectbeskar/beskar7/compare/v0.4.0...v0.4.1
+[v0.4.0]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.9...v0.4.0
+[v0.4.0-alpha.9]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.8...v0.4.0-alpha.9
+[v0.4.0-alpha.8]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.7...v0.4.0-alpha.8
+[v0.4.0-alpha.7]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.6...v0.4.0-alpha.7
 [v0.4.0-alpha.6]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.5...v0.4.0-alpha.6
 [v0.4.0-alpha.5]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.4...v0.4.0-alpha.5
 [v0.4.0-alpha.4]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha...v0.4.0-alpha.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [v0.4.1] - 2026-09-07
 
-Chart-only patch. The controller, the CRDs and the wire contract (`v4.2`) are
-unchanged; the image is rebuilt from identical code so the chart's `appVersion`
-resolves to a real tag.
+Patch release. The CRDs and the wire contract (`v4.2`) are unchanged, so there
+is nothing to re-apply and no bootstrap-template migration.
+
+### Added
+
+- **`--trusted-proxies`** — comma-separated CIDRs (or bare IPs) whose
+  `X-Forwarded-For` the `/boot` rate limiter will believe when identifying the
+  client, surfaced in the chart as `callback.trustedProxies`. Also
+  `callback.service.externalTrafficPolicy`, so a LoadBalancer or NodePort
+  Service can be switched to `Local`. (#152)
 
 ### Fixed
 
@@ -30,6 +37,26 @@ resolves to a real tag.
 - **`callback.service.type` with no value broke the LoadBalancer branch.**
   `eq .Values.callback.service.type "LoadBalancer"` had no default, so an unset
   `type` failed the comparison outright instead of falling back to `ClusterIP`. (#151)
+
+- **A fleet booting through one address starved the `/boot` rate limiter.** The
+  limiter keys on the peer address, and every documented exposure option can
+  collapse a whole fleet onto one of them: a LoadBalancer or NodePort Service
+  with the default `externalTrafficPolicy: Cluster` SNATs to a node IP, and an
+  L4 proxy without PROXY protocol presents its own. All hosts then shared a
+  single 1 r/s bucket, so a fleet powering on together — after a DC power event,
+  say — booted a few hosts per second while the rest retried. Operators can now
+  either preserve the client IP (`externalTrafficPolicy: Local`) or declare
+  their hops (`--trusted-proxies`).
+
+  `X-Forwarded-For` remains **ignored by default**. `/boot` has no bearer gate,
+  so trusting a client-settable header unconditionally would let a single caller
+  mint unlimited rate-limit buckets and neutralise the limiter; the header is
+  read only when the peer is itself a declared proxy, and then the right-most
+  entry that is not a trusted proxy wins, so values a client prepends can never
+  be selected. (#152)
+- **IPv6 peers produced a bracketed rate-limit key.** `remoteAddrToIP` scanned
+  for the last colon, so `[2001:db8::1]:443` keyed as `[2001:db8::1]`. It now
+  uses `net.SplitHostPort`. Cosmetic — the key was stable either way. (#152)
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.0
+VERSION ?= v0.4.1
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.0 — **first GA release**  
+**Version:** v0.4.1 — patch release on the GA line (`v0.4.0` was the first GA)  
 **API:** `v1beta1` is **stable and frozen**. The schema evolves **additive-only**; a breaking change requires a future `v1beta2` introduced with a conversion webhook.  
 **Contract:** controller↔inspector wire contract **v4.2, frozen** ([contract](docs/inspector-contract.md)). Pair with a `contract-v4.2` [inspector release](https://github.com/projectbeskar/beskar7-inspector/releases).  
 **Upgrading:** v0.4.0 is **not** compatible with v0.3.x, and the alpha series contains breaking API changes — see [Upgrading](docs/upgrading.md) and the [CHANGELOG](CHANGELOG.md).
@@ -56,7 +56,7 @@ helm install beskar7 beskar7/beskar7 \
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0/beskar7-manifests-v0.4.0.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.1/beskar7-manifests-v0.4.1.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,8 @@ is stable as of `v0.4.0`, so upgrades within the `v0.4.x` line are additive.
 
 | Version | Supported |
 |---|---|
-| `v0.4.0` (latest) | ✅ |
+| `v0.4.1` (latest) | ✅ |
+| `v0.4.0` | ⚠️ upgrade — `helm upgrade --reuse-values` is broken against it ([CHANGELOG](CHANGELOG.md)) |
 | earlier `v0.4.0-alpha.*` | ❌ upgrade first |
 | `v0.3.x` | ❌ end of life — not compatible with v0.4 ([CHANGELOG](CHANGELOG.md)) |
 

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.0
-appVersion: "v0.4.0"
+version: 0.4.1
+appVersion: "v0.4.1"
 keywords:
   - cluster-api
   - infrastructure

--- a/charts/beskar7/templates/deployment.yaml
+++ b/charts/beskar7/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         {{- with .Values.watchNamespaces }}
         - --watch-namespaces={{ join "," . }}
         {{- end }}
+        {{- with (.Values.callback | default dict).trustedProxies }}
+        - --trusted-proxies={{ join "," . }}
+        {{- end }}
         ports:
         - containerPort: 8443
           name: metrics

--- a/charts/beskar7/templates/service-callback.yaml
+++ b/charts/beskar7/templates/service-callback.yaml
@@ -33,6 +33,9 @@ spec:
   {{- if and (eq ($callbackSvc.type | default "ClusterIP") "LoadBalancer") $callbackSvc.loadBalancerIP }}
   loadBalancerIP: {{ $callbackSvc.loadBalancerIP | quote }}
   {{- end }}
+  {{- if and (ne ($callbackSvc.type | default "ClusterIP") "ClusterIP") $callbackSvc.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $callbackSvc.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - name: callback
     port: 8082

--- a/charts/beskar7/values.yaml
+++ b/charts/beskar7/values.yaml
@@ -215,10 +215,40 @@ callback:
     nodePort: ""
     # Extra annotations on the callback Service (e.g. cloud load-balancer hints).
     annotations: {}
+    # externalTrafficPolicy for the callback Service (NodePort/LoadBalancer only).
+    #
+    # Kubernetes defaults this to Cluster, which SNATs the client address to a
+    # node IP. The /boot rate limiter keys on the source address, so under
+    # Cluster every booting host shares ONE bucket and a fleet powering on
+    # together starves on it. "Local" preserves the real client IP and gives
+    # each host its own bucket — at the cost that only nodes running the
+    # controller Pod accept traffic, so the load balancer must health-check
+    # accordingly.
+    #
+    # If you cannot use Local (or you front :8082 with an L4 proxy), set
+    # callback.trustedProxies below instead. Empty leaves the field unset.
+    externalTrafficPolicy: ""
   # External DNS name(s) the serving-cert SAN must cover. Include the host portion
   # of bootstrap.urlBase here when it is a name. Added to both the cert-manager
   # Certificate dnsNames and the self-signed cert SAN list.
   externalNames: []
+  # Networks whose X-Forwarded-For header the /boot rate limiter may believe,
+  # as CIDRs or bare IPs (a bare IP means that single host). Rendered into
+  # --trusted-proxies.
+  #
+  # Empty (the default) ignores the header entirely and limits on the peer
+  # address. That is the safe default: /boot has no bearer gate, so trusting a
+  # client-settable header would let one caller mint unlimited rate-limit
+  # buckets and neutralise the limiter. Only list hops you actually control.
+  #
+  # Set this when something between your hosts and the callback server rewrites
+  # the source address and you cannot use
+  # callback.service.externalTrafficPolicy: Local — e.g. an ingress or L4 proxy
+  # in front of :8082. Without it every booting host shares one bucket.
+  #
+  #   trustedProxies:
+  #     - 10.0.0.0/8
+  trustedProxies: []
   # External IP(s) the serving-cert SAN must cover. Use when bootstrap.urlBase is
   # an IP (e.g. a fixed LoadBalancer IP). Added as IP SANs in both cert paths.
   #

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -84,6 +84,7 @@ func main() {
 	var watchNamespacesRaw string
 	var inspectionTimeout time.Duration
 	var deploymentTimeout time.Duration
+	var trustedProxies string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -135,6 +136,15 @@ func main() {
 			"large enough that a single unreachable BMC's 30s Redfish timeout stalls reconciles "+
 			"for healthy hosts; controller-runtime never reconciles the same object "+
 			"concurrently, so distinct workers always act on distinct BMCs.")
+	flag.StringVar(&trustedProxies, "trusted-proxies", "",
+		"Comma-separated CIDRs (or bare IPs) whose X-Forwarded-For header the /boot rate "+
+			"limiter will believe when identifying the client. Empty (the default) ignores "+
+			"the header and rate-limits on the peer address, which is the only safe "+
+			"behaviour on this ungated route. Set it when the callback server sits behind "+
+			"something that rewrites the source address — a LoadBalancer or NodePort "+
+			"Service with the default externalTrafficPolicy: Cluster, or an L4 proxy "+
+			"without PROXY protocol — otherwise every booting host shares one bucket and a "+
+			"fleet powering on together starves on it.")
 
 	// Default to production-safe zap config: structured JSON output, no stack
 	// traces below Error, level-based encoding. Operators who want
@@ -268,7 +278,20 @@ func main() {
 	// Certificate via cert-manager).
 	// bootstrapURLBase is passed so the /boot handler can render beskar7.api=
 	// into the iPXE cmdline (§5). It must be externally reachable from bare metal.
-	if err := controllers.SetupCallbackServer(mgr, inspectionPort, inspectionCertDir, bootstrapURLBase); err != nil {
+	// Parsed here rather than inside the handler so a typo is a startup failure
+	// instead of a silently ignored setting that only shows up as unexplained
+	// 429s during a fleet boot.
+	parsedTrustedProxies, err := controllers.ParseTrustedProxies(trustedProxies)
+	if err != nil {
+		setupLog.Error(err, "invalid --trusted-proxies")
+		os.Exit(1)
+	}
+	if len(parsedTrustedProxies) > 0 {
+		setupLog.Info("Trusting X-Forwarded-For from configured proxies for /boot rate limiting",
+			"networks", len(parsedTrustedProxies))
+	}
+
+	if err := controllers.SetupCallbackServer(mgr, inspectionPort, inspectionCertDir, bootstrapURLBase, parsedTrustedProxies); err != nil {
 		setupLog.Error(err, "unable to setup callback server")
 		os.Exit(1)
 	}

--- a/controllers/boot_handler.go
+++ b/controllers/boot_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -91,6 +92,19 @@ type BootHandlerConfig struct {
 	// callback TLS certificate. Base64-encoded into beskar7.ca=. Sourced from
 	// the callback cert dir (ca.crt if present, else tls.crt).
 	CABytes []byte
+
+	// TrustedProxies are the networks whose X-Forwarded-For header this handler
+	// will believe when attributing a request to a client IP for rate limiting.
+	// Empty (the default) means the header is ignored entirely and the peer
+	// address is used, which is the only safe default on an ungated route.
+	//
+	// Set this when the callback server sits behind something that rewrites the
+	// source address, otherwise every booting host shares one rate-limit bucket:
+	// a LoadBalancer or NodePort Service with the default
+	// externalTrafficPolicy: Cluster SNATs to a node IP, and an L4 proxy without
+	// PROXY protocol presents its own address. A fleet PXE-booting together —
+	// after a power event, say — then starves on a single bucket.
+	TrustedProxies []*net.IPNet
 }
 
 // ipEntry pairs a rate limiter with the time it was last seen. Used by
@@ -143,10 +157,15 @@ func (h *BootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// CA bytes, or rendered script.
 	log := h.Log.WithValues("namespace", namespace, "host", hostName, "remote", r.RemoteAddr)
 
-	// Rate-limit per source IP before touching the API server. The /boot route is
-	// ungated (no bearer token), so rate limiting is the first line of defence
-	// against credential-stuffing on the nonce space.
-	clientIP := remoteAddrToIP(r.RemoteAddr)
+	// Rate-limit per client address before touching the API server. The /boot
+	// route is ungated (no bearer token), so this bounds the API-server load a
+	// flood can generate and slows scanning of the nonce space. The nonce itself
+	// is 256 bits from crypto/rand and single-use, so guessing is infeasible
+	// regardless; the limiter is defence in depth, not the primary control.
+	//
+	// "Client address" is the peer, or the X-Forwarded-For entry when the peer is
+	// a configured trusted proxy — see clientIP.
+	clientIP := h.clientIP(r)
 	if !h.allowIP(clientIP) {
 		log.V(1).Info("boot GET: rate-limited", "ip", clientIP)
 		// 429 so operators can distinguish rate-limit events from opaque 404s.
@@ -700,12 +719,96 @@ func (h *BootHandler) allowIP(ip string) bool {
 
 // remoteAddrToIP extracts the IP portion from an "ip:port" RemoteAddr.
 // Falls back to the full string on parse failure so rate limiting still
-// operates (the key is stable per connection either way).
+// operates (the key is stable per connection either way). SplitHostPort is
+// used rather than a manual scan for the last colon so that IPv6 peers
+// ("[2001:db8::1]:443") yield a bare address instead of a bracketed one.
 func remoteAddrToIP(remoteAddr string) string {
-	for i := len(remoteAddr) - 1; i >= 0; i-- {
-		if remoteAddr[i] == ':' {
-			return remoteAddr[:i]
-		}
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
 	}
 	return remoteAddr
+}
+
+// clientIP returns the address this request should be rate-limited under.
+//
+// The peer address is used unless the peer is itself one of the operator's
+// configured trusted proxies. X-Forwarded-For is attacker-controlled on a route
+// with no bearer gate: believing it unconditionally would let a single caller
+// mint unlimited distinct buckets and neutralise the limiter entirely, so the
+// header is ignored until an operator states which hops may set it.
+//
+// When the peer is trusted, the right-most entry that is not itself a trusted
+// proxy wins. Proxies append on the right, so any entries a client prepends sit
+// to the left of the ones our own hops added and can never be selected. If the
+// header is absent, malformed, or lists only trusted hops, the peer address is
+// used — the safe direction, since it can only over-attribute to one bucket.
+func (h *BootHandler) clientIP(r *http.Request) string {
+	peer := remoteAddrToIP(r.RemoteAddr)
+	if len(h.Config.TrustedProxies) == 0 {
+		return peer
+	}
+	peerIP := net.ParseIP(peer)
+	if peerIP == nil || !ipInAny(peerIP, h.Config.TrustedProxies) {
+		return peer
+	}
+
+	var hops []string
+	for _, header := range r.Header.Values("X-Forwarded-For") {
+		for _, part := range strings.Split(header, ",") {
+			if trimmed := strings.TrimSpace(part); trimmed != "" {
+				hops = append(hops, trimmed)
+			}
+		}
+	}
+	for i := len(hops) - 1; i >= 0; i-- {
+		ip := net.ParseIP(hops[i])
+		if ip == nil || ipInAny(ip, h.Config.TrustedProxies) {
+			continue
+		}
+		return ip.String()
+	}
+	return peer
+}
+
+// ParseTrustedProxies turns a comma-separated list of CIDRs into networks for
+// BootHandlerConfig.TrustedProxies. A bare address is accepted and treated as a
+// single-host network ("10.0.0.7" == "10.0.0.7/32"), because that is what an
+// operator naturally writes for one load balancer.
+//
+// An empty string yields no networks, which disables X-Forwarded-For parsing.
+// Malformed input is an error rather than a skipped entry: silently dropping a
+// CIDR would leave the limiter quietly mis-attributing every request to one
+// bucket, which is exactly the failure this setting exists to prevent.
+func ParseTrustedProxies(list string) ([]*net.IPNet, error) {
+	var nets []*net.IPNet
+	for _, raw := range strings.Split(list, ",") {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		if _, network, err := net.ParseCIDR(entry); err == nil {
+			nets = append(nets, network)
+			continue
+		}
+		ip := net.ParseIP(entry)
+		if ip == nil {
+			return nil, fmt.Errorf("trusted proxy %q is neither a CIDR nor an IP address", entry)
+		}
+		bits := 32
+		if ip.To4() == nil {
+			bits = 128
+		}
+		nets = append(nets, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+	}
+	return nets, nil
+}
+
+// ipInAny reports whether ip falls inside any of the given networks.
+func ipInAny(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }

--- a/controllers/boot_handler_test.go
+++ b/controllers/boot_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -997,6 +998,132 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 		By("different IP is unaffected by ip1's exhausted bucket")
 		Expect(handler.allowIP(ip2)).To(BeTrue(),
 			"ip2 has an independent bucket and must not be limited")
+	})
+
+	It("client IP: X-Forwarded-For is ignored when no proxies are trusted", func() {
+		// The default. /boot has no bearer gate, so an attacker who could steer
+		// attribution with a header could mint unlimited buckets and neutralise
+		// the limiter entirely.
+		handler := &BootHandler{Client: k8sClient, Log: ctrl.Log.WithName("xff-untrusted"), Config: bootTestConfig()}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/boot/ns/host/nonce", nil)
+		req.RemoteAddr = "10.0.0.1:5555"
+		req.Header.Set("X-Forwarded-For", "203.0.113.9")
+
+		Expect(handler.clientIP(req)).To(Equal("10.0.0.1"),
+			"header must be ignored entirely when TrustedProxies is empty")
+	})
+
+	It("client IP: X-Forwarded-For is honoured only from a trusted peer", func() {
+		nets, err := ParseTrustedProxies("10.0.0.0/8")
+		Expect(err).NotTo(HaveOccurred())
+		cfg := bootTestConfig()
+		cfg.TrustedProxies = nets
+		handler := &BootHandler{Client: k8sClient, Log: ctrl.Log.WithName("xff-trusted"), Config: cfg}
+
+		By("a trusted peer's header is believed")
+		trusted := httptest.NewRequest(http.MethodGet, "/api/v1/boot/ns/host/nonce", nil)
+		trusted.RemoteAddr = "10.0.0.1:5555"
+		trusted.Header.Set("X-Forwarded-For", "203.0.113.9")
+		Expect(handler.clientIP(trusted)).To(Equal("203.0.113.9"))
+
+		By("an untrusted peer's header is not")
+		untrusted := httptest.NewRequest(http.MethodGet, "/api/v1/boot/ns/host/nonce", nil)
+		untrusted.RemoteAddr = "198.51.100.7:5555"
+		untrusted.Header.Set("X-Forwarded-For", "203.0.113.9")
+		Expect(handler.clientIP(untrusted)).To(Equal("198.51.100.7"),
+			"a direct caller must not be able to attribute itself elsewhere")
+	})
+
+	It("client IP: a client-prepended X-Forwarded-For entry cannot win", func() {
+		// The spoofing case. A client sends its own XFF; the real proxy appends
+		// the true peer to the right. Taking the right-most untrusted entry
+		// means the forged value is never selected.
+		nets, err := ParseTrustedProxies("10.0.0.0/8")
+		Expect(err).NotTo(HaveOccurred())
+		cfg := bootTestConfig()
+		cfg.TrustedProxies = nets
+		handler := &BootHandler{Client: k8sClient, Log: ctrl.Log.WithName("xff-spoof"), Config: cfg}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/boot/ns/host/nonce", nil)
+		req.RemoteAddr = "10.0.0.1:5555"
+		req.Header.Set("X-Forwarded-For", "1.2.3.4, 203.0.113.9")
+
+		Expect(handler.clientIP(req)).To(Equal("203.0.113.9"),
+			"the forged left-most entry must lose to the value the proxy appended")
+	})
+
+	It("client IP: falls back to the peer when every hop is trusted or malformed", func() {
+		nets, err := ParseTrustedProxies("10.0.0.0/8")
+		Expect(err).NotTo(HaveOccurred())
+		cfg := bootTestConfig()
+		cfg.TrustedProxies = nets
+		handler := &BootHandler{Client: k8sClient, Log: ctrl.Log.WithName("xff-fallback"), Config: cfg}
+
+		allTrusted := httptest.NewRequest(http.MethodGet, "/api/v1/boot/ns/host/nonce", nil)
+		allTrusted.RemoteAddr = "10.0.0.1:5555"
+		allTrusted.Header.Set("X-Forwarded-For", "10.0.0.8, 10.0.0.9")
+		Expect(handler.clientIP(allTrusted)).To(Equal("10.0.0.1"))
+
+		garbage := httptest.NewRequest(http.MethodGet, "/api/v1/boot/ns/host/nonce", nil)
+		garbage.RemoteAddr = "10.0.0.1:5555"
+		garbage.Header.Set("X-Forwarded-For", "not-an-ip")
+		Expect(handler.clientIP(garbage)).To(Equal("10.0.0.1"),
+			"malformed input must not become a rate-limit key")
+	})
+
+	It("client IP: hosts behind one trusted proxy get independent buckets", func() {
+		// The bug this fixes. Without XFF parsing every host arrives as the
+		// proxy address and shares a single burst=5 bucket, so a fleet powering
+		// on together starves.
+		nets, err := ParseTrustedProxies("10.0.0.1")
+		Expect(err).NotTo(HaveOccurred())
+		cfg := bootTestConfig()
+		cfg.TrustedProxies = nets
+		handler := &BootHandler{Client: k8sClient, Log: ctrl.Log.WithName("xff-fleet"), Config: cfg}
+
+		newReq := func(host string) *http.Request {
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/boot/ns/host/nonce", nil)
+			r.RemoteAddr = "10.0.0.1:5555"
+			r.Header.Set("X-Forwarded-For", host)
+			return r
+		}
+
+		By("exhausting one host's bucket")
+		first := handler.clientIP(newReq("203.0.113.10"))
+		for i := 0; i < bootIPRateLimitBurst; i++ {
+			Expect(handler.allowIP(first)).To(BeTrue())
+		}
+		Expect(handler.allowIP(first)).To(BeFalse())
+
+		By("a different host behind the same proxy is unaffected")
+		second := handler.clientIP(newReq("203.0.113.11"))
+		Expect(second).NotTo(Equal(first))
+		Expect(handler.allowIP(second)).To(BeTrue(),
+			"a second host must not inherit the first host's exhausted bucket")
+	})
+
+	It("ParseTrustedProxies accepts CIDRs and bare IPs, and rejects junk", func() {
+		nets, err := ParseTrustedProxies(" 10.0.0.0/8 , 192.168.1.5 ,, 2001:db8::/32 ")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nets).To(HaveLen(3), "blank entries are skipped, the rest parse")
+
+		Expect(nets[1].Contains(net.ParseIP("192.168.1.5"))).To(BeTrue(),
+			"a bare IP must become a single-host network")
+		Expect(nets[1].Contains(net.ParseIP("192.168.1.6"))).To(BeFalse())
+		Expect(nets[2].Contains(net.ParseIP("2001:db8::1"))).To(BeTrue())
+
+		Expect(ParseTrustedProxies("")).To(BeEmpty(),
+			"empty input disables the feature rather than erroring")
+
+		_, err = ParseTrustedProxies("10.0.0.0/8,nonsense")
+		Expect(err).To(HaveOccurred(),
+			"a typo must fail loudly at startup, not silently collapse every host into one bucket")
+	})
+
+	It("remoteAddrToIP handles IPv6 peers", func() {
+		Expect(remoteAddrToIP("[2001:db8::1]:443")).To(Equal("2001:db8::1"))
+		Expect(remoteAddrToIP("10.0.0.1:5555")).To(Equal("10.0.0.1"))
 	})
 
 	// ── 9. No secret leakage ───────────────────────────────────────────────

--- a/controllers/inspection_handler.go
+++ b/controllers/inspection_handler.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -440,7 +441,10 @@ func readCallbackCA(certDir string) ([]byte, error) {
 // bootstrapURLBase is the externally-reachable HTTPS base URL of this server
 // (e.g. "https://beskar7.example.com:8082"). It is rendered into the
 // beskar7.api= kernel cmdline parameter by the /boot handler. Must be non-empty.
-func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string, bootstrapURLBase string) error {
+//
+// trustedProxies are the networks whose X-Forwarded-For the /boot rate limiter
+// will believe. Empty means the header is ignored and the peer address is used.
+func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string, bootstrapURLBase string, trustedProxies []*net.IPNet) error {
 	if certDir == "" {
 		return fmt.Errorf("callback server cert dir is empty; set --inspection-cert-dir")
 	}
@@ -509,8 +513,9 @@ func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string, bootstrapUR
 		Client: mgr.GetClient(),
 		Log:    bootLog,
 		Config: BootHandlerConfig{
-			APIBase: bootstrapURLBase,
-			CABytes: caBytes,
+			APIBase:        bootstrapURLBase,
+			CABytes:        caBytes,
+			TrustedProxies: trustedProxies,
 		},
 	}
 

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -271,10 +271,10 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 ### Release Process
 
-1. **Create Release Tag** — the current release line is `v0.4.0-alpha.N`; bump N for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
+1. **Create Release Tag** — the current release line is `v0.4.x` (GA); bump the patch for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.0
-   git push origin v0.4.0
+   git tag v0.4.1
+   git push origin v0.4.1
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.0`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.1`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,7 @@ The external SAN is added to both certificate paths: the cert-manager `Certifica
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.0/beskar7-manifests-v0.4.0.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.1/beskar7-manifests-v0.4.1.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.

--- a/docs/ipxe-setup.md
+++ b/docs/ipxe-setup.md
@@ -175,6 +175,41 @@ Common exposure options:
   controller speaks TLS natively; SNI passthrough is simpler than termination +
   re-encryption.
 
+#### Preserve the client address, or the rate limiter will bite
+
+`/boot` is rate-limited per source address (1 r/s, burst 5). Every option above
+can hide the real client behind a single address, and then **all** your hosts
+share one bucket — a fleet powering on together, after a DC power event say,
+then serves a handful of hosts per second while the rest retry. It degrades
+rather than fails, because iPXE retries, but boots crawl.
+
+Two ways to avoid it, in order of preference:
+
+1. **Preserve the source IP.** For a LoadBalancer or NodePort Service, set
+   `callback.service.externalTrafficPolicy: Local`. Kubernetes defaults to
+   `Cluster`, which SNATs the client to a node address. With `Local` the real
+   host IP survives and each host gets its own bucket. The trade-off is that
+   only nodes running the controller Pod accept traffic, so the load balancer
+   must health-check accordingly.
+
+2. **Declare your proxies.** If you cannot use `Local` — an ingress or an L4
+   proxy without PROXY protocol — list the hops in `callback.trustedProxies`
+   (rendered into `--trusted-proxies`), as CIDRs or bare IPs:
+
+   ```yaml
+   callback:
+     trustedProxies:
+       - 10.0.0.0/8
+   ```
+
+   The handler then reads the client address from `X-Forwarded-For`, taking the
+   right-most entry that is not itself a trusted proxy.
+
+`X-Forwarded-For` is **ignored by default**, and that is deliberate: `/boot` has
+no bearer gate, so believing a client-settable header would let one caller mint
+unlimited rate-limit buckets and neutralise the limiter. Only list hops you
+control — anything you trust can attribute a request to any address it likes.
+
 ### HTTPS everywhere on the boot path
 
 | Hop | Required | Reason |

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -87,9 +87,9 @@ inspector one minor version behind — it simply does not get the newer capabili
 
 ## `v0.4.0` → `v0.4.1` — chart fix only, no API or contract change
 
-`v0.4.1` changes nothing in the controller, the CRDs, or the wire contract. The
-container image is rebuilt from identical code so that the chart's `appVersion`
-points at a real tag. The only change is in the Helm chart.
+`v0.4.1` leaves the CRDs and the wire contract untouched, so there is nothing to
+re-apply and no bootstrap-template migration. It carries one chart fix and one
+controller change, both opt-in or invisible by default.
 
 **Why upgrade:** the `v0.4.0` chart cannot be upgraded with `--reuse-values` —
 it aborts before rendering with `nil pointer evaluating interface {}.service`
@@ -106,6 +106,15 @@ helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.1 \
 CRDs are unchanged, so there is nothing to re-apply. If you are already on
 `v0.4.0` and previously worked around the bug by re-passing your values with
 `-f`, that keeps working — no action needed beyond the version bump.
+
+**Worth checking while you are here:** `/boot` is rate-limited per source
+address, and a LoadBalancer or NodePort Service with the default
+`externalTrafficPolicy: Cluster` SNATs every host to a node IP — so your whole
+fleet shares one 1 r/s bucket and a mass power-on boots slowly. `v0.4.1` adds
+two ways out: `callback.service.externalTrafficPolicy: Local` to preserve the
+client IP, or `callback.trustedProxies` to declare the hops allowed to set
+`X-Forwarded-For`. Both default to off, so nothing changes until you set them.
+See [ipxe-setup.md](ipxe-setup.md) for which to pick.
 
 ## `v0.4.0-alpha.9` → `v0.4.0` — no API changes
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -31,13 +31,13 @@ these instead:
 
 ```bash
 # Helm 3.14+ — replays your overrides on top of the NEW chart's defaults.
-helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.0 \
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.1 \
   --reset-then-reuse-values
 ```
 
 ```bash
 # Any Helm version — keep your settings in a file and pass it every time.
-helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.0 \
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.1 \
   -f my-beskar7-values.yaml
 ```
 
@@ -55,6 +55,7 @@ from the release you deployed:
 
 | beskar7 release | contract |
 |---|---|
+| `v0.4.1` | `v4.2` **frozen** |
 | `v0.4.0` (GA) | `v4.2` **frozen** |
 | `v0.4.0-alpha.9` | `v4.2` |
 | `v0.4.0-alpha.8` | `v4.1` |
@@ -83,6 +84,28 @@ docker pull ghcr.io/projectbeskar/beskar7-inspector:contract-v4.2
 Within a frozen `v4.x` line the changes are additive, so a controller tolerates an
 inspector one minor version behind — it simply does not get the newer capability
 (see `docs/inspector-contract.md` §14). Do not rely on that across a major bump.
+
+## `v0.4.0` → `v0.4.1` — chart fix only, no API or contract change
+
+`v0.4.1` changes nothing in the controller, the CRDs, or the wire contract. The
+container image is rebuilt from identical code so that the chart's `appVersion`
+points at a real tag. The only change is in the Helm chart.
+
+**Why upgrade:** the `v0.4.0` chart cannot be upgraded with `--reuse-values` —
+it aborts before rendering with `nil pointer evaluating interface {}.service`
+(or `.externalNames`). That flag discards the incoming chart's defaults, so
+`callback` and `bootstrap`, both added after alpha.6, are missing. `v0.4.1`
+tolerates the missing maps and falls back to the documented defaults.
+
+```bash
+helm repo update
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.1 \
+  --reset-then-reuse-values
+```
+
+CRDs are unchanged, so there is nothing to re-apply. If you are already on
+`v0.4.0` and previously worked around the bug by re-passing your values with
+`-f`, that keeps working — no action needed beyond the version bump.
 
 ## `v0.4.0-alpha.9` → `v0.4.0` — no API changes
 


### PR DESCRIPTION
Patch release on the GA line. The CRDs and the wire contract (`v4.2`) are **unchanged**, so there is nothing to re-apply and no bootstrap-template migration.

Two fixes, both found while validating the published v0.4.0 build on dome.

## 1. `helm upgrade --reuse-values` aborted (ships #151)

The `v0.4.0` chart cannot be upgraded with `--reuse-values` — it dies before rendering on a nil `callback`/`bootstrap` map, because Helm's `reuseValues()` sets `chart.Values = {}` and discards the incoming chart's defaults. Since that's the flag operators reach for when preserving values, the published GA chart is effectively un-upgradable in place for anyone installed before alpha.7.

## 2. A fleet booting through one address starved the `/boot` rate limiter

`/boot` is limited to 1 r/s (burst 5) keyed on the peer address, and **every documented exposure option can collapse a whole fleet onto one address** — LoadBalancer and NodePort SNAT to a node IP under the default `externalTrafficPolicy: Cluster`, and an L4 proxy without PROXY protocol presents its own. All hosts then share a single bucket, so a mass power-on boots a few hosts per second while the rest retry. It degrades rather than fails (iPXE retries), which is why it went unnoticed.

Two ways out, **both off by default** — nothing changes until an operator opts in:

| | |
|---|---|
| `callback.service.externalTrafficPolicy: Local` | Preserves the client IP. Preferred — no trust delegation. Costs node-local LB health-checking. |
| `callback.trustedProxies` -> `--trusted-proxies` | For when `Local` isn't an option (ingress, L4 proxy). |

### `X-Forwarded-For` stays ignored by default

`/boot` has no bearer gate, so believing a client-settable header unconditionally would let one caller mint unlimited rate-limit buckets and neutralise the limiter outright. The header is read **only** when the peer is inside a declared `--trusted-proxies` network, and then the right-most entry that is **not** itself a trusted proxy wins — proxies append on the right, so anything a client prepends sits to the left and can never be selected. Absent/malformed/all-trusted headers fall back to the peer, the safe direction. A malformed `--trusted-proxies` value fails at **startup** rather than being skipped, since a silently dropped CIDR reintroduces exactly this bug.

Also fixes `remoteAddrToIP`, which scanned for the last colon and keyed an IPv6 peer as `[2001:db8::1]`. Cosmetic — the key was stable either way.

## Version bump

Pointers moved: `Chart.yaml` version + appVersion, `Makefile` VERSION, release-manifest URLs in README and `docs/installation.md`, default `IMG` in `docs/development-setup.md`, `SECURITY.md` supported table.

**Deliberately not moved**, as a blanket bump would falsify them: the contract "FROZEN for v0.4.0 GA", "`v1beta1` stable as of `v0.4.0`", "images signed from `v0.4.0` onward", "removed in v0.4.0", the "`stages:` never executed before `v0.4.0`" note, and the `alpha.8 -> v0.4.0` / `alpha.9 -> v0.4.0` procedures.

Also repaired: `docs/ci-cd-and-testing.md` still called the release line `v0.4.0-alpha.N`, and the CHANGELOG link refs were stale (`[Unreleased]` compared against alpha.6; no refs for alpha.7/8/9 or v0.4.0).

## Verification

- New tests cover the default, trusted vs untrusted peer, **the spoofing case**, malformed-input fallback, two hosts behind one proxy getting independent buckets, `ParseTrustedProxies` parsing, and IPv6 peers. **Verified they fail with the fix disabled and pass with it restored.**
- `golangci-lint` clean, full suite green under `-race`, no `api/` or `config/` changes so `make manifests` is a no-op.
- Chart: `helm lint` clean; defaults render **no** new args (`--trusted-proxies` and `externalTrafficPolicy` appear only when set); the `--reuse-values` repro still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
