### PR TITLE
fix(kustomize): keep the version label out of immutable selectors — v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [v0.4.2] - 2026-09-07
+
+Fixes the kustomize install path. No API, CRD or contract (`v4.2`) change.
+**Helm users are unaffected and can upgrade normally**; `kubectl apply` users
+need one manual step, described in [docs/upgrading.md](docs/upgrading.md).
+
+### Fixed
+
+- **`kubectl apply` upgrades were impossible.** `config/default/kustomization.yaml`
+  set `includeSelectors: true` on a label group containing
+  `app.kubernetes.io/version`, so the version landed in
+  `Deployment.spec.selector` — an **immutable** field — and in the webhook
+  Service selector. `make release-manifests` rewrites that label every release,
+  so re-applying the published manifest, which is the first install method in the
+  README and the procedure in `docs/upgrading.md`, failed outright:
+
+  ```
+  The Deployment "controller-manager" is invalid: spec.selector:
+  Invalid value: {...}: field is immutable
+  ```
+
+  Reproduced v0.4.0 → v0.4.1 and verified fixed. The version label is now applied
+  to metadata only; selectors carry stable identity labels. The same split was
+  applied to the `large` and `extra-large` overlays. (#153)
+- **Webhook Service could lose its endpoints, blocking all `Beskar7Cluster`
+  admission.** Same root cause: the version label was in that Service's selector,
+  so after a version skew it matched no pods. With `failurePolicy: Fail`, every
+  `Beskar7Cluster` create/update/**delete** was then rejected — observed in the
+  field as a cluster stuck in `Deleting`, because the controller could not patch
+  the finalizer off. (#153)
+
 ## [v0.4.1] - 2026-09-07
 
 Patch release. The CRDs and the wire contract (`v4.2`) are unchanged, so there
@@ -936,7 +967,8 @@ For detailed implementation information, see the examples directory and document
 - CI: lint, tests, container build, CRD generation, Kind sanity checks.
 - Core controllers and CRDs for `PhysicalHost`, `Beskar7Machine`, `Beskar7Cluster`.
 
-[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.2...HEAD
+[v0.4.2]: https://github.com/projectbeskar/beskar7/compare/v0.4.1...v0.4.2
 [v0.4.1]: https://github.com/projectbeskar/beskar7/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.9...v0.4.0
 [v0.4.0-alpha.9]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.8...v0.4.0-alpha.9

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.1
+VERSION ?= v0.4.2
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.1 — patch release on the GA line (`v0.4.0` was the first GA)  
+**Version:** v0.4.2 — patch release on the GA line (`v0.4.0` was the first GA)  
 **API:** `v1beta1` is **stable and frozen**. The schema evolves **additive-only**; a breaking change requires a future `v1beta2` introduced with a conversion webhook.  
 **Contract:** controller↔inspector wire contract **v4.2, frozen** ([contract](docs/inspector-contract.md)). Pair with a `contract-v4.2` [inspector release](https://github.com/projectbeskar/beskar7-inspector/releases).  
 **Upgrading:** v0.4.0 is **not** compatible with v0.3.x, and the alpha series contains breaking API changes — see [Upgrading](docs/upgrading.md) and the [CHANGELOG](CHANGELOG.md).
@@ -56,7 +56,7 @@ helm install beskar7 beskar7/beskar7 \
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.1/beskar7-manifests-v0.4.1.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.2/beskar7-manifests-v0.4.2.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,8 +37,9 @@ is stable as of `v0.4.0`, so upgrades within the `v0.4.x` line are additive.
 
 | Version | Supported |
 |---|---|
-| `v0.4.1` (latest) | ✅ |
-| `v0.4.0` | ⚠️ upgrade — `helm upgrade --reuse-values` is broken against it ([CHANGELOG](CHANGELOG.md)) |
+| `v0.4.2` (latest) | ✅ |
+| `v0.4.1` | ⚠️ upgrade — `kubectl apply` upgrades are impossible against it ([CHANGELOG](CHANGELOG.md)) |
+| `v0.4.0` | ⚠️ upgrade — also breaks `helm upgrade --reuse-values` |
 | earlier `v0.4.0-alpha.*` | ❌ upgrade first |
 | `v0.3.x` | ❌ end of life — not compatible with v0.4 ([CHANGELOG](CHANGELOG.md)) |
 

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.1
-appVersion: "v0.4.1"
+version: 0.4.2
+appVersion: "v0.4.2"
 keywords:
   - cluster-api
   - infrastructure

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,14 +6,28 @@ namespace: beskar7-system
 # "controller-manager" becomes "my-deployment-controller-manager".
 # namePrefix: my-deployment-
 
-# Labels to add to all resources and selectors. includeSelectors: true
-# preserves the v1 commonLabels behavior (the labels are injected into
-# Deployment/Service selectors too, not just metadata).
+# Two groups on purpose — the split is load-bearing, do not merge them.
+#
+# Identity labels go into selectors. They must be STABLE for the lifetime of a
+# deployment, because Deployment.spec.selector is immutable and a Service
+# selector silently stops matching its pods when it drifts.
+#
+# The version label must NOT go into selectors. `make release-manifests` rewrites
+# it on every release, so with includeSelectors: true the Deployment selector
+# changed every version and `kubectl apply -f beskar7-manifests-<new>.yaml` — the
+# documented upgrade path — failed outright with:
+#
+#   spec.selector: Invalid value: {...}: field is immutable
+#
+# and the webhook Service selector stopped matching the pods, leaving it with no
+# endpoints so failurePolicy: Fail blocked all Beskar7Cluster admission.
 labels:
 - pairs:
     app.kubernetes.io/name: beskar7
-    app.kubernetes.io/version: v0.2.7
   includeSelectors: true
+- pairs:
+    app.kubernetes.io/version: v0.2.7
+  includeSelectors: false
 
 resources:
 - ../crd

--- a/config/overlays/extra-large/kustomization.yaml
+++ b/config/overlays/extra-large/kustomization.yaml
@@ -15,12 +15,17 @@ namePrefix: extra-large-
 # deployment-size is already covered by the labels block below (which also
 # carries includeSelectors: true), so the old commonLabels entry was redundant
 # and was dropped during the v1→v2 migration.
+# The version label is deliberately NOT in a selector group — it is rewritten on
+# every release, and Deployment.spec.selector is immutable (see
+# config/default/kustomization.yaml).
 labels:
 - includeSelectors: true
   pairs:
     app.kubernetes.io/name: beskar7
-    app.kubernetes.io/version: v0.3.4-alpha
     deployment-size: extra-large
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/version: v0.3.4-alpha
 
 images:
 - name: controller

--- a/config/overlays/large/kustomization.yaml
+++ b/config/overlays/large/kustomization.yaml
@@ -14,12 +14,17 @@ namePrefix: large-
 # deployment-size is already covered by the labels block below (which also
 # carries includeSelectors: true), so the old commonLabels entry was redundant
 # and was dropped during the v1→v2 migration.
+# The version label is deliberately NOT in a selector group — it is rewritten on
+# every release, and Deployment.spec.selector is immutable (see
+# config/default/kustomization.yaml).
 labels:
 - includeSelectors: true
   pairs:
     app.kubernetes.io/name: beskar7
-    app.kubernetes.io/version: v0.3.4-alpha
     deployment-size: large
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/version: v0.3.4-alpha
 
 images:
 - name: controller

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -273,8 +273,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.x` (GA); bump the patch for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.1
-   git push origin v0.4.1
+   git tag v0.4.2
+   git push origin v0.4.2
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.1`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.2`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,7 @@ The external SAN is added to both certificate paths: the cert-manager `Certifica
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.1/beskar7-manifests-v0.4.1.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.2/beskar7-manifests-v0.4.2.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -31,13 +31,13 @@ these instead:
 
 ```bash
 # Helm 3.14+ — replays your overrides on top of the NEW chart's defaults.
-helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.1 \
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.2 \
   --reset-then-reuse-values
 ```
 
 ```bash
 # Any Helm version — keep your settings in a file and pass it every time.
-helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.1 \
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.2 \
   -f my-beskar7-values.yaml
 ```
 
@@ -55,6 +55,7 @@ from the release you deployed:
 
 | beskar7 release | contract |
 |---|---|
+| `v0.4.2` | `v4.2` **frozen** |
 | `v0.4.1` | `v4.2` **frozen** |
 | `v0.4.0` (GA) | `v4.2` **frozen** |
 | `v0.4.0-alpha.9` | `v4.2` |
@@ -84,6 +85,58 @@ docker pull ghcr.io/projectbeskar/beskar7-inspector:contract-v4.2
 Within a frozen `v4.x` line the changes are additive, so a controller tolerates an
 inspector one minor version behind — it simply does not get the newer capability
 (see `docs/inspector-contract.md` §14). Do not rely on that across a major bump.
+
+## `v0.4.1` → `v0.4.2` — one-time manual step for `kubectl apply` installs
+
+No API, CRD or contract change. **Helm users: nothing special, upgrade normally.**
+
+```bash
+helm repo update
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.2 \
+  --reset-then-reuse-values
+```
+
+### If you installed with `kubectl apply -f beskar7-manifests-*.yaml`, read this
+
+Releases up to and including `v0.4.1` baked `app.kubernetes.io/version` into
+`Deployment.spec.selector`. That field is **immutable**, and the label changes
+every release, so upgrading by re-applying the manifest has never worked:
+
+```
+The Deployment "controller-manager" is invalid: spec.selector:
+Invalid value: {...}: field is immutable
+```
+
+The same label was in the webhook Service selector, so after a partial upgrade
+that Service could stop matching the controller Pod and sit with no endpoints —
+and because the webhook is `failurePolicy: Fail`, every `Beskar7Cluster` create,
+update and **delete** was then rejected, which shows up as a cluster that will
+not finish deleting.
+
+`v0.4.2` takes the version label out of both selectors, so from here on
+`kubectl apply` upgrades work normally. Getting to `v0.4.2` needs one manual
+step, because changing a selector is exactly what the old objects forbid:
+
+```bash
+# 1. Delete the two objects whose selectors changed. CRDs, CRs and your hosts
+#    are untouched — this only removes the controller Pod for a moment.
+kubectl -n beskar7-system delete deployment beskar7-controller-manager
+kubectl -n beskar7-system delete service beskar7-webhook-service
+
+# 2. Apply the new manifest.
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.2/beskar7-manifests-v0.4.2.yaml
+
+# 3. Confirm the webhook Service actually has an endpoint — an empty list here
+#    is what blocks Beskar7Cluster admission.
+kubectl -n beskar7-system get endpoints beskar7-webhook-service
+```
+
+Provisioning is not interrupted by the controller being down briefly: state
+lives in the CRs and a host mid-inspection is picked up on the next reconcile.
+
+**If a `Beskar7Cluster` is already stuck deleting** because the webhook has no
+endpoints, completing the steps above unblocks it — the finalizer clears as soon
+as admission works again. Do not remove the finalizer by hand.
 
 ## `v0.4.0` → `v0.4.1` — chart fix only, no API or contract change
 


### PR DESCRIPTION
Fixes the kustomize install path and cuts **v0.4.2**. No API, CRD or contract (`v4.2`) change.

Found by the v0.4.1 dome validation.

## The bug

`config/default/kustomization.yaml` set `includeSelectors: true` on a label group containing `app.kubernetes.io/version`, so the version landed in **`Deployment.spec.selector`** — an immutable field — and in the webhook Service selector. `make release-manifests` rewrites that label every release, so the selector changed each version and re-applying the published manifest failed:

```
The Deployment "controller-manager" is invalid: spec.selector:
Invalid value: {...}: field is immutable
```

That is the **first install method in the README** and the procedure in `docs/upgrading.md` — so `kubectl apply` upgrades have never worked. **Helm is unaffected**: the chart selector uses `beskar7.selectorLabels`, which carries no version.

### Second symptom, same cause

The webhook Service selector stopped matching the controller Pod on version skew and sat with **no endpoints**. With `failurePolicy: Fail`, every `Beskar7Cluster` create/update/**delete** was then rejected — which shows up as a `Beskar7Cluster` **stuck in `Deleting`**, because the controller cannot patch off its own finalizer. Hit exactly this on dome.

## The fix

Split into two label groups — stable identity labels keep `includeSelectors: true`; the version label moves to `includeSelectors: false` so it still lands on metadata. Same split applied to the `large` and `extra-large` overlays, which had the same construction.

## Verification

| step | result |
|---|---|
| Reproduce on shipped releases (v0.4.0 → v0.4.1, scratch ns) | `field is immutable` |
| Build bundle at two synthetic versions with the fix | selectors **byte-identical** |
| Apply one over the other | `deployment.apps/controller-manager configured` |
| Version label on the live object after upgrade | updated correctly |

Plus: `helm lint` clean, chart CRDs in sync, build + `test/rbac` green, bundle renders with image `v0.4.2` and a stable selector.

## ⚠️ One-time migration

The fix changes the selector one final time, so **existing `kubectl apply` installs must delete the Deployment and webhook Service before applying v0.4.2**. `docs/upgrading.md` carries the procedure, including how to unwedge a `Beskar7Cluster` already stuck deleting. Helm users upgrade normally.

## Version bump

Pointers moved: `Chart.yaml` version + appVersion, `Makefile` VERSION, release-manifest URLs, default `IMG`, `SECURITY.md` table.

Deliberately **not** moved (historical statements): contract "FROZEN for v0.4.0 GA", "stable as of `v0.4.0`", "signed from `v0.4.0` onward", and the `alpha.N → v0.4.0` / `v0.4.0 → v0.4.1` procedures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
