### PR TITLE
fix(physicalhost): clear a finished run's state so a host can be reused

### DIFF
--- a/api/v1beta1/physicalhost_types.go
+++ b/api/v1beta1/physicalhost_types.go
@@ -399,6 +399,10 @@ const (
 	SetBootPXEFailedReason        string = "SetBootPXEFailed"
 	InspectionFailedReason        string = "InspectionFailed"
 	InspectionTimeoutReason       string = "InspectionTimeout"
+	// HostReleasedReason marks HostInspected=False when a host goes back to
+	// Available. The inspection described the run that just ended, not the
+	// hardware, so it must not carry into the next consumer's claim.
+	HostReleasedReason string = "HostReleased"
 	// InsecureCABundleConflictReason is set when InsecureSkipVerify=true is
 	// combined with CABundleSecretRef != "" — the two are mutually exclusive
 	// (a CA bundle and "skip verification" together is incoherent). The

--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -299,6 +299,17 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 	// Connection successful - mark as ready
 	conditions.MarkTrue(physicalHost, infrastructurev1beta1.RedfishConnectionReadyCondition)
 
+	// Drop anything left over from a previous provisioning run before the
+	// annotation handlers below, so a host that is claimed again starts clean.
+	//
+	// Deliberately BEFORE the handlers, not after: they legitimately write
+	// inspection state onto an unclaimed host (the Beskar7Machine controller
+	// signals through annotations, and consumption is not gated on ConsumerRef).
+	// Clearing afterwards would erase what they just wrote.
+	if physicalHost.Spec.ConsumerRef == nil {
+		r.clearProvisioningRunState(logger, physicalHost)
+	}
+
 	// Act on inspection-request annotation set by Beskar7Machine controller.
 	// The Beskar7Machine controller writes only to PhysicalHost.Spec.Annotations (a spec
 	// write via MergeFrom patch); we read it here and drive the Status transition ourselves,
@@ -354,7 +365,6 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 			r.updateStatus(physicalHost, infrastructurev1beta1.StateInUse, true, "")
 		}
 	} else {
-		// Host is available
 		if physicalHost.Status.State != infrastructurev1beta1.StateAvailable {
 			logger.Info("Host available, transitioning to Available")
 			r.updateStatus(physicalHost, infrastructurev1beta1.StateAvailable, true, "")
@@ -364,6 +374,49 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 
 	logger.Info("Reconciliation complete", "state", physicalHost.Status.State, "ready", physicalHost.Status.Ready)
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+}
+
+// clearProvisioningRunState drops the status that belongs to one provisioning
+// run, so the host can be claimed again.
+//
+// Without this a PhysicalHost could only ever be provisioned once. The timeouts
+// are measured as time.Since(InspectionTimestamp) and
+// time.Since(DeployingTimestamp) by the Beskar7Machine controller, and both were
+// only ever set (guarded by `== nil`) and never cleared. A host released after a
+// successful provision therefore kept the timestamps of that run, and the next
+// Beskar7Machine to claim it was marked terminally failed with
+// InspectionTimedOut within seconds — before its host had even powered on.
+//
+// That broke every reuse path a bare-metal provider depends on: a
+// MachineDeployment replacing a replica, rebuilding a cluster on the same
+// hardware, and MachineHealthCheck remediation.
+//
+// Status.Bootstrap is deliberately NOT cleared here. It is not run-scoped in the
+// way the timestamps are: the bootstrap-url and bootstrap-token annotations are
+// consumed into it while the host is still unclaimed, so wiping it on every
+// unclaimed reconcile destroys state the Beskar7Machine controller just wrote.
+// Token hygiene across consumers is a separate concern and needs its own change.
+//
+// Idempotent: safe to call on every reconcile of an unclaimed host.
+func (r *PhysicalHostReconciler) clearProvisioningRunState(logger logr.Logger, physicalHost *infrastructurev1beta1.PhysicalHost) {
+	if physicalHost.Status.InspectionTimestamp == nil &&
+		physicalHost.Status.DeployingTimestamp == nil &&
+		physicalHost.Status.InspectionPhase == "" {
+		return
+	}
+
+	logger.Info("Clearing previous provisioning-run state from released host",
+		"host", physicalHost.Name)
+
+	physicalHost.Status.InspectionTimestamp = nil
+	physicalHost.Status.DeployingTimestamp = nil
+	physicalHost.Status.InspectionPhase = ""
+
+	// HostInspected describes the run that just ended, not the host. Leaving it
+	// True would tell the next consumer the box had already been inspected.
+	conditions.MarkFalse(physicalHost, infrastructurev1beta1.HostInspectedCondition,
+		infrastructurev1beta1.HostReleasedReason, clusterv1.ConditionSeverityInfo,
+		"Host released; previous inspection no longer applies")
 }
 
 // applyInspectionRequest reads the InspectionRequestAnnotation and, when present, drives

--- a/controllers/physicalhost_controller_test.go
+++ b/controllers/physicalhost_controller_test.go
@@ -283,6 +283,120 @@ var _ = Describe("PhysicalHost Controller", func() {
 			}, Timeout, Interval).Should(Succeed())
 		})
 
+		// A PhysicalHost must be reusable. Before this, InspectionTimestamp and
+		// DeployingTimestamp were only ever set (guarded by `== nil`) and never
+		// cleared, so a released host kept the previous run's clock. The next
+		// Beskar7Machine to claim it computed time.Since(InspectionTimestamp)
+		// against that stale value and was marked terminally failed with
+		// InspectionTimedOut within seconds — breaking MachineDeployment replica
+		// replacement, cluster rebuild on the same hardware, and MHC remediation.
+		It("Should clear the previous run's state when released, so the host can be reused", func() {
+			Expect(k8sClient.Create(ctx, physicalHost)).To(Succeed())
+			phLookupKey := types.NamespacedName{Name: physicalHost.Name, Namespace: physicalHost.Namespace}
+
+			_, err := reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Driving a full provisioning run: claim -> Inspecting -> Deploying")
+			ph := &infrastructurev1beta1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, phLookupKey, ph)).To(Succeed())
+			phPatch := ph.DeepCopy()
+			if phPatch.Annotations == nil {
+				phPatch.Annotations = map[string]string{}
+			}
+			phPatch.Annotations[InspectionRequestAnnotation] = "inspect"
+			phPatch.Spec.ConsumerRef = &corev1.ObjectReference{
+				Kind:       "Beskar7Machine",
+				APIVersion: InfrastructureAPIVersion,
+				Name:       "first-consumer",
+				Namespace:  ph.Namespace,
+			}
+			Expect(k8sClient.Patch(ctx, phPatch, client.MergeFrom(ph))).To(Succeed())
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			ph2 := &infrastructurev1beta1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, phLookupKey, ph2)).To(Succeed())
+			ph2Patch := ph2.DeepCopy()
+			if ph2Patch.Annotations == nil {
+				ph2Patch.Annotations = map[string]string{}
+			}
+			ph2Patch.Annotations[InspectionRequestAnnotation] = "inspect-complete"
+			Expect(k8sClient.Patch(ctx, ph2Patch, client.MergeFrom(ph2))).To(Succeed())
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Confirming the run really did leave state behind")
+			Eventually(func(g Gomega) {
+				got := &infrastructurev1beta1.PhysicalHost{}
+				g.Expect(k8sClient.Get(ctx, phLookupKey, got)).To(Succeed())
+				g.Expect(got.Status.State).To(Equal(infrastructurev1beta1.StateDeploying))
+				g.Expect(got.Status.InspectionTimestamp).NotTo(BeNil())
+				g.Expect(got.Status.DeployingTimestamp).NotTo(BeNil())
+			}, Timeout, Interval).Should(Succeed())
+
+			By("Releasing the host, as Beskar7Machine does on delete: ConsumerRef = nil")
+			released := &infrastructurev1beta1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, phLookupKey, released)).To(Succeed())
+			relPatch := released.DeepCopy()
+			relPatch.Spec.ConsumerRef = nil
+			Expect(k8sClient.Patch(ctx, relPatch, client.MergeFrom(released))).To(Succeed())
+
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("The released host must carry NOTHING from the previous run")
+			Eventually(func(g Gomega) {
+				got := &infrastructurev1beta1.PhysicalHost{}
+				g.Expect(k8sClient.Get(ctx, phLookupKey, got)).To(Succeed())
+				g.Expect(got.Status.State).To(Equal(infrastructurev1beta1.StateAvailable))
+
+				// The regression: these two drive the inspection and deployment
+				// timeouts in the Beskar7Machine controller. A stale value fails the
+				// next consumer instantly.
+				g.Expect(got.Status.InspectionTimestamp).To(BeNil(),
+					"InspectionTimestamp must not survive release — the next consumer's inspection timeout is measured from it")
+				g.Expect(got.Status.DeployingTimestamp).To(BeNil(),
+					"DeployingTimestamp must not survive release — the next consumer's deployment timeout is measured from it")
+
+				g.Expect(got.Status.InspectionPhase).To(BeEmpty(),
+					"InspectionPhase describes the finished run")
+				g.Expect(conditions.IsTrue(got, infrastructurev1beta1.HostInspectedCondition)).To(BeFalse(),
+					"HostInspected describes the finished run, not the hardware")
+			}, Timeout, Interval).Should(Succeed())
+
+			By("A second consumer can claim it and start a fresh inspection")
+			reclaim := &infrastructurev1beta1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, phLookupKey, reclaim)).To(Succeed())
+			reclaimPatch := reclaim.DeepCopy()
+			if reclaimPatch.Annotations == nil {
+				reclaimPatch.Annotations = map[string]string{}
+			}
+			reclaimPatch.Annotations[InspectionRequestAnnotation] = "inspect"
+			reclaimPatch.Spec.ConsumerRef = &corev1.ObjectReference{
+				Kind:       "Beskar7Machine",
+				APIVersion: InfrastructureAPIVersion,
+				Name:       "second-consumer",
+				Namespace:  reclaim.Namespace,
+			}
+			Expect(k8sClient.Patch(ctx, reclaimPatch, client.MergeFrom(reclaim))).To(Succeed())
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				got := &infrastructurev1beta1.PhysicalHost{}
+				g.Expect(k8sClient.Get(ctx, phLookupKey, got)).To(Succeed())
+				g.Expect(got.Status.State).To(Equal(infrastructurev1beta1.StateInspecting))
+				g.Expect(got.Status.InspectionTimestamp).NotTo(BeNil())
+				// The whole point: the second consumer's clock starts now, not when
+				// the first consumer's run began.
+				g.Expect(got.Status.InspectionTimestamp.Time).To(BeTemporally("~", time.Now(), 2*time.Minute),
+					"the reclaimed host's inspection clock must start at the new claim")
+			}, Timeout, Interval).Should(Succeed())
+		})
+
 		It("Should handle deletion gracefully", func() {
 			By("Creating the PhysicalHost resource")
 			Expect(k8sClient.Create(ctx, physicalHost)).To(Succeed())


### PR DESCRIPTION
**A PhysicalHost could only ever be provisioned once.**

`Status.InspectionTimestamp` and `Status.DeployingTimestamp` were only ever set — each guarded by `== nil` — and never cleared. The Beskar7Machine controller measures its timeouts as `time.Since()` against them, so a host released after a successful provision kept that run's clock and the next Beskar7Machine to claim it failed terminally almost at once:

```
reason:  InspectionTimedOut
message: Inspection did not complete within 10m0s
```

Observed on the dome lab: a host provisioned at 18:12 was released, claimed by a new Beskar7Machine at 19:37, and went `Failed` within **~23 seconds** — still carrying `inspectionTimestamp: 18:12` and `deployingTimestamp: 18:18`, before its host had even powered on.

This breaks every reuse path a bare-metal provider depends on: a `MachineDeployment` replacing a replica, rebuilding a cluster on the same hardware, and `MachineHealthCheck` remediation.

## The fix

Clear the run-scoped status when the host has no consumer — the timestamps, `InspectionPhase`, and `HostInspected` (flipped False with a new `HostReleased` reason, since it describes the run that ended rather than the hardware).

## Two placement details, both found by existing tests

- **It runs BEFORE the annotation handlers, not after.** They legitimately write inspection state onto an *unclaimed* host — the Beskar7Machine controller signals through annotations and consumption isn't gated on `ConsumerRef` — so clearing afterwards erased what they'd just written and broke the inspection-result test.
- **`Status.Bootstrap` is deliberately left alone.** My first attempt cleared it and broke the bootstrap-url test: the URL and token annotations are consumed into it *while the host is still unclaimed*. Token hygiene across consumers is a real but separate concern (a host re-claimed inside the 30-minute window inherits the previous consumer's token, because `bootstrapTokenStillValid` skips minting while one is unexpired) and needs its own change.

Running on every unclaimed reconcile rather than only on the transition also heals a host released uncleanly — a manager restart mid-release, or an operator clearing `ConsumerRef` by hand. The helper early-returns when there's nothing to clear, so it's idempotent.

## Verification

The envtest drives a full run to `Deploying`, releases the host, asserts nothing from that run survives, then re-claims it with a second consumer and asserts the new inspection clock starts at the new claim. **Confirmed to fail with the fix disabled** — exactly one failing spec, the new one.

`make manifests` is a no-op for `config/` (the new reason is a Go constant, no CRD schema impact) · chart CRDs still in sync · full suite green under `-race` · `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)