### PR TITLE
chore(release): v0.4.3 — hosts can be provisioned more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [v0.4.3] - 2026-09-07
+
+Fixes host reuse. No API, CRD or contract (`v4.2`) change; no manual upgrade step.
+
+### Fixed
+
+- **A `PhysicalHost` could only ever be provisioned once.**
+  `Status.InspectionTimestamp` and `Status.DeployingTimestamp` were set on the
+  first run (each guarded by `== nil`) and never cleared. The `Beskar7Machine`
+  controller measures its inspection and deployment timeouts as `time.Since()`
+  against them, so a host released after a successful provision kept that run's
+  clock and the next machine to claim it was marked terminally failed almost
+  immediately with `InspectionTimedOut` — before the host had even powered on.
+
+  This broke every path that reuses hardware: a `MachineDeployment` replacing a
+  replica, rebuilding a cluster on the same hosts, and `MachineHealthCheck`
+  remediation.
+
+  The run-scoped status is now cleared when a host has no `consumerRef`, which
+  also heals a host released uncleanly (a manager restart mid-release, or a
+  `consumerRef` cleared by hand). `InspectionPhase` is reset and `HostInspected`
+  flipped to False with a new `HostReleased` reason, since both describe the run
+  that ended rather than the hardware. Verified on bare metal: a host carrying a
+  stale timestamp was released, cleared, re-claimed, and provisioned again to
+  `Ready` with the node coming up as `b7://<namespace>/<host>`. (#154)
+
 ## [v0.4.2] - 2026-09-07
 
 Fixes the kustomize install path. No API, CRD or contract (`v4.2`) change.
@@ -967,7 +993,8 @@ For detailed implementation information, see the examples directory and document
 - CI: lint, tests, container build, CRD generation, Kind sanity checks.
 - Core controllers and CRDs for `PhysicalHost`, `Beskar7Machine`, `Beskar7Cluster`.
 
-[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.3...HEAD
+[v0.4.3]: https://github.com/projectbeskar/beskar7/compare/v0.4.2...v0.4.3
 [v0.4.2]: https://github.com/projectbeskar/beskar7/compare/v0.4.1...v0.4.2
 [v0.4.1]: https://github.com/projectbeskar/beskar7/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/projectbeskar/beskar7/compare/v0.4.0-alpha.9...v0.4.0

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.2
+VERSION ?= v0.4.3
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.2 — patch release on the GA line (`v0.4.0` was the first GA)  
+**Version:** v0.4.3 — patch release on the GA line (`v0.4.0` was the first GA)  
 **API:** `v1beta1` is **stable and frozen**. The schema evolves **additive-only**; a breaking change requires a future `v1beta2` introduced with a conversion webhook.  
 **Contract:** controller↔inspector wire contract **v4.2, frozen** ([contract](docs/inspector-contract.md)). Pair with a `contract-v4.2` [inspector release](https://github.com/projectbeskar/beskar7-inspector/releases).  
 **Upgrading:** v0.4.0 is **not** compatible with v0.3.x, and the alpha series contains breaking API changes — see [Upgrading](docs/upgrading.md) and the [CHANGELOG](CHANGELOG.md).
@@ -56,7 +56,7 @@ helm install beskar7 beskar7/beskar7 \
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.2/beskar7-manifests-v0.4.2.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.3/beskar7-manifests-v0.4.3.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,8 +37,9 @@ is stable as of `v0.4.0`, so upgrades within the `v0.4.x` line are additive.
 
 | Version | Supported |
 |---|---|
-| `v0.4.2` (latest) | ✅ |
-| `v0.4.1` | ⚠️ upgrade — `kubectl apply` upgrades are impossible against it ([CHANGELOG](CHANGELOG.md)) |
+| `v0.4.3` (latest) | ✅ |
+| `v0.4.2` | ⚠️ upgrade — a released host cannot be provisioned again ([CHANGELOG](CHANGELOG.md)) |
+| `v0.4.1` | ⚠️ upgrade — also makes `kubectl apply` upgrades impossible |
 | `v0.4.0` | ⚠️ upgrade — also breaks `helm upgrade --reuse-values` |
 | earlier `v0.4.0-alpha.*` | ❌ upgrade first |
 | `v0.3.x` | ❌ end of life — not compatible with v0.4 ([CHANGELOG](CHANGELOG.md)) |

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.2
-appVersion: "v0.4.2"
+version: 0.4.3
+appVersion: "v0.4.3"
 keywords:
   - cluster-api
   - infrastructure

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -273,8 +273,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.x` (GA); bump the patch for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.2
-   git push origin v0.4.2
+   git tag v0.4.3
+   git push origin v0.4.3
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.2`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.3`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,7 @@ The external SAN is added to both certificate paths: the cert-manager `Certifica
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.2/beskar7-manifests-v0.4.2.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.3/beskar7-manifests-v0.4.3.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -31,13 +31,13 @@ these instead:
 
 ```bash
 # Helm 3.14+ — replays your overrides on top of the NEW chart's defaults.
-helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.2 \
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.3 \
   --reset-then-reuse-values
 ```
 
 ```bash
 # Any Helm version — keep your settings in a file and pass it every time.
-helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.2 \
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.3 \
   -f my-beskar7-values.yaml
 ```
 
@@ -55,6 +55,7 @@ from the release you deployed:
 
 | beskar7 release | contract |
 |---|---|
+| `v0.4.3` | `v4.2` **frozen** |
 | `v0.4.2` | `v4.2` **frozen** |
 | `v0.4.1` | `v4.2` **frozen** |
 | `v0.4.0` (GA) | `v4.2` **frozen** |
@@ -85,6 +86,38 @@ docker pull ghcr.io/projectbeskar/beskar7-inspector:contract-v4.2
 Within a frozen `v4.x` line the changes are additive, so a controller tolerates an
 inspector one minor version behind — it simply does not get the newer capability
 (see `docs/inspector-contract.md` §14). Do not rely on that across a major bump.
+
+## `v0.4.2` → `v0.4.3` — hosts can be provisioned more than once
+
+No API, CRD or contract change, and no manual step. Upgrade normally:
+
+```bash
+helm repo update
+helm upgrade beskar7 beskar7/beskar7 -n beskar7-system --version 0.4.3 \
+  --reset-then-reuse-values
+```
+
+**Why upgrade:** before `v0.4.3` a `PhysicalHost` could only ever be provisioned
+once. `Status.InspectionTimestamp` and `Status.DeployingTimestamp` were set on
+the first run and never cleared, and the `Beskar7Machine` controller measures its
+timeouts against them — so the next machine to claim a released host was marked
+terminally failed within seconds:
+
+```
+reason:  InspectionTimedOut
+message: Inspection did not complete within 10m0s
+```
+
+That affected every path that reuses hardware: a `MachineDeployment` replacing a
+replica, rebuilding a cluster on the same hosts, and `MachineHealthCheck`
+remediation.
+
+**If you have hosts stuck in this state**, no manual repair is needed. The
+controller clears the leftover state on any reconcile of a host with no
+`consumerRef`, so an affected host recovers on its own once the new controller
+is running. A `Beskar7Machine` already marked `InspectionTimedOut` is terminal by
+design and must still be deleted and recreated — the host underneath it is now
+reusable.
 
 ## `v0.4.1` → `v0.4.2` — one-time manual step for `kubectl apply` installs
 


### PR DESCRIPTION
Ships #154. No API, CRD or contract (`v4.2`) change, and **no manual upgrade step**.

## Why

Before this, a `PhysicalHost` could only ever be provisioned **once**. `InspectionTimestamp` and `DeployingTimestamp` were set on the first run and never cleared, and the `Beskar7Machine` controller measures its timeouts against them — so the next machine to claim a released host was marked terminally failed within seconds:

```
reason:  InspectionTimedOut
message: Inspection did not complete within 10m0s
```

That broke every path that reuses hardware: `MachineDeployment` replica replacement, rebuilding a cluster on the same hosts, and `MachineHealthCheck` remediation.

## Upgrading

Nothing manual. Affected hosts **self-heal** once the new controller runs, because the state is cleared on any reconcile of a host with no `consumerRef`. A `Beskar7Machine` already marked `InspectionTimedOut` is terminal by design and still has to be deleted and recreated — the host underneath it is reusable again.

## Verified on hardware

A host carrying a stale `inspectionTimestamp` from an earlier run was released, cleared (`Clearing previous provisioning-run state from released host`), re-claimed **without deleting the PhysicalHost**, and provisioned through to `Ready` — node up as `b7://b7e2e/b7e2e-cp0`. Under the old code the new machine failed in ~23 seconds.

## Version bump

Moved: `Chart.yaml` version + appVersion, `Makefile` VERSION, release-manifest URLs, default `IMG`, `SECURITY.md` table.

Deliberately **not** moved: contract "FROZEN for v0.4.0 GA", "`v1beta1` stable as of `v0.4.0`", "signed from `v0.4.0` onward", the `alpha.N → v0.4.0` procedures, and the `v0.4.1 → v0.4.2` kubectl-apply migration section — all must keep naming the versions they describe.

`helm lint` clean · rendered image `v0.4.3` · chart CRDs in sync · `test/rbac` green · kustomize bundle still renders a version-free selector (KUST-1 holding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)