### PR TITLE
chore(release): v0.4.4 — CAPI contract-label fix, hostSelector, failure-domain placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [v0.4.4] - 2026-09-09
+
+Patch release on the GA line: the CAPI contract-label fix below, plus everything merged
+since `v0.4.3` — `hostSelector` (#158), the claim honouring `Machine.spec.failureDomain`
+(#157), and the k0s image-side start gate and image-build guide (#156). The only schema
+change is the additive `hostSelector` field; see `docs/upgrading.md` for the one manual
+step (CRD label) and the CRD re-apply.
+
 ### Fixed
 
 - **CAPI ≥ v1.11 could not read `Beskar7Cluster.status.failureDomains`, and a
@@ -1064,7 +1072,8 @@ For detailed implementation information, see the examples directory and document
 - CI: lint, tests, container build, CRD generation, Kind sanity checks.
 - Core controllers and CRDs for `PhysicalHost`, `Beskar7Machine`, `Beskar7Cluster`.
 
-[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.4...HEAD
+[v0.4.4]: https://github.com/projectbeskar/beskar7/compare/v0.4.3...v0.4.4
 [v0.4.3]: https://github.com/projectbeskar/beskar7/compare/v0.4.2...v0.4.3
 [v0.4.2]: https://github.com/projectbeskar/beskar7/compare/v0.4.1...v0.4.2
 [v0.4.1]: https://github.com/projectbeskar/beskar7/compare/v0.4.0...v0.4.1

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.3
+VERSION ?= v0.4.4
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.3 — patch release on the GA line (`v0.4.0` was the first GA)  
+**Version:** v0.4.4 — patch release on the GA line (`v0.4.0` was the first GA)  
 **API:** `v1beta1` is **stable and frozen**. The schema evolves **additive-only**; a breaking change requires a future `v1beta2` introduced with a conversion webhook.  
 **Contract:** controller↔inspector wire contract **v4.2, frozen** ([contract](docs/inspector-contract.md)). Pair with a `contract-v4.2` [inspector release](https://github.com/projectbeskar/beskar7-inspector/releases).  
 **Upgrading:** v0.4.0 is **not** compatible with v0.3.x, and the alpha series contains breaking API changes — see [Upgrading](docs/upgrading.md) and the [CHANGELOG](CHANGELOG.md).
@@ -56,7 +56,7 @@ helm install beskar7 beskar7/beskar7 \
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.3/beskar7-manifests-v0.4.3.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.4/beskar7-manifests-v0.4.4.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,8 @@ is stable as of `v0.4.0`, so upgrades within the `v0.4.x` line are additive.
 
 | Version | Supported |
 |---|---|
-| `v0.4.3` (latest) | ✅ |
+| `v0.4.4` (latest) | ✅ |
+| `v0.4.3` | ✅ |
 | `v0.4.2` | ⚠️ upgrade — a released host cannot be provisioned again ([CHANGELOG](CHANGELOG.md)) |
 | `v0.4.1` | ⚠️ upgrade — also makes `kubectl apply` upgrades impossible |
 | `v0.4.0` | ⚠️ upgrade — also breaks `helm upgrade --reuse-values` |

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.3
-appVersion: "v0.4.3"
+version: 0.4.4
+appVersion: "v0.4.4"
 keywords:
   - cluster-api
   - infrastructure

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -273,8 +273,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.x` (GA); bump the patch for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.3
-   git push origin v0.4.3
+   git tag v0.4.4
+   git push origin v0.4.4
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.3`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.4`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,7 @@ The external SAN is added to both certificate paths: the cert-manager `Certifica
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.3/beskar7-manifests-v0.4.3.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.4/beskar7-manifests-v0.4.4.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -87,7 +87,13 @@ Within a frozen `v4.x` line the changes are additive, so a controller tolerates 
 inspector one minor version behind — it simply does not get the newer capability
 (see `docs/inspector-contract.md` §14). Do not rely on that across a major bump.
 
-## Unreleased — CAPI contract label
+## `v0.4.3` → `v0.4.4` — contract label fix, `hostSelector`, failure-domain placement
+
+Apply the new CRDs first (they add the additive `spec.hostSelector` to `Beskar7Machine` and
+`Beskar7MachineTemplate`), then the controller. No bootstrap-template or inspector change (contract
+stays `v4.2`).
+
+### The CRD contract label
 
 The CRDs no longer claim the `cluster.x-k8s.io/v1beta2` contract (see the CHANGELOG entry: on CAPI
 v1.11+ that claim made CAPI read `status.failureDomains` as a list and fail). Apply the new CRDs as


### PR DESCRIPTION
## Summary

Patch release on the GA line: the `cluster.x-k8s.io/v1beta2` contract-label fix (#160) plus everything merged since `v0.4.3` — `hostSelector` (#158), the claim honouring `Machine.spec.failureDomain` (#157), and the k0s image-side start gate + image-build guide (#156).

Version pointers only (Makefile, chart, README, installation, development-setup, ci-cd example, SECURITY table); CHANGELOG `[Unreleased]` → `[v0.4.4]`; `docs/upgrading.md` gets the `v0.4.3` → `v0.4.4` section (re-apply CRDs for the additive `hostSelector` field; manual label removal for Helm-installed CRDs). Historical version mentions untouched. CRDs regenerate byte-identical.

Tag `v0.4.4` after merge triggers `release.yml` + `helm-publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)