### PR TITLE
fix(beskar7machine): wake waiting machines when a PhysicalHost becomes Available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `PhysicalHost` turning `Available` now wakes the `Beskar7Machine`s still
+  waiting for a host.** A machine that reconciled moments before its host
+  finished enrolling (or before another machine released it) parked on the
+  one-minute no-host requeue with nothing to end the wait early; with
+  controller-runtime 0.23's priority queue that minute was also no longer
+  shortened by the finalizer-add retry. A second watch on `PhysicalHost`,
+  admitted only on the transition into a claimable state, re-enqueues the
+  namespace's unassociated machines. The one-minute requeue stays as a
+  backstop. This is also what made the integration suite's "Delete and
+  release" specs flake.
+
 ### Changed
 
 - **Built against Cluster API v1.13 and its `api/core/v1beta2` Go API** (was

--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -43,10 +43,13 @@ import (
 	conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -303,7 +306,9 @@ func (r *Beskar7MachineReconciler) reconcileNormal(ctx context.Context, logger l
 	} else if placement != nil {
 		// Distinct from an empty inventory: hosts may well be Available, just
 		// not where CAPI placed this Machine. Requeue, never terminal — a host in
-		// that domain can free up, or the operator can label one.
+		// that domain can free up, or the operator can label one. The minute is
+		// a backstop: a host entering Available re-enqueues the machine at once
+		// (AvailablePhysicalHostToWaitingBeskar7Machines).
 		logger.Info("No available PhysicalHost satisfies the placement constraint, requeuing", "placement", placement.String())
 		conditions.MarkFalse(b7machine, infrastructurev1beta1.PhysicalHostAssociatedCondition,
 			infrastructurev1beta1.NoMatchingPhysicalHostReason, clusterv1.ConditionSeverityInfo,
@@ -1574,6 +1579,11 @@ func (r *Beskar7MachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&infrastructurev1beta1.PhysicalHost{},
 			handler.EnqueueRequestsFromMapFunc(r.PhysicalHostToBeskar7Machine),
 		).
+		Watches(
+			&infrastructurev1beta1.PhysicalHost{},
+			handler.EnqueueRequestsFromMapFunc(r.AvailablePhysicalHostToWaitingBeskar7Machines),
+			builder.WithPredicates(hostBecameAvailable()),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: maxConcurrentOrDefault(r.MaxConcurrentReconciles),
 		}).
@@ -1600,6 +1610,57 @@ func (r *Beskar7MachineReconciler) PhysicalHostToBeskar7Machine(ctx context.Cont
 	return []reconcile.Request{
 		{NamespacedName: types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name}},
 	}
+}
+
+// hostBecameAvailable admits exactly the PhysicalHost events on which an
+// unclaimed host enters Available: creation already in that state, and the
+// transition into it (enrolment, release by a deleted machine). Status churn
+// on a host that is already free does not pass, so waiting machines are not
+// re-enqueued on every host resync.
+func hostBecameAvailable() predicate.Funcs {
+	free := func(o client.Object) bool {
+		h, ok := o.(*infrastructurev1beta1.PhysicalHost)
+		return ok && h.Status.State == infrastructurev1beta1.StateAvailable && h.Spec.ConsumerRef == nil
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return free(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return free(e.ObjectNew) && !free(e.ObjectOld) },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
+// AvailablePhysicalHostToWaitingBeskar7Machines maps a PhysicalHost that has
+// just become claimable to every Beskar7Machine in its namespace that is
+// still waiting for one. The no-host path requeues after a minute as a
+// backstop, and a machine that reconciled moments before its host finished
+// enrolling would otherwise sit out that whole minute: nothing else
+// re-enqueues it, and controller-runtime's priority queue collapses a
+// pending delayed requeue into any earlier event-driven reconcile.
+func (r *Beskar7MachineReconciler) AvailablePhysicalHostToWaitingBeskar7Machines(ctx context.Context, obj client.Object) []reconcile.Request {
+	host, ok := obj.(*infrastructurev1beta1.PhysicalHost)
+	if !ok {
+		r.Log.Error(nil, "Expected a PhysicalHost in AvailablePhysicalHostToWaitingBeskar7Machines map", "object", obj)
+		return nil
+	}
+	if host.Status.State != infrastructurev1beta1.StateAvailable || host.Spec.ConsumerRef != nil {
+		return nil
+	}
+	machines := &infrastructurev1beta1.Beskar7MachineList{}
+	if err := r.List(ctx, machines, client.InNamespace(host.Namespace)); err != nil {
+		r.Log.Error(err, "Failed to list Beskar7Machines waiting for a PhysicalHost", "namespace", host.Namespace)
+		return nil
+	}
+	var requests []reconcile.Request
+	for i := range machines.Items {
+		m := &machines.Items[i]
+		if !m.DeletionTimestamp.IsZero() || m.Status.FailureReason != nil ||
+			conditions.IsTrue(m, infrastructurev1beta1.PhysicalHostAssociatedCondition) {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(m)})
+	}
+	return requests
 }
 
 // parseMemoryCapacityGB converts a BMC-reported capacity string to whole decimal gigabytes.

--- a/controllers/beskar7machine_controller_test.go
+++ b/controllers/beskar7machine_controller_test.go
@@ -23,7 +23,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrastructurev1beta1 "github.com/projectbeskar/beskar7/api/v1beta1"
 	"github.com/projectbeskar/beskar7/internal/auth"
@@ -2254,5 +2256,99 @@ var _ = Describe("Host claim honours placement: failure domain and hostSelector"
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.RequeueAfter).To(Equal(time.Minute))
 		Expect(conditions.Get(b7m2, infrastructurev1beta1.PhysicalHostAssociatedCondition).Reason).To(Equal(infrastructurev1beta1.WaitingForPhysicalHostReason))
+	})
+})
+
+var _ = Describe("Waking waiting Beskar7Machines when a PhysicalHost becomes Available", func() {
+	// A machine that reconciles moments before its host finishes enrolling
+	// parks on the one-minute no-host requeue. The host's own transition to
+	// Available is the only event that can end that wait early, so the
+	// predicate must pass exactly that transition and the map must pick
+	// exactly the machines that are still looking for a host.
+
+	hostIn := func(state string) *infrastructurev1beta1.PhysicalHost {
+		return &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "wake-host", Namespace: "default"},
+			Status:     infrastructurev1beta1.PhysicalHostStatus{State: state},
+		}
+	}
+	claimedIn := func(state string) *infrastructurev1beta1.PhysicalHost {
+		h := hostIn(state)
+		h.Spec.ConsumerRef = &corev1.ObjectReference{Kind: "Beskar7Machine", Name: "someone", Namespace: "default"}
+		return h
+	}
+	machine := func(ns, name string, mutate func(*infrastructurev1beta1.Beskar7Machine)) *infrastructurev1beta1.Beskar7Machine {
+		m := &infrastructurev1beta1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Finalizers: []string{Beskar7MachineFinalizer}},
+			Spec: infrastructurev1beta1.Beskar7MachineSpec{
+				InspectionImageURL: "http://boot/inspect.ipxe",
+				TargetImageURL:     "http://boot/kairos.tar.gz",
+				TargetImageDigest:  bootTestDigest,
+			},
+		}
+		if mutate != nil {
+			mutate(m)
+		}
+		return m
+	}
+
+	It("admits only the events on which an unclaimed host enters Available", func() {
+		p := hostBecameAvailable()
+
+		Expect(p.Create(event.CreateEvent{Object: hostIn(infrastructurev1beta1.StateAvailable)})).To(BeTrue(), "created already free")
+		Expect(p.Create(event.CreateEvent{Object: hostIn(infrastructurev1beta1.StateEnrolling)})).To(BeFalse(), "created enrolling")
+		Expect(p.Create(event.CreateEvent{Object: claimedIn(infrastructurev1beta1.StateAvailable)})).To(BeFalse(), "created with a consumer")
+
+		Expect(p.Update(event.UpdateEvent{ObjectOld: hostIn(""), ObjectNew: hostIn(infrastructurev1beta1.StateAvailable)})).To(BeTrue(), "enrolment finished")
+		Expect(p.Update(event.UpdateEvent{ObjectOld: claimedIn(infrastructurev1beta1.StateInUse), ObjectNew: hostIn(infrastructurev1beta1.StateAvailable)})).To(BeTrue(), "released")
+		Expect(p.Update(event.UpdateEvent{ObjectOld: hostIn(infrastructurev1beta1.StateAvailable), ObjectNew: hostIn(infrastructurev1beta1.StateAvailable)})).To(BeFalse(), "status churn on a free host")
+		Expect(p.Update(event.UpdateEvent{ObjectOld: hostIn(infrastructurev1beta1.StateAvailable), ObjectNew: claimedIn(infrastructurev1beta1.StateAvailable)})).To(BeFalse(), "claimed")
+
+		Expect(p.Delete(event.DeleteEvent{Object: hostIn(infrastructurev1beta1.StateAvailable)})).To(BeFalse())
+		Expect(p.Generic(event.GenericEvent{Object: hostIn(infrastructurev1beta1.StateAvailable)})).To(BeFalse())
+	})
+
+	It("enqueues the machines still waiting for a host in the host's namespace and nothing else", func() {
+		never := machine("default", "never-reconciled", nil)
+		waiting := machine("default", "waiting", func(m *infrastructurev1beta1.Beskar7Machine) {
+			conditions.MarkFalse(m, infrastructurev1beta1.PhysicalHostAssociatedCondition,
+				infrastructurev1beta1.WaitingForPhysicalHostReason, clusterv1.ConditionSeverityInfo, "No available PhysicalHost found")
+		})
+		placed := machine("default", "no-match", func(m *infrastructurev1beta1.Beskar7Machine) {
+			conditions.MarkFalse(m, infrastructurev1beta1.PhysicalHostAssociatedCondition,
+				infrastructurev1beta1.NoMatchingPhysicalHostReason, clusterv1.ConditionSeverityInfo, "no host in rack-1")
+		})
+		associated := machine("default", "associated", func(m *infrastructurev1beta1.Beskar7Machine) {
+			conditions.MarkTrue(m, infrastructurev1beta1.PhysicalHostAssociatedCondition)
+		})
+		failed := machine("default", "failed", func(m *infrastructurev1beta1.Beskar7Machine) {
+			reason := infrastructurev1beta1.InvalidHostSelectorReason
+			m.Status.FailureReason = &reason
+		})
+		now := metav1.Now()
+		deleting := machine("default", "deleting", func(m *infrastructurev1beta1.Beskar7Machine) {
+			m.DeletionTimestamp = &now
+		})
+		elsewhere := machine("other-ns", "waiting-elsewhere", nil)
+
+		c := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+			WithObjects(never, waiting, placed, associated, failed, deleting, elsewhere).Build()
+		r := &Beskar7MachineReconciler{Client: c, Scheme: scheme.Scheme, Log: ctrl.Log.WithName("wake-test")}
+
+		names := func(reqs []reconcile.Request) []string {
+			out := make([]string, 0, len(reqs))
+			for _, req := range reqs {
+				Expect(req.Namespace).To(Equal("default"))
+				out = append(out, req.Name)
+			}
+			return out
+		}
+
+		Expect(names(r.AvailablePhysicalHostToWaitingBeskar7Machines(context.Background(), hostIn(infrastructurev1beta1.StateAvailable)))).
+			To(ConsistOf("never-reconciled", "waiting", "no-match"))
+
+		By("mapping nothing for a host that is not claimable")
+		Expect(r.AvailablePhysicalHostToWaitingBeskar7Machines(context.Background(), claimedIn(infrastructurev1beta1.StateAvailable))).To(BeEmpty())
+		Expect(r.AvailablePhysicalHostToWaitingBeskar7Machines(context.Background(), hostIn(infrastructurev1beta1.StateInUse))).To(BeEmpty())
 	})
 })

--- a/docs/beskar7machine.md
+++ b/docs/beskar7machine.md
@@ -58,7 +58,7 @@ By default a Beskar7Machine claims the first `Available` PhysicalHost in its nam
 
 Placement applies to a **fresh claim only**: a host the machine already holds is never re-evaluated, so labelling or relabelling hosts moves future claims, not running nodes. `hardwareRequirements` does **not** steer the claim — it is validated after inspection, and a mismatch is terminal — so on a mixed inventory use a selector to land on the right class of host in the first place.
 
-When hosts are `Available` but none satisfies the constraint, `PhysicalHostAssociated=False` carries reason `NoMatchingPhysicalHost` (an empty inventory reports `WaitingForPhysicalHost`) and the machine requeues every minute. A selector that cannot be parsed (an unknown operator, for example) is terminal: `InvalidHostSelector`.
+When hosts are `Available` but none satisfies the constraint, `PhysicalHostAssociated=False` carries reason `NoMatchingPhysicalHost` (an empty inventory reports `WaitingForPhysicalHost`) and the machine requeues every minute — sooner if a `PhysicalHost` in the namespace becomes `Available` in the meantime, which re-enqueues every machine still waiting for a host. A selector that cannot be parsed (an unknown operator, for example) is terminal: `InvalidHostSelector`.
 
 ## Reconcile flow
 


### PR DESCRIPTION
## What

A `PhysicalHost` turning `Available` now wakes every `Beskar7Machine` in its namespace that is still waiting for a host.

## Why

A machine that reconciles moments before its host finishes enrolling (or before another machine releases it) parks on the one-minute no-host requeue, and nothing ends that wait early:

- `PhysicalHostToBeskar7Machine` only maps hosts that already have a `ConsumerRef`, so a host *becoming* claimable never enqueues anyone.
- controller-runtime 0.23 (in since #162) defaults to the priority queue, which collapses a pending delayed requeue into any earlier event-driven reconcile. The finalizer-add `RequeueAfter` that used to retry the claim a second later is consumed by the reconcile triggered by the finalizer patch itself, which runs before the host is `Available` and returns the one-minute requeue.

In production that is up to a minute of idle latency per waiting machine after every enrolment or release. In CI it is the flaky "Delete and release" integration specs: a 60 s `Eventually` against a 60 s requeue, decided by sub-second scheduling. It failed on #161 and on the first #162 run.

## How

A second `Watches(&PhysicalHost{})` on the machine controller, admitted by a `hostBecameAvailable` predicate only on the transition into a claimable state (created `Available` without a consumer, or updated from not-free to free), mapped by `AvailablePhysicalHostToWaitingBeskar7Machines` to the namespace's machines that are not deleting, not terminally failed and not yet `PhysicalHostAssociated`. Status churn on an already-free host does not pass the predicate, so nothing is re-enqueued on resyncs. The one-minute requeue stays as a backstop.

## Verification

- Two new envtest-package specs: the predicate's admit/reject matrix and the map's selection (waiting / never-reconciled / `NoMatchingPhysicalHost` in, associated / failed / deleting / other namespace out).
- Integration suite: 5 consecutive local runs green, ~9 s each (was ~67 s when a spec had to wait out the minute).
- `go test ./... -race`, `golangci-lint run`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
