### PR TITLE
feat(manager): --controllers=none, a callback-only instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,23 @@ step (CRD label) and the CRD re-apply.
   cannot be parsed is terminal (`InvalidHostSelector`); no matching host is
   `PhysicalHostAssociated=False/NoMatchingPhysicalHost` and a requeue. CRD
   schema change (additive); chart CRDs regenerated. `examples/host-pools.yaml`.
+- **`--controllers=none`: a callback-only manager.** Bare-metal hosts must reach
+  the callback endpoints (`/boot`, `/api/v1/inspection`, `/api/v1/bootstrap`,
+  `/api/v1/provisioned`) from the provisioning network during PXE boot, which is
+  often not a network the management cluster is on. A second copy of the manager
+  placed on that network used to run every controller as well, and two full
+  managers fight: they race for host claims, and when their `--bootstrap-url-base`
+  values differ they rewrite the `bootstrap-url` annotation against each other,
+  hundreds of `the object has been modified` reconcile errors a minute. With
+  `--controllers=none` an instance serves the callback endpoints and the health
+  probes on the usual cached client and registers no reconciler or webhook.
+  Leader election is off in that mode; `--leader-elect=true` and
+  `--enable-webhook=true` alongside it are rejected at startup. The callback
+  server now pre-warms the PhysicalHost, Beskar7Machine, Machine and Secret
+  informers its handlers read, so the first callback of each kind no longer
+  waits on a lazy cache sync (a no-op in the full manager, where the controllers
+  create the same informers). Documented in `docs/ipxe-setup.md` and the chart
+  README; troubleshooting §14 covers the two-manager symptom.
 
 ### Fixed
 

--- a/charts/beskar7/README.md
+++ b/charts/beskar7/README.md
@@ -56,6 +56,14 @@ helm install my-release beskar7/beskar7 \
 
 Bare-metal hosts must be able to reach the `bootstrap.urlBase` during PXE boot. It is rendered into `PhysicalHost.Status.Bootstrap.URL` for each provisioned host.
 
+**Callback-only instance.** When the management cluster has no interface on the provisioning network, nothing the chart can expose is reachable from a PXE-booting host. The supported answer is a second copy of the manager binary on a machine that is on that network, started with `--controllers=none`: it serves the callback endpoints and registers no reconciler or webhook, so it does not compete with this release's controllers. The chart does not deploy that instance (it needs a kubeconfig for this cluster, which the in-cluster Deployment does not use), but three values of this release must line up with it:
+
+- `bootstrap.urlBase` — the callback-only instance's external address, e.g. `https://192.0.2.10:8082`. The in-cluster controller writes it into `PhysicalHost.Status.Bootstrap.URL`; start the callback-only instance with the same `--bootstrap-url-base`.
+- `callback.externalIPs` / `callback.externalNames` — include that address so the serving cert in `certManager.certificate.secretName` covers it; the callback-only instance can then use a copy of that Secret as its `--inspection-cert-dir`.
+- `watchNamespaces` — give the callback-only instance the same list (or, if empty here, cluster-wide read access).
+
+Give it a kubeconfig whose identity holds the manager's RBAC; a token for the chart's ServiceAccount is the simplest. `callback.service.type` can stay `ClusterIP`, since hosts never talk to the in-cluster instance in this topology. Walk-through: [docs/ipxe-setup.md](../../docs/ipxe-setup.md#management-cluster-off-the-provisioning-network-a-callback-only-instance).
+
 ## Configuration
 
 All configurable values with their defaults:

--- a/charts/beskar7/values.yaml
+++ b/charts/beskar7/values.yaml
@@ -181,6 +181,13 @@ bootstrap:
   # callback.externalNames / callback.externalIPs. The inspector verifies the
   # callback cert against the CA delivered on its cmdline and has no
   # insecure-skip path, so a SAN mismatch is a hard failure.
+  #
+  # If the management cluster has no interface on the provisioning network at
+  # all, run a second copy of the manager binary on that network with
+  # --controllers=none (callback-only: no reconciler, no webhook, no leader
+  # election) and set urlBase to ITS address; start it with the same
+  # --bootstrap-url-base. The chart does not deploy that instance — see the
+  # chart README and docs/ipxe-setup.md.
   urlBase: "https://beskar7-controller-manager.beskar7-system.svc:8082"
 
 # Callback server (inspection POST + bootstrap GET + per-host /boot) exposure.

--- a/cmd/manager/flags.go
+++ b/cmd/manager/flags.go
@@ -17,8 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"errors"
+	"fmt"
+	"net"
 	"sort"
 	"strings"
+	"time"
 )
 
 // parseWatchNamespaces parses a --watch-namespaces flag value into a
@@ -55,4 +59,90 @@ func parseWatchNamespaces(raw string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// controllersMode is the value of the --controllers flag: which reconcilers
+// a manager instance registers.
+type controllersMode string
+
+const (
+	// controllersAll runs every reconciler plus the callback server — the
+	// normal in-cluster manager.
+	controllersAll controllersMode = "all"
+
+	// controllersNone is callback-only. The instance registers no reconciler
+	// and no webhook; it serves the host-callback HTTPS endpoints and the
+	// health probes on top of the same cached client the handlers always
+	// use. That lets a copy of the manager sit on the provisioning network
+	// (where PXE-booting hosts can reach it) without competing with the
+	// in-cluster controllers for host claims or for the bootstrap-url
+	// annotation handshake — two full managers race on both.
+	controllersNone controllersMode = "none"
+)
+
+// parseControllersMode parses a --controllers flag value. Matching ignores
+// case and surrounding whitespace; anything other than "all" or "none" is an
+// error so a typo is a startup failure rather than a silently-full manager.
+func parseControllersMode(raw string) (controllersMode, error) {
+	switch mode := controllersMode(strings.ToLower(strings.TrimSpace(raw))); mode {
+	case controllersAll, controllersNone:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid --controllers value %q: must be %q or %q", raw, controllersAll, controllersNone)
+	}
+}
+
+// managerConfig is the parsed command line as far as the wiring in
+// setupManager and the flag-compatibility checks in validate care about it.
+// main() fills it from the flags; tests build it directly.
+type managerConfig struct {
+	controllers controllersMode
+
+	// enableLeaderElection is --leader-elect as parsed. leaderElectSet records
+	// whether the flag was given on the command line at all, which validate
+	// needs to tell the default apart from an operator asking for it.
+	enableLeaderElection bool
+	leaderElectSet       bool
+
+	enableWebhook bool
+
+	bootstrapURLBase  string
+	inspectionPort    int
+	inspectionCertDir string
+	trustedProxies    []*net.IPNet
+
+	inspectionTimeout       time.Duration
+	deploymentTimeout       time.Duration
+	maxConcurrentReconciles int
+}
+
+// validate rejects flag combinations that contradict each other. It runs
+// after flag.Parse and before the manager is built, so a bad command line
+// fails at startup with a message naming both flags instead of producing a
+// process that looks healthy and misbehaves.
+func (c managerConfig) validate() error {
+	if c.controllers != controllersNone {
+		return nil
+	}
+	if c.enableWebhook {
+		return errors.New("--enable-webhook=true contradicts --controllers=none: a callback-only " +
+			"instance registers no webhook, so admission requests routed to it would fail closed; " +
+			"drop --enable-webhook")
+	}
+	if c.leaderElectSet && c.enableLeaderElection {
+		return errors.New("--leader-elect=true contradicts --controllers=none: a callback-only " +
+			"instance runs no leader-elected work, and holding the lease would keep the real " +
+			"controller from ever becoming leader; drop --leader-elect or pass --leader-elect=false")
+	}
+	return nil
+}
+
+// leaderElection is the effective leader-election setting. A callback-only
+// instance never takes part: it has nothing to lead, and if it won the lease
+// the full manager would sit idle as a non-leader with nothing reconciling.
+func (c managerConfig) leaderElection() bool {
+	if c.controllers == controllersNone {
+		return false
+	}
+	return c.enableLeaderElection
 }

--- a/cmd/manager/flags_test.go
+++ b/cmd/manager/flags_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -79,6 +80,113 @@ func TestParseWatchNamespaces(t *testing.T) {
 			got := parseWatchNamespaces(tc.in)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("parseWatchNamespaces(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseControllersMode(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    controllersMode
+		wantErr bool
+	}{
+		{name: "all", in: "all", want: controllersAll},
+		{name: "none", in: "none", want: controllersNone},
+		{name: "case and whitespace are ignored", in: "  NONE ", want: controllersNone},
+		{name: "empty is rejected", in: "", wantErr: true},
+		{name: "typo is rejected", in: "nonee", wantErr: true},
+		{name: "a controller list is not supported", in: "physicalhost,beskar7machine", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseControllersMode(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseControllersMode(%q) = %q, want an error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseControllersMode(%q): unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseControllersMode(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestManagerConfigValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     managerConfig
+		wantErr string // substring of the expected error; empty means valid
+	}{
+		{
+			name: "all mode accepts the defaults",
+			cfg:  managerConfig{controllers: controllersAll, enableLeaderElection: true},
+		},
+		{
+			name: "all mode accepts the webhook",
+			cfg:  managerConfig{controllers: controllersAll, enableLeaderElection: true, enableWebhook: true},
+		},
+		{
+			name: "callback-only with the leader-elect default is fine",
+			cfg:  managerConfig{controllers: controllersNone, enableLeaderElection: true},
+		},
+		{
+			name: "callback-only with an explicit --leader-elect=false is fine",
+			cfg:  managerConfig{controllers: controllersNone, enableLeaderElection: false, leaderElectSet: true},
+		},
+		{
+			name:    "callback-only rejects an explicit --leader-elect=true",
+			cfg:     managerConfig{controllers: controllersNone, enableLeaderElection: true, leaderElectSet: true},
+			wantErr: "--leader-elect=true contradicts --controllers=none",
+		},
+		{
+			name:    "callback-only rejects the webhook",
+			cfg:     managerConfig{controllers: controllersNone, enableWebhook: true},
+			wantErr: "--enable-webhook=true contradicts --controllers=none",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validate() = nil, want an error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("validate() = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestManagerConfigLeaderElection(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  managerConfig
+		want bool
+	}{
+		{name: "all mode keeps the flag on", cfg: managerConfig{controllers: controllersAll, enableLeaderElection: true}, want: true},
+		{name: "all mode keeps the flag off", cfg: managerConfig{controllers: controllersAll, enableLeaderElection: false}, want: false},
+		{name: "callback-only forces it off even at the default", cfg: managerConfig{controllers: controllersNone, enableLeaderElection: true}, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.leaderElection(); got != tc.want {
+				t.Errorf("leaderElection() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -48,9 +49,8 @@ import (
 )
 
 var (
-	scheme                  = runtime.NewScheme()
-	setupLog                = ctrl.Log.WithName("setup")
-	maxConcurrentReconciles int
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
 )
 
 func init() {
@@ -84,7 +84,9 @@ func main() {
 	var watchNamespacesRaw string
 	var inspectionTimeout time.Duration
 	var deploymentTimeout time.Duration
+	var maxConcurrentReconciles int
 	var trustedProxies string
+	var controllersRaw string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -93,7 +95,8 @@ func main() {
 			"Used to compute per-machine bootstrap URLs.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
+			"Enabling this will ensure there is only one active controller manager. "+
+			"Always off with --controllers=none; passing --leader-elect=true there is rejected.")
 	flag.DurationVar(&leaderElectionLeaseDuration, "leader-elect-lease-duration", 15*time.Second,
 		"The duration that non-leader candidates will wait to force acquire leadership.")
 	flag.DurationVar(&leaderElectionRenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
@@ -101,7 +104,7 @@ func main() {
 	flag.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
 		"The duration the clients should wait between attempting acquisition and renewal of a leadership.")
 	flag.BoolVar(&enableWebhook, "enable-webhook", false,
-		"Enable webhook server for admission control and defaulting.")
+		"Enable webhook server for admission control and defaulting. Rejected with --controllers=none.")
 	flag.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook server port.")
 	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs",
@@ -145,6 +148,16 @@ func main() {
 			"Service with the default externalTrafficPolicy: Cluster, or an L4 proxy "+
 			"without PROXY protocol — otherwise every booting host shares one bucket and a "+
 			"fleet powering on together starves on it.")
+	flag.StringVar(&controllersRaw, "controllers", string(controllersAll),
+		"Which reconcilers this instance runs. 'all' (the default) registers the "+
+			"Beskar7Machine, Beskar7Cluster and PhysicalHost controllers. 'none' is "+
+			"callback-only: the instance serves the host-callback HTTPS endpoints (/boot, "+
+			"/api/v1/inspection, /api/v1/bootstrap, /api/v1/provisioned, "+
+			"/api/v1/provision-failed) and the health probes but registers no reconciler "+
+			"or webhook. Use 'none' for a second instance placed on the provisioning "+
+			"network when PXE-booting hosts cannot reach the management cluster; a second "+
+			"full manager would fight the first over host claims and the bootstrap-url "+
+			"annotation. 'none' turns leader election off and rejects --enable-webhook=true.")
 
 	// Default to production-safe zap config: structured JSON output, no stack
 	// traces below Error, level-based encoding. Operators who want
@@ -159,6 +172,60 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	controllersMode, err := parseControllersMode(controllersRaw)
+	if err != nil {
+		setupLog.Error(err, "invalid --controllers")
+		os.Exit(1)
+	}
+
+	// Parsed here rather than inside the /boot handler so a typo is a startup
+	// failure instead of a silently ignored setting that only shows up as
+	// unexplained 429s during a fleet boot.
+	parsedTrustedProxies, err := controllers.ParseTrustedProxies(trustedProxies)
+	if err != nil {
+		setupLog.Error(err, "invalid --trusted-proxies")
+		os.Exit(1)
+	}
+	if len(parsedTrustedProxies) > 0 {
+		setupLog.Info("Trusting X-Forwarded-For from configured proxies for /boot rate limiting",
+			"networks", len(parsedTrustedProxies))
+	}
+
+	if maxConcurrentReconciles < 1 {
+		setupLog.Info("--max-concurrent-reconciles below 1; using the default",
+			"requested", maxConcurrentReconciles, "effective", controllers.DefaultMaxConcurrentReconciles)
+		maxConcurrentReconciles = controllers.DefaultMaxConcurrentReconciles
+	}
+
+	cfg := managerConfig{
+		controllers:             controllersMode,
+		enableLeaderElection:    enableLeaderElection,
+		enableWebhook:           enableWebhook,
+		bootstrapURLBase:        bootstrapURLBase,
+		inspectionPort:          inspectionPort,
+		inspectionCertDir:       inspectionCertDir,
+		trustedProxies:          parsedTrustedProxies,
+		inspectionTimeout:       inspectionTimeout,
+		deploymentTimeout:       deploymentTimeout,
+		maxConcurrentReconciles: maxConcurrentReconciles,
+	}
+	// flag.Visit only sees flags that were actually given, which is how
+	// validate tells the --leader-elect default apart from an explicit request.
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "leader-elect" {
+			cfg.leaderElectSet = true
+		}
+	})
+	if err := cfg.validate(); err != nil {
+		setupLog.Error(err, "contradictory flags")
+		os.Exit(1)
+	}
+	if cfg.controllers == controllersNone {
+		setupLog.Info("Callback-only mode: serving the host-callback endpoints and health probes only; "+
+			"no reconciler or webhook will be registered and leader election is off",
+			"controllers", string(cfg.controllers))
+	}
 
 	// H-1: Warn if --bootstrap-url-base is a cluster-internal .svc address.
 	// Bare-metal hosts boot outside the cluster and cannot resolve cluster DNS;
@@ -200,7 +267,7 @@ func main() {
 		Metrics:                metricsOptions,
 		WebhookServer:          webhook.NewServer(webhookServerOptions),
 		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
+		LeaderElection:         cfg.leaderElection(),
 		LeaderElectionID:       "beskar7.infrastructure.cluster.x-k8s.io",
 		LeaseDuration:          &leaderElectionLeaseDuration,
 		RenewDeadline:          &leaderElectionRenewDeadline,
@@ -226,48 +293,42 @@ func main() {
 		os.Exit(1)
 	}
 
-	if maxConcurrentReconciles < 1 {
-		setupLog.Info("--max-concurrent-reconciles below 1; using the default",
-			"requested", maxConcurrentReconciles, "effective", controllers.DefaultMaxConcurrentReconciles)
-		maxConcurrentReconciles = controllers.DefaultMaxConcurrentReconciles
-	}
-	setupLog.Info("Reconciler concurrency", "maxConcurrentReconciles", maxConcurrentReconciles)
-
-	// Setup controllers
-	// RedfishClientFactory is intentionally omitted; SetupWithManager defaults it to
-	// internalredfish.NewClient and returns an error if it remains nil after defaulting.
-	if err = (&controllers.Beskar7MachineReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Log:               ctrl.Log.WithName("controllers").WithName("Beskar7Machine"),
-		BootstrapURLBase:  bootstrapURLBase,
-		InspectionTimeout: inspectionTimeout,
-		DeploymentTimeout: deploymentTimeout,
-
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Beskar7Machine")
+	if err := setupManager(mgr, cfg); err != nil {
+		setupLog.Error(err, "unable to set up manager")
 		os.Exit(1)
 	}
 
-	if err = (&controllers.Beskar7ClusterReconciler{
-		Client:                  mgr.GetClient(),
-		Scheme:                  mgr.GetScheme(),
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-	}).SetupWithManager(context.Background(), mgr, controller.Options{}); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Beskar7Cluster")
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
 
-	if err = (&controllers.PhysicalHostReconciler{
-		Client:                  mgr.GetClient(),
-		Scheme:                  mgr.GetScheme(),
-		Log:                     ctrl.Log.WithName("controllers").WithName("PhysicalHost"),
-		Recorder:                mgr.GetEventRecorderFor("beskar7-physicalhost-controller"), //nolint:staticcheck // legacy recorder: moving to events.EventRecorder changes every Eventf call site; follow-up to D-023
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "PhysicalHost")
-		os.Exit(1)
+// setupManager registers what the manager runs on top of its cache: the
+// reconcilers, the host-callback HTTPS server, the Beskar7Cluster webhook and
+// the health probes. cfg.controllers gates the reconcilers and, through
+// validate, the webhook:
+//
+//   - controllersAll: the normal manager — everything above.
+//   - controllersNone: callback-only. No reconciler and no webhook is
+//     registered; the callback server and the probes still are, on the same
+//     cached client the handlers always use (the bearer verifier reads
+//     PhysicalHost status through it; the /boot and bootstrap handlers read
+//     Beskar7Machine, PhysicalHost, the owning Machine and Secrets).
+//
+// It is split out of main so a test can wire a manager against envtest and
+// check what each mode registers. cfg is validated again here so the function
+// is safe to call with a hand-built config.
+func setupManager(mgr ctrl.Manager, cfg managerConfig) error {
+	if err := cfg.validate(); err != nil {
+		return err
+	}
+
+	if cfg.controllers == controllersAll {
+		if err := setupControllers(mgr, cfg); err != nil {
+			return err
+		}
 	}
 
 	// Setup the host-callback HTTPS server. Hosts the inspection POST, bootstrap
@@ -278,46 +339,65 @@ func main() {
 	// Certificate via cert-manager).
 	// bootstrapURLBase is passed so the /boot handler can render beskar7.api=
 	// into the iPXE cmdline (§5). It must be externally reachable from bare metal.
-	// Parsed here rather than inside the handler so a typo is a startup failure
-	// instead of a silently ignored setting that only shows up as unexplained
-	// 429s during a fleet boot.
-	parsedTrustedProxies, err := controllers.ParseTrustedProxies(trustedProxies)
-	if err != nil {
-		setupLog.Error(err, "invalid --trusted-proxies")
-		os.Exit(1)
-	}
-	if len(parsedTrustedProxies) > 0 {
-		setupLog.Info("Trusting X-Forwarded-For from configured proxies for /boot rate limiting",
-			"networks", len(parsedTrustedProxies))
+	if err := controllers.SetupCallbackServer(mgr, cfg.inspectionPort, cfg.inspectionCertDir, cfg.bootstrapURLBase, cfg.trustedProxies); err != nil {
+		return fmt.Errorf("unable to setup callback server: %w", err)
 	}
 
-	if err := controllers.SetupCallbackServer(mgr, inspectionPort, inspectionCertDir, bootstrapURLBase, parsedTrustedProxies); err != nil {
-		setupLog.Error(err, "unable to setup callback server")
-		os.Exit(1)
-	}
-
-	// Setup webhooks if enabled
-	if enableWebhook {
+	// Setup webhooks if enabled. validate has already refused this in
+	// callback-only mode.
+	if cfg.enableWebhook {
 		setupLog.Info("Setting up webhooks")
-		if err = (&webhooks.Beskar7ClusterWebhook{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to setup webhook", "webhook", "Beskar7Cluster")
-			os.Exit(1)
+		if err := (&webhooks.Beskar7ClusterWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to setup webhook %s: %w", "Beskar7Cluster", err)
 		}
 	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
+		return fmt.Errorf("unable to set up health check: %w", err)
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
+		return fmt.Errorf("unable to set up ready check: %w", err)
+	}
+	return nil
+}
+
+// setupControllers registers the three reconcilers. RedfishClientFactory is
+// intentionally omitted; SetupWithManager defaults it to
+// internalredfish.NewClient and returns an error if it remains nil after
+// defaulting.
+func setupControllers(mgr ctrl.Manager, cfg managerConfig) error {
+	setupLog.Info("Reconciler concurrency", "maxConcurrentReconciles", cfg.maxConcurrentReconciles)
+
+	if err := (&controllers.Beskar7MachineReconciler{
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Log:               ctrl.Log.WithName("controllers").WithName("Beskar7Machine"),
+		BootstrapURLBase:  cfg.bootstrapURLBase,
+		InspectionTimeout: cfg.inspectionTimeout,
+		DeploymentTimeout: cfg.deploymentTimeout,
+
+		MaxConcurrentReconciles: cfg.maxConcurrentReconciles,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "Beskar7Machine", err)
 	}
 
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+	if err := (&controllers.Beskar7ClusterReconciler{
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		MaxConcurrentReconciles: cfg.maxConcurrentReconciles,
+	}).SetupWithManager(context.Background(), mgr, controller.Options{}); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "Beskar7Cluster", err)
 	}
+
+	if err := (&controllers.PhysicalHostReconciler{
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Log:                     ctrl.Log.WithName("controllers").WithName("PhysicalHost"),
+		Recorder:                mgr.GetEventRecorderFor("beskar7-physicalhost-controller"), //nolint:staticcheck // legacy recorder: moving to events.EventRecorder changes every Eventf call site; follow-up to D-023
+		MaxConcurrentReconciles: cfg.maxConcurrentReconciles,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", "PhysicalHost", err)
+	}
+	return nil
 }

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,414 @@
+/*
+Copyright 2026 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	infrastructurev1beta1 "github.com/projectbeskar/beskar7/api/v1beta1"
+	"github.com/projectbeskar/beskar7/controllers"
+	"github.com/projectbeskar/beskar7/internal/auth"
+	internalmetrics "github.com/projectbeskar/beskar7/internal/metrics"
+)
+
+// recordingManager wraps a real manager and records what setupManager
+// registers on it: every Runnable handed to Add, and whether the webhook
+// server was requested. Registering a webhook is the only path that asks for
+// the webhook server, and asking is what schedules it to start.
+type recordingManager struct {
+	ctrl.Manager
+	runnables        []manager.Runnable
+	webhookRequested bool
+}
+
+func (m *recordingManager) Add(r manager.Runnable) error {
+	m.runnables = append(m.runnables, r)
+	return m.Manager.Add(r)
+}
+
+func (m *recordingManager) GetWebhookServer() webhook.Server {
+	m.webhookRequested = true
+	return m.Manager.GetWebhookServer()
+}
+
+// controllerCount is the number of registered runnables that are
+// controllers. controller-runtime's builder hands the manager the concrete
+// controller, which implements the exported controller.Controller interface;
+// the callback-server runnable does not.
+func (m *recordingManager) controllerCount() int {
+	n := 0
+	for _, r := range m.runnables {
+		if _, ok := r.(controller.Controller); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSetupManager wires a manager against envtest in both --controllers
+// modes and checks what each registers. The callback-only case is the point
+// of the test: no reconciler, no webhook, but the health probes and the
+// bearer-gated callback routes still answer, with the bearer verifier reading
+// PhysicalHost status through the manager's cache.
+func TestSetupManager(t *testing.T) {
+	restCfg := startEnvtest(t)
+	internalmetrics.Init()
+
+	certDir := t.TempDir()
+	pool := writeServingCert(t, certDir)
+
+	k8sClient, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	newManager := func(t *testing.T, probeAddr string) *recordingManager {
+		t.Helper()
+		// Controller names are process-global in controller-runtime; skipping
+		// the check keeps the "all" case valid under -count>1.
+		skipNameValidation := true
+		mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
+			Scheme:                 scheme,
+			Metrics:                metricsserver.Options{BindAddress: "0"},
+			HealthProbeBindAddress: probeAddr,
+			// The "all" case registers the webhook, and starting the manager
+			// then starts the webhook server: give it the test cert and a
+			// free port instead of the production defaults.
+			WebhookServer: webhook.NewServer(webhook.Options{Port: freePort(t), CertDir: certDir}),
+			Controller:    config.Controller{SkipNameValidation: &skipNameValidation},
+		})
+		if err != nil {
+			t.Fatalf("create manager: %v", err)
+		}
+		return &recordingManager{Manager: mgr}
+	}
+
+	baseConfig := func(callbackPort int) managerConfig {
+		return managerConfig{
+			bootstrapURLBase:        fmt.Sprintf("https://127.0.0.1:%d", callbackPort),
+			inspectionPort:          callbackPort,
+			inspectionCertDir:       certDir,
+			inspectionTimeout:       controllers.DefaultInspectionTimeout,
+			deploymentTimeout:       controllers.DefaultDeploymentTimeout,
+			maxConcurrentReconciles: controllers.DefaultMaxConcurrentReconciles,
+		}
+	}
+
+	// startManager runs mgr until the subtest ends and waits for its cache.
+	startManager := func(t *testing.T, mgr ctrl.Manager) {
+		t.Helper()
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- mgr.Start(ctx) }()
+		t.Cleanup(func() {
+			cancel()
+			if err := <-done; err != nil {
+				t.Errorf("manager exited with error: %v", err)
+			}
+		})
+		if !mgr.GetCache().WaitForCacheSync(ctx) {
+			t.Fatal("manager cache never synced")
+		}
+	}
+
+	t.Run("callback-only registers no controller and still serves the callbacks", func(t *testing.T) {
+		callbackPort, probePort := freePort(t), freePort(t)
+		mgr := newManager(t, fmt.Sprintf("127.0.0.1:%d", probePort))
+		cfg := baseConfig(callbackPort)
+		cfg.controllers = controllersNone
+		cfg.enableLeaderElection = true // the flag default; must be ignored, not rejected
+
+		if err := setupManager(mgr, cfg); err != nil {
+			t.Fatalf("setupManager: %v", err)
+		}
+		if n := mgr.controllerCount(); n != 0 {
+			t.Fatalf("callback-only mode registered %d controllers, want 0", n)
+		}
+		if mgr.webhookRequested {
+			t.Fatal("callback-only mode registered a webhook")
+		}
+
+		startManager(t, mgr)
+
+		// Health probes on the manager's probe address.
+		probeBase := fmt.Sprintf("http://127.0.0.1:%d", probePort)
+		expectStatus(t, http.DefaultClient, http.MethodGet, probeBase+"/healthz", "", http.StatusOK)
+		expectStatus(t, http.DefaultClient, http.MethodGet, probeBase+"/readyz", "", http.StatusOK)
+
+		// The callback server's own /healthz over TLS.
+		httpsClient := &http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+			},
+		}
+		callbackBase := fmt.Sprintf("https://127.0.0.1:%d", callbackPort)
+		expectStatus(t, httpsClient, http.MethodGet, callbackBase+"/healthz", "", http.StatusOK)
+
+		// A bearer-gated route. The verifier reads the host's token hash from
+		// PhysicalHost status through the cache, so this also proves the cache
+		// serves the handlers with no controller registered.
+		ctx := context.Background()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "callback-only-"}}
+		if err := k8sClient.Create(ctx, ns); err != nil {
+			t.Fatalf("create namespace: %v", err)
+		}
+		plaintext, hash, err := auth.MintToken()
+		if err != nil {
+			t.Fatalf("mint token: %v", err)
+		}
+		host := &infrastructurev1beta1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "host-1", Namespace: ns.Name},
+			Spec: infrastructurev1beta1.PhysicalHostSpec{
+				RedfishConnection: infrastructurev1beta1.RedfishConnection{
+					Address:              "https://192.0.2.10",
+					CredentialsSecretRef: "bmc-creds",
+				},
+			},
+		}
+		if err := k8sClient.Create(ctx, host); err != nil {
+			t.Fatalf("create PhysicalHost: %v", err)
+		}
+		// No controller ran, so no finalizer: the delete completes and the
+		// host is gone before the "all" case starts reconcilers.
+		t.Cleanup(func() {
+			if err := k8sClient.Delete(context.Background(), host); err != nil {
+				t.Errorf("delete PhysicalHost: %v", err)
+			}
+		})
+		host.Status.Bootstrap = &infrastructurev1beta1.BootstrapStatus{
+			TokenHash: hash,
+			ExpiresAt: &metav1.Time{Time: time.Now().Add(time.Hour)},
+		}
+		if err := k8sClient.Status().Update(ctx, host); err != nil {
+			t.Fatalf("update PhysicalHost status: %v", err)
+		}
+
+		route := fmt.Sprintf("%s/api/v1/bootstrap/%s/%s", callbackBase, ns.Name, host.Name)
+		// The status update reaches the cache through a watch, so the
+		// accepted-token case is polled; the rejections are checked once the
+		// token is known to be visible.
+		//
+		// A host with no consumer is a 404 from the handler — anything but 401
+		// means the bearer gate let the request through.
+		expectStatus(t, httpsClient, http.MethodGet, route, "Bearer "+plaintext, http.StatusNotFound)
+		expectStatus(t, httpsClient, http.MethodGet, route, "", http.StatusUnauthorized)
+		expectStatus(t, httpsClient, http.MethodGet, route, "Bearer not-the-token", http.StatusUnauthorized)
+	})
+
+	t.Run("all registers the three controllers and the webhook", func(t *testing.T) {
+		callbackPort := freePort(t)
+		mgr := newManager(t, "0")
+		cfg := baseConfig(callbackPort)
+		cfg.controllers = controllersAll
+		cfg.enableWebhook = true
+
+		if err := setupManager(mgr, cfg); err != nil {
+			t.Fatalf("setupManager: %v", err)
+		}
+		if n := mgr.controllerCount(); n != 3 {
+			t.Fatalf("all mode registered %d controllers, want 3 (Beskar7Machine, Beskar7Cluster, PhysicalHost)", n)
+		}
+		if !mgr.webhookRequested {
+			t.Fatal("all mode with --enable-webhook did not register the webhook")
+		}
+		// Start and stop it so the callback-server runnable shuts its listener
+		// down instead of leaking it for the rest of the test binary.
+		startManager(t, mgr)
+	})
+}
+
+// expectStatus polls url with the given method and Authorization header
+// until it answers with want, failing the test after ten seconds.
+func expectStatus(t *testing.T, c *http.Client, method, url, authorization string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	var last string
+	for {
+		req, err := http.NewRequest(method, url, nil)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		if authorization != "" {
+			req.Header.Set("Authorization", authorization)
+		}
+		resp, err := c.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == want {
+				return
+			}
+			last = fmt.Sprintf("status %d", resp.StatusCode)
+		} else {
+			last = err.Error()
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s %s (auth %q): want status %d, last result: %s", method, url, authorization, want, last)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// startEnvtest boots an envtest control plane with the Beskar7 CRDs and the
+// minimal CAPI CRDs, resolving assets the same way controllers/suite_test.go
+// does when KUBEBUILDER_ASSETS is unset.
+func startEnvtest(t *testing.T) *rest.Config {
+	t.Helper()
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		out, err := exec.Command("bash", "-lc",
+			"go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20 use 1.31.x -p path").CombinedOutput()
+		if err != nil {
+			t.Fatalf("resolve envtest assets: %v\n%s", err, out)
+		}
+		t.Setenv("KUBEBUILDER_ASSETS", strings.TrimSpace(string(out)))
+	}
+	env := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "config", "test-external-crds"),
+		},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: os.Getenv("KUBEBUILDER_ASSETS"),
+	}
+	restCfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := env.Stop(); err != nil {
+			t.Errorf("stop envtest: %v", err)
+		}
+	})
+	restCfg.QPS = 1000
+	restCfg.Burst = 2000
+	restCfg.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
+	return restCfg
+}
+
+// freePort returns a TCP port that was free a moment ago.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if err := l.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	return port
+}
+
+// writeServingCert writes a CA and a leaf serving certificate for 127.0.0.1
+// into dir as ca.crt, tls.crt and tls.key — the layout SetupCallbackServer
+// reads — and returns a pool that trusts the CA.
+func writeServingCert(t *testing.T, dir string) *x509.CertPool {
+	t.Helper()
+	now := time.Now()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "beskar7-test-ca"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA certificate: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA certificate: %v", err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "beskar7-callback-test"},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf certificate: %v", err)
+	}
+	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	files := map[string][]byte{
+		"ca.crt":  caPEM,
+		"tls.crt": pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER}),
+		"tls.key": pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: leafKeyDER}),
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("append CA to pool")
+	}
+	return pool
+}

--- a/controllers/inspection_handler.go
+++ b/controllers/inspection_handler.go
@@ -33,6 +33,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -469,19 +470,37 @@ func SetupCallbackServer(mgr ctrl.Manager, port int, certDir string, bootstrapUR
 		return fmt.Errorf("read callback CA for /boot handler: %w", err)
 	}
 
-	// Pre-warm the ConfigMap informer. The inspection handler writes a
-	// transient per-host inspection-result ConfigMap on every POST (D-005);
+	// Pre-warm the informers the handlers read through the cached client.
+	//
+	// The ConfigMap one matters in every mode: the inspection handler writes
+	// a transient per-host inspection-result ConfigMap on every POST (D-005);
 	// without pre-warming, the first POST after manager startup blocks for
 	// up to the cache's sync timeout waiting for the lazily-created
 	// informer to populate, which under a kind-fresh cluster regularly
 	// exceeds the kube-apiserver's request budget and surfaces as
 	// "Timeout: failed waiting for *v1.ConfigMap Informer to sync" — the
 	// inspector POST then 5xx's and the smoke-test inspector simulator
-	// cannot drive the host to Ready. Calling GetInformer here registers
-	// the informer with the cache; mgr.Start() will boot it alongside the
-	// other watches before the first reconcile fires.
-	if _, err := mgr.GetCache().GetInformer(context.Background(), &corev1.ConfigMap{}); err != nil {
-		return fmt.Errorf("pre-warm ConfigMap informer for inspection handler: %w", err)
+	// cannot drive the host to Ready.
+	//
+	// The others matter in callback-only mode (--controllers=none). In the
+	// full manager the reconcilers' watches create the PhysicalHost,
+	// Beskar7Machine and Secret informers at start and the first reconcile
+	// creates the Machine one; with no reconciler registered nothing does,
+	// and every first callback of a kind would pay the same lazy-sync cost.
+	// Calling GetInformer here registers the informers with the cache;
+	// mgr.Start() boots them alongside the other watches. The cache keys
+	// informers by type, so in the full manager these are the ones the
+	// controllers use anyway and nothing extra is created.
+	for _, obj := range []client.Object{
+		&corev1.ConfigMap{},
+		&corev1.Secret{},
+		&infrastructurev1beta1.PhysicalHost{},
+		&infrastructurev1beta1.Beskar7Machine{},
+		&clusterv1.Machine{},
+	} {
+		if _, err := mgr.GetCache().GetInformer(context.Background(), obj); err != nil {
+			return fmt.Errorf("pre-warm %T informer for the callback handlers: %w", obj, err)
+		}
 	}
 
 	inspectionLog := ctrl.Log.WithName("inspection-handler")

--- a/docs/ipxe-setup.md
+++ b/docs/ipxe-setup.md
@@ -175,6 +175,56 @@ Common exposure options:
   controller speaks TLS natively; SNI passthrough is simpler than termination +
   re-encryption.
 
+#### Management cluster off the provisioning network: a callback-only instance
+
+Sometimes none of those options exist: the management cluster has no interface
+on the provisioning network, so nothing it can expose — Service, NodePort or
+Ingress — is reachable while a host PXE-boots. The answer is a second copy of
+the manager on a machine that *is* on that network (the boot server is the
+natural place), started with `--controllers=none`. It serves the callback
+endpoints and the health probes and registers **no reconciler and no webhook**;
+the in-cluster manager keeps doing all the reconciling.
+
+```bash
+beskar7 \
+  --controllers=none \
+  --kubeconfig=/etc/beskar7/kubeconfig \
+  --watch-namespaces=b7e2e \
+  --bootstrap-url-base=https://192.0.2.10:8082 \
+  --inspection-cert-dir=/etc/beskar7/serving-certs \
+  --metrics-bind-address=0
+```
+
+What the instance needs:
+
+- **A kubeconfig whose identity holds the manager's RBAC.** The handlers read
+  PhysicalHosts, Beskar7Machines, Machines and Secrets and write the
+  inspection-result ConfigMap and the PhysicalHost annotations, through the same
+  cached client the full manager uses. A token for the chart's ServiceAccount is
+  the simplest identity. `--kubeconfig` (or `KUBECONFIG`) points at it.
+- **`tls.crt`, `tls.key` and `ca.crt` in `--inspection-cert-dir`** with a SAN
+  covering the address in `--bootstrap-url-base`. Hosts only ever talk to this
+  instance, so only this certificate matters to the inspector. If you add the
+  address to `callback.externalIPs` / `callback.externalNames` in the chart, the
+  serving-cert Secret it issues covers it and can be copied out as-is.
+- **The same `--bootstrap-url-base` on both instances.** The in-cluster
+  controller writes it into `PhysicalHost.Status.Bootstrap.URL` and the
+  callback-only instance renders it into `beskar7.api=` on the `/boot` response;
+  set `bootstrap.urlBase` in the chart to the callback-only instance's address.
+- **The same `--watch-namespaces`**, or none with cluster-wide read access, so
+  its cache covers every namespace hosts live in.
+
+Leader election is off in this mode without being asked (there is nothing to
+lead, and a callback-only instance holding the lease would idle the real
+controller); passing `--leader-elect=true` or `--enable-webhook=true` alongside
+`--controllers=none` is rejected at startup.
+
+Do **not** run the second copy with every controller. Two full managers race for
+host claims, and when their `--bootstrap-url-base` values differ each keeps
+rewriting the `infrastructure.cluster.x-k8s.io/bootstrap-url` annotation to its
+own value — the symptom is a storm of `the object has been modified` reconcile
+errors ([Troubleshooting §14](troubleshooting.md#14-reconcile-errors-storm-with-the-object-has-been-modified-two-full-managers-share-a-namespace)).
+
 #### Preserve the client address, or the rate limiter will bite
 
 `/boot` is rate-limited per source address (1 r/s, burst 5). Every option above

--- a/docs/resource-planning.md
+++ b/docs/resource-planning.md
@@ -188,6 +188,10 @@ args:
 # Optional: reconcile workers per controller. Default 1. Raise for larger fleets
 # or to stop one unreachable BMC's 30s timeout blocking healthy hosts.
 - --max-concurrent-reconciles=4
+# Optional: which reconcilers this instance runs. Default all. 'none' is a
+# callback-only instance for a second copy on the provisioning network — no
+# reconciler, no webhook, leader election off. See docs/ipxe-setup.md.
+- --controllers=all
 ```
 
 `--max-concurrent-reconciles` sets the worker count for **all three** controllers

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -653,6 +653,29 @@ directory under `/var/log/journal/` that is not the current one — has no k0s o
 `sudo journalctl -D /var/log/journal/<other-id> -o cat | grep -c 'k0s\['` is `0`. Before the gate,
 that journal is where the premature join showed up.
 
+### 14. Reconcile errors storm with `the object has been modified`: two full managers share a namespace
+
+**Symptom:** the manager logs hundreds of lines a minute like
+`Operation cannot be fulfilled on physicalhosts.infrastructure.cluster.x-k8s.io "<host>": the object has been modified; please apply your changes to the latest version and try again`,
+the `infrastructure.cluster.x-k8s.io/bootstrap-url` annotation on a PhysicalHost appears, disappears
+and reappears with a different value, or a host is claimed by a Beskar7Machine, released and claimed
+again by another.
+
+**Cause:** two manager instances are running every controller against the same namespaces. The usual
+way to get there is a second copy started on the boot server so that PXE-booting hosts can reach the
+callback endpoints ([iPXE setup → callback-only instance](ipxe-setup.md#management-cluster-off-the-provisioning-network-a-callback-only-instance)),
+but started as a full manager. Two Beskar7Machine controllers then race for hosts, and if their
+`--bootstrap-url-base` values differ each rewrites `PhysicalHost.Status.Bootstrap.URL` to its own
+value through the annotation, forever. Leader election does not protect against this: the
+out-of-cluster copy runs with `--leader-elect=false` because it has no in-cluster namespace to hold
+the lease in.
+
+**Solution:** restart the second copy with `--controllers=none`. It keeps serving `/boot`,
+`/api/v1/inspection`, `/api/v1/bootstrap` and `/api/v1/provisioned` and registers no reconciler, so
+the conflicts stop as soon as it comes back. Give both instances the same `--bootstrap-url-base`: the
+in-cluster controller writes that value into `PhysicalHost.Status.Bootstrap.URL` and the callback-only
+instance renders it into the iPXE cmdline.
+
 ## Getting Help
 
 If you can't resolve your issue:


### PR DESCRIPTION
## What

`--controllers=none`: a manager instance that registers no reconciler and no webhook, and only serves the host-callback endpoints (`/boot`, `/api/v1/inspection`, `/api/v1/bootstrap`, `/api/v1/provisioned` on `:8082`) plus the health probes.

## Why

Bare-metal hosts must reach the callback endpoints from the provisioning network during PXE boot, which is often not a network the management cluster is on. The way round that is a second copy of the manager on that network, and until now that copy ran every controller too. Two full managers fight: they race for host claims, and when their `--bootstrap-url-base` values differ each rewrites the bootstrap-url annotation to its own value, at hundreds of "the object has been modified" reconcile errors a minute (`ensureBootstrapDataReady` re-annotates whenever `PhysicalHost.Status.Bootstrap.URL` differs from its computed URL). Both were reproduced on the dome lab; the double token mint that #164 makes survivable is the same topology fault.

## How

- `--controllers=none` registers nothing but keeps the cached client, the callback server and the probes; the bearer verifier reads PhysicalHost status through the cache, the `/boot` and bootstrap handlers read Beskar7Machine, PhysicalHost, the owning Machine and Secrets. Leader election is forced off in that mode (a callback-only instance holding the lease would idle the real controller); an explicit `--leader-elect=true` or `--enable-webhook=true` alongside it, or an unknown value, is rejected at startup with a message naming both flags.
- `SetupCallbackServer` pre-warms the Secret, PhysicalHost, Beskar7Machine and Machine informers alongside the ConfigMap one, so the first callback of each kind does not pay a lazy cache sync; the full manager gets nothing extra (informers are keyed by type).
- The wiring moves out of `main()` into `setupManager` so an envtest-backed test can check what each mode registers.
- Docs: a callback-only subsection in `docs/ipxe-setup.md` (command line, kubeconfig with the manager's RBAC, a cert covering the address, the same `--bootstrap-url-base` and `--watch-namespaces` on both instances); troubleshooting §14 for the two-manager symptom; the flag in resource-planning; a paragraph in the chart README and a `values.yaml` comment. No chart knob: the chart's Deployment uses in-cluster auth and the mode's consumer is an out-of-cluster process. CHANGELOG.

## Verification

- envtest test through a manager wrapper that records `Add` and `GetWebhookServer`: `none` registers zero controllers and no webhook, and after `Start` the probes, the callback `/healthz` over TLS and the bearer-gated bootstrap route all answer (no token and a wrong token are 401, the right token reaches the handler); `all` registers three controllers and the webhook. Negative-verified: with the mode gate removed the `none` case fails with "registered 3 controllers, want 0". Flag unit tests cover parsing and each rejected combination.
- Rebased onto main after #162: one conflict in `main.go` (the `//nolint` #162 put on the legacy event recorder now sits inside `setupControllers`) and the `sigs.k8s.io/cluster-api/api/v1beta1` import in `inspection_handler.go` moved to `api/core/v1beta2`. `go test ./... -race` and `golangci-lint run` clean. The integration suite hits the pre-existing "Delete and release" timing race that #163 fixes; it is not related to this change.

Origin: chip session in worktree `intelligent-williams-d958fe`, rebased and opened from this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
