### PR TITLE
fix(physicalhost): keep a credential annotation until status carries the mint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,7 +400,7 @@ jobs:
         echo "=== Pods (all namespaces) ==="
         kubectl get pods -A -o wide
         echo "=== Beskar7 controller log (last 500) ==="
-        kubectl -n beskar7-system logs deploy/beskar7-controller-manager --tail=500 || true
+        kubectl -n beskar7-system logs deploy/beskar7-controller-manager --tail=2000 || true
         echo "=== Mock-redfish log ==="
         kubectl -n beskar7-smoke logs deploy/mock-redfish --tail=100 || true
         echo "=== Mock-inspector Job + log ==="

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- **A bootstrap token or boot nonce is no longer re-minted while the host controller
+  is promoting it.** `applyBootstrapTokenAnnotation` / `applyBootNonceAnnotation`
+  copied the freshly minted hash into `Status.Bootstrap` and cleared the annotation
+  in the same pass, but the deferred patch writes metadata before status, so for
+  a moment the host advertised no credential at all. A `Beskar7Machine` reconcile
+  landing in that gap (the host is still `InUse`, so `triggerInspection` runs again)
+  found no unexpired hash, minted a new token, and the inspector — which had
+  already read the first plaintext from the Secret — got 401 on its callbacks
+  (seen in the E2E smoke on `pool-host-b`; the same mechanism as the dome-lab
+  strandings). The annotation now outlives the status write by one pass and is
+  cleared only once status carries the same hash, so no published version of the
+  host is without its credential; a failed status patch no longer loses the mint
+  either. The CI failure diagnostics keep 2000 manager log lines instead of 500 —
+  the first mint had scrolled out of the dump.
 - **A `PhysicalHost` turning `Available` now wakes the `Beskar7Machine`s still
   waiting for a host.** A machine that reconciled moments before its host
   finished enrolling (or before another machine released it) parked on the

--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -490,10 +490,17 @@ func (r *PhysicalHostReconciler) applyBootstrapURLAnnotation(logger logr.Logger,
 // Status.Bootstrap. The plaintext token is delivered out-of-band via a Secret —
 // the annotation only carries the hash + lifetime.
 //
-// Same idempotent "annotation in, status out, annotation cleared" pattern as
-// applyBootstrapURLAnnotation. Malformed JSON is logged and the annotation is
-// left in place so the next reconcile (or operator) can investigate; clearing
-// would silently drop a token-state signal.
+// "Annotation in, status out" as in applyBootstrapURLAnnotation, but the clear
+// is deferred by one pass: the annotation stays until status already carries
+// the same mint. The deferred patch writes metadata before status (two API
+// calls), so clearing in the same pass publishes a version of the host that
+// advertises no credential at all; the Beskar7Machine controller reads
+// annotation-then-status and, landing in that gap while the host is still
+// InUse, minted a fresh token over the one the inspector had already fetched
+// (401 on every callback). Keeping the annotation one pass longer also means a
+// failed status patch cannot lose the mint. Malformed JSON is logged and the
+// annotation is left in place so the next reconcile (or operator) can
+// investigate; clearing would silently drop a token-state signal.
 func (r *PhysicalHostReconciler) applyBootstrapTokenAnnotation(logger logr.Logger, physicalHost *infrastructurev1beta1.PhysicalHost) {
 	raw := physicalHost.Annotations[BootstrapTokenAnnotation]
 	if raw == "" {
@@ -511,6 +518,14 @@ func (r *PhysicalHostReconciler) applyBootstrapTokenAnnotation(logger logr.Logge
 		return
 	}
 
+	if bs := physicalHost.Status.Bootstrap; bs != nil && bs.TokenHash == value.Hash &&
+		bs.ExpiresAt != nil && bs.ExpiresAt.Equal(&value.ExpiresAt) {
+		// Second pass: the status patch carrying this mint has landed.
+		logger.V(1).Info("Status already carries the bootstrap-token mint; clearing the annotation", "host", physicalHost.Name)
+		delete(physicalHost.Annotations, BootstrapTokenAnnotation)
+		return
+	}
+
 	if physicalHost.Status.Bootstrap == nil {
 		physicalHost.Status.Bootstrap = &infrastructurev1beta1.BootstrapStatus{}
 	}
@@ -521,8 +536,6 @@ func (r *PhysicalHostReconciler) applyBootstrapTokenAnnotation(logger logr.Logge
 	physicalHost.Status.Bootstrap.IssuedAt = &issuedAt
 	physicalHost.Status.Bootstrap.ExpiresAt = &expiresAt
 	logger.Info("Applied bootstrap-token annotation to Status.Bootstrap", "host", physicalHost.Name)
-
-	delete(physicalHost.Annotations, BootstrapTokenAnnotation)
 }
 
 // applyBootNonceAnnotation reads the BootNonceAnnotation, JSON-decodes the
@@ -532,11 +545,13 @@ func (r *PhysicalHostReconciler) applyBootstrapTokenAnnotation(logger logr.Logge
 // will see only whatever value was already in Status before the annotation was
 // applied (nil until the handler fires).
 //
-// Same idempotent "annotation in, status out, annotation cleared" pattern as
-// applyBootstrapTokenAnnotation. Malformed JSON → log + leave annotation in
-// place (do not clear) so the next reconcile or an operator can investigate;
-// clearing would silently discard a nonce-state signal. Empty hash → ignore
-// the annotation and clear it (nothing useful to persist).
+// Same two-phase handoff as applyBootstrapTokenAnnotation: status first, the
+// annotation is cleared on the following pass once status shows the same
+// mint, so no published version of the host is without a nonce. Malformed
+// JSON → log + leave annotation in place (do not clear) so the next reconcile
+// or an operator can investigate; clearing would silently discard a
+// nonce-state signal. Empty hash → ignore the annotation and clear it
+// (nothing useful to persist).
 func (r *PhysicalHostReconciler) applyBootNonceAnnotation(logger logr.Logger, physicalHost *infrastructurev1beta1.PhysicalHost) {
 	raw := physicalHost.Annotations[BootNonceAnnotation]
 	if raw == "" {
@@ -554,6 +569,14 @@ func (r *PhysicalHostReconciler) applyBootNonceAnnotation(logger logr.Logger, ph
 		return
 	}
 
+	if bs := physicalHost.Status.Bootstrap; bs != nil && bs.BootNonceHash == value.Hash &&
+		bs.BootNonceExpiresAt != nil && bs.BootNonceExpiresAt.Equal(&value.ExpiresAt) {
+		// Second pass: the status patch carrying this mint has landed.
+		logger.V(1).Info("Status already carries the boot-nonce mint; clearing the annotation", "host", physicalHost.Name)
+		delete(physicalHost.Annotations, BootNonceAnnotation)
+		return
+	}
+
 	if physicalHost.Status.Bootstrap == nil {
 		physicalHost.Status.Bootstrap = &infrastructurev1beta1.BootstrapStatus{}
 	}
@@ -564,8 +587,6 @@ func (r *PhysicalHostReconciler) applyBootNonceAnnotation(logger logr.Logger, ph
 	// Intentionally do NOT touch BootNonceConsumedAt — that field belongs to
 	// the /boot handler (D-010). This controller must not clear or overwrite it.
 	logger.Info("Applied boot-nonce annotation to Status.Bootstrap", "host", physicalHost.Name)
-
-	delete(physicalHost.Annotations, BootNonceAnnotation)
 }
 
 // applyInspectionResultAnnotation reads the InspectionResultAnnotation, fetches

--- a/controllers/physicalhost_controller_test.go
+++ b/controllers/physicalhost_controller_test.go
@@ -630,7 +630,7 @@ var _ = Describe("PhysicalHost Controller", func() {
 			}, Timeout, Interval).Should(Succeed())
 		})
 
-		It("Should consume bootstrap-token annotation, persist hash+lifetime to Status.Bootstrap, and clear the annotation", func() {
+		It("Should consume bootstrap-token annotation, persist hash+lifetime to Status.Bootstrap, and clear the annotation only once status shows it", func() {
 			By("Creating the PhysicalHost and making it Available")
 			Expect(k8sClient.Create(ctx, physicalHost)).To(Succeed())
 
@@ -663,23 +663,36 @@ var _ = Describe("PhysicalHost Controller", func() {
 			phPatch.Annotations[BootstrapTokenAnnotation] = string(encoded)
 			Expect(k8sClient.Patch(ctx, phPatch, client.MergeFrom(ph))).To(Succeed())
 
-			By("Reconciling — controller should consume annotation and persist to Status.Bootstrap")
+			By("Reconciling once — the controller persists the mint to Status.Bootstrap but keeps the annotation")
 			_, err = reconcileWithTimeout(reconciler, phLookupKey)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func(g Gomega) {
-				got := &infrastructurev1beta1.PhysicalHost{}
-				g.Expect(k8sClient.Get(ctx, phLookupKey, got)).To(Succeed())
-				g.Expect(got.Status.Bootstrap).NotTo(BeNil(), "Status.Bootstrap must be initialized")
-				g.Expect(got.Status.Bootstrap.TokenHash).To(Equal(fakeHash))
-				g.Expect(got.Status.Bootstrap.IssuedAt).NotTo(BeNil())
-				g.Expect(got.Status.Bootstrap.ExpiresAt).NotTo(BeNil())
-				// Allow some skew between encoded and decoded times due to status round-trip.
-				g.Expect(got.Status.Bootstrap.ExpiresAt.Time.After(got.Status.Bootstrap.IssuedAt.Time)).To(BeTrue(),
-					"ExpiresAt must be after IssuedAt")
-				g.Expect(got.Annotations).NotTo(HaveKey(BootstrapTokenAnnotation),
-					"bootstrap-token annotation must be removed after consumption")
-			}, Timeout, Interval).Should(Succeed())
+			got := &infrastructurev1beta1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, phLookupKey, got)).To(Succeed())
+			Expect(got.Status.Bootstrap).NotTo(BeNil(), "Status.Bootstrap must be initialized")
+			Expect(got.Status.Bootstrap.TokenHash).To(Equal(fakeHash))
+			Expect(got.Status.Bootstrap.IssuedAt).NotTo(BeNil())
+			Expect(got.Status.Bootstrap.ExpiresAt).NotTo(BeNil())
+			// Allow some skew between encoded and decoded times due to status round-trip.
+			Expect(got.Status.Bootstrap.ExpiresAt.Time.After(got.Status.Bootstrap.IssuedAt.Time)).To(BeTrue(),
+				"ExpiresAt must be after IssuedAt")
+			// The patch writes metadata before status. Clearing the annotation in the
+			// same pass would publish a version that advertises no token, and the
+			// Beskar7Machine controller (annotation, then status) would mint again over
+			// the token the inspector already fetched.
+			Expect(got.Annotations).To(HaveKey(BootstrapTokenAnnotation),
+				"the annotation must outlive the status write by one pass")
+			Expect(unexpiredBootstrapTokenHash(got, time.Now())).To(Equal(fakeHash),
+				"a reader must see the same hash through every published version")
+
+			By("Reconciling again — status already carries the mint, so the annotation is cleared")
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, phLookupKey, got)).To(Succeed())
+			Expect(got.Annotations).NotTo(HaveKey(BootstrapTokenAnnotation),
+				"bootstrap-token annotation must be removed once status shows it")
+			Expect(got.Status.Bootstrap.TokenHash).To(Equal(fakeHash))
+			Expect(unexpiredBootstrapTokenHash(got, time.Now())).To(Equal(fakeHash))
 		})
 
 		It("Should consume inspection-result annotation, persist InspectionReport to Status, delete the ConfigMap, and clear the annotation", func() {
@@ -912,6 +925,75 @@ var _ = Describe("PhysicalHost Controller", func() {
 	})
 })
 
+// applyBootstrapTokenAnnotation two-phase handoff. Pure unit; no I/O.
+var _ = Describe("applyBootstrapTokenAnnotation", func() {
+	var r *PhysicalHostReconciler
+
+	BeforeEach(func() {
+		r = &PhysicalHostReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			Log:    ctrl.Log.WithName("bootstrap-token-test"),
+		}
+	})
+
+	annotate := func(ph *infrastructurev1beta1.PhysicalHost, hash string, expiresAt metav1.Time) {
+		encoded, err := json.Marshal(BootstrapTokenAnnotationValue{
+			Hash:      hash,
+			IssuedAt:  metav1.NewTime(expiresAt.Add(-time.Hour)),
+			ExpiresAt: expiresAt,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		if ph.Annotations == nil {
+			ph.Annotations = map[string]string{}
+		}
+		ph.Annotations[BootstrapTokenAnnotation] = string(encoded)
+	}
+
+	It("keeps the annotation until status carries the mint, then clears it — a reader never sees neither", func() {
+		hash := "1111111111111111111111111111111111111111111111111111111111111111"
+		expiresAt := metav1.NewTime(time.Now().Add(time.Hour).Truncate(time.Second))
+		ph := &infrastructurev1beta1.PhysicalHost{}
+		annotate(ph, hash, expiresAt)
+
+		By("pass 1: status out, annotation kept")
+		r.applyBootstrapTokenAnnotation(r.Log, ph)
+		Expect(ph.Status.Bootstrap).NotTo(BeNil())
+		Expect(ph.Status.Bootstrap.TokenHash).To(Equal(hash))
+		Expect(ph.Annotations).To(HaveKey(BootstrapTokenAnnotation))
+		Expect(unexpiredBootstrapTokenHash(ph, time.Now())).To(Equal(hash))
+
+		By("pass 2: status shows the mint, annotation cleared")
+		r.applyBootstrapTokenAnnotation(r.Log, ph)
+		Expect(ph.Annotations).NotTo(HaveKey(BootstrapTokenAnnotation))
+		Expect(ph.Status.Bootstrap.TokenHash).To(Equal(hash))
+		Expect(unexpiredBootstrapTokenHash(ph, time.Now())).To(Equal(hash))
+	})
+
+	It("lets a newer mint replace the status hash, and clears that annotation only on the following pass", func() {
+		previous := "2222222222222222222222222222222222222222222222222222222222222222"
+		newer := "3333333333333333333333333333333333333333333333333333333333333333"
+		previousExpiry := metav1.NewTime(time.Now().Add(10 * time.Minute).Truncate(time.Second))
+		newerExpiry := metav1.NewTime(time.Now().Add(time.Hour).Truncate(time.Second))
+		ph := &infrastructurev1beta1.PhysicalHost{
+			Status: infrastructurev1beta1.PhysicalHostStatus{
+				Bootstrap: &infrastructurev1beta1.BootstrapStatus{TokenHash: previous, ExpiresAt: &previousExpiry},
+			},
+		}
+		annotate(ph, newer, newerExpiry)
+
+		r.applyBootstrapTokenAnnotation(r.Log, ph)
+		Expect(ph.Status.Bootstrap.TokenHash).To(Equal(newer))
+		Expect(ph.Status.Bootstrap.ExpiresAt.Time.Equal(newerExpiry.Time)).To(BeTrue())
+		Expect(ph.Annotations).To(HaveKey(BootstrapTokenAnnotation), "not cleared until status carries the newer mint")
+		Expect(unexpiredBootstrapTokenHash(ph, time.Now())).To(Equal(newer))
+
+		r.applyBootstrapTokenAnnotation(r.Log, ph)
+		Expect(ph.Annotations).NotTo(HaveKey(BootstrapTokenAnnotation))
+		Expect(ph.Status.Bootstrap.TokenHash).To(Equal(newer))
+	})
+})
+
 // applyBootNonceAnnotation unit tests (D-009). Pure unit; no I/O so no envtest needed.
 // Mirrors the applyBootstrapTokenAnnotation tests in the Context block above.
 var _ = Describe("applyBootNonceAnnotation", func() {
@@ -950,8 +1032,16 @@ var _ = Describe("applyBootNonceAnnotation", func() {
 		Expect(ph.Status.Bootstrap.BootNonceHash).To(Equal(fakeHash))
 		Expect(ph.Status.Bootstrap.BootNonceExpiresAt).NotTo(BeNil())
 		Expect(ph.Status.Bootstrap.BootNonceExpiresAt.Time.Equal(expiresAt.Time)).To(BeTrue())
+		Expect(ph.Annotations).To(HaveKey(BootNonceAnnotation),
+			"the annotation must outlive the status write by one pass (metadata is patched before status)")
+		Expect(unexpiredBootNonceHash(ph, time.Now())).To(Equal(fakeHash))
+
+		By("clearing the annotation on the next pass, once status shows the same mint")
+		r.applyBootNonceAnnotation(r.Log, ph)
 		Expect(ph.Annotations).NotTo(HaveKey(BootNonceAnnotation),
-			"annotation must be cleared after consumption")
+			"annotation must be cleared once status carries the mint")
+		Expect(ph.Status.Bootstrap.BootNonceHash).To(Equal(fakeHash))
+		Expect(unexpiredBootNonceHash(ph, time.Now())).To(Equal(fakeHash))
 	})
 
 	It("does not touch BootNonceConsumedAt (that field belongs to the /boot handler)", func() {

--- a/docs/physicalhost.md
+++ b/docs/physicalhost.md
@@ -50,7 +50,7 @@ For the diagram and the full transition table, see [State Management](state-mana
 
 ## Bootstrap signaling
 
-When the Beskar7Machine controller has bootstrap data ready, it patches two annotations on the PhysicalHost. The PhysicalHost reconciler reads them on its next pass, persists the values to status, and clears the annotation:
+When the Beskar7Machine controller has bootstrap data ready, it patches two annotations on the PhysicalHost. The PhysicalHost reconciler reads them on its next pass, persists the values to status, and clears the annotation. For the credential annotations (`bootstrap-token`, and the `boot-nonce` minted at inspection time) the clear happens one pass later, once status already shows the same hash: the reconciler's patch writes metadata before status, so clearing in the same pass would publish a version of the host that advertises no credential, and a reader in that gap (the Beskar7Machine controller checks the annotation, then status) would mint a fresh one over a token the inspector may already hold:
 
 | Annotation | Persisted to | Source code |
 |---|---|---|


### PR DESCRIPTION
## What

The host controller keeps a freshly minted credential annotation (`bootstrap-token`, `boot-nonce`) until `Status.Bootstrap` already carries the same hash, and clears it on the following pass instead of in the same one.

## Why

`applyBootstrapTokenAnnotation` / `applyBootNonceAnnotation` copied the hash the Beskar7Machine controller had just minted into status and deleted the annotation in the same reconcile. CAPI's `patch.Helper` writes the main resource before the status subresource (`util/patch/patch.go`: `h.patch`, then `h.patchStatus`), so every promotion published a version of the `PhysicalHost` that advertised **no credential at all**: annotation gone, status not yet written, state still `InUse`.

A Beskar7Machine reconcile enqueued by that very event re-enters `triggerInspection` (the host is still `InUse`), `unexpiredBootstrapTokenHash` returns `""` (a silent path, no log line), and it mints again. The inspector had already read the first plaintext from the per-host Secret, so its callbacks were rejected with 401 and the machine timed out.

This is what failed the E2E smoke on #167 twice in a row (layer 7, `pool-host-b`: the manager log shows a second `Applied bootstrap-token annotation to Status.Bootstrap` one second after the inspector read its token, then `auth: rejected bearer token … bootstrap token mismatch`). It is latent since the token handoff was introduced; #164's annotation-first lookup did not change it, recent timing shifts (#162's queue, #165's informer pre-warm) made the second pool host hit it reliably. The dome lab's stranded hosts are the same mechanism.

## How

- Pass 1 writes status and keeps the annotation. Pass 2, once status shows the same hash **and** expiry, deletes it. A reader that checks annotation-then-status therefore sees the hash through every published version. A failed status patch can no longer lose a mint either (before, the metadata patch had already removed the annotation).
- Same treatment for the boot nonce; `BootNonceConsumedAt` is untouched as before.
- No Beskar7Machine controller change. `Status.Bootstrap` is not cleared on release (#154) and the Secret is never deleted, so a re-claimed host always has a visible hash: the "neither" state was only ever this gap.
- The other promoted annotations (`bootstrap-url`, `inspection-request`, `inspection-result`) keep the one-pass pattern; their gap only causes benign re-triggers (the smoke log shows "starting inspection" applied twice), not credential churn.
- CI: the failure diagnostics keep 2000 manager log lines instead of 500; the first mint had scrolled out of the dump this needed.
- Docs: `docs/physicalhost.md` describes the two-phase clear. CHANGELOG.

## Verification

- envtest spec for the token now asserts the intermediate invariant (status written, annotation still present, `unexpiredBootstrapTokenHash` sees the hash) and the clear on the next pass; pure specs for token and nonce cover both passes and a newer mint replacing an older status hash.
- `go test ./controllers/ -race`, integration suite twice (~9 s each), `golangci-lint`: clean.
- The E2E on this PR is the real proof; the failure was reproduced 2/2 on #167's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
