### PR TITLE
feat: clusterctl provider contract — installable with clusterctl init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,11 +550,16 @@ jobs:
         fi
         echo "OVERRIDE_VERSION=$OVERRIDE_VERSION" >> "$GITHUB_ENV"
         make clusterctl-override VERSION="$OVERRIDE_VERSION"
+        # A versioned URL, not releases/latest/: clusterctl resolves "latest"
+        # against GitHub while creating the repository client, before it looks
+        # at the local repository, and the latest published release may not
+        # carry the assets yet. With the explicit version every read is served
+        # from ~/.cluster-api/overrides.
         cat > /tmp/clusterctl.yaml <<EOF
         providers:
           - name: beskar7
             type: InfrastructureProvider
-            url: https://github.com/projectbeskar/beskar7/releases/latest/infrastructure-components.yaml
+            url: https://github.com/projectbeskar/beskar7/releases/${OVERRIDE_VERSION}/infrastructure-components.yaml
         images:
           infrastructure-beskar7:
             repository: ${{ env.REGISTRY }}/${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: release-manifests
-        path: beskar7-manifests-v0.0.0-ci.yaml
+        path: |
+          beskar7-manifests-v0.0.0-ci.yaml
+          infrastructure-components.yaml
+          metadata.yaml
 
   # Job 7: End-to-End Smoke Test
   #
@@ -447,10 +450,158 @@ jobs:
         path: benchmark.txt
 
   # Summary Job
+  # The same smoke, installed the way clusterctl users get it: the components
+  # YAML built from this tree published into a clusterctl local repository
+  # (~/.cluster-api/overrides), then `clusterctl init --infrastructure beskar7`.
+  # This is what proves the clusterctl provider contract end to end — variable
+  # substitution, target namespace, labels, cert-manager wiring, the provider
+  # inventory — and that the kustomize-based install can actually provision
+  # (callback Service, cert SAN, NetworkPolicy), which the Helm job never
+  # exercises.
+  e2e-clusterctl:
+    name: E2E clusterctl install
+    runs-on: ubuntu-latest
+    needs: [manifests, container]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1
+      with:
+        cluster_name: beskar7-clusterctl
+        kubectl_version: v1.31.0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.25'
+
+    - name: Install kustomize and controller-gen
+      run: |
+        go install sigs.k8s.io/kustomize/kustomize/v5@v5.4.3
+        make install-controller-gen
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build controller image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64
+        push: false
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:smoke-ci
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Build mock-redfish image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile.mock-redfish
+        platforms: linux/amd64
+        push: false
+        tags: ${{ env.REGISTRY }}/${{ github.repository }}/mock-redfish:smoke-ci
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Build mock-inspector image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile.mock-inspector
+        platforms: linux/amd64
+        push: false
+        tags: ${{ env.REGISTRY }}/${{ github.repository }}/mock-inspector:smoke-ci
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Load images into kind
+      run: |
+        kind load docker-image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:smoke-ci --name beskar7-clusterctl
+        kind load docker-image ${{ env.REGISTRY }}/${{ github.repository }}/mock-redfish:smoke-ci --name beskar7-clusterctl
+        kind load docker-image ${{ env.REGISTRY }}/${{ github.repository }}/mock-inspector:smoke-ci --name beskar7-clusterctl
+
+    - name: Install Cluster API core via clusterctl
+      run: |
+        # clusterctl installs cert-manager itself. Keep the version in step
+        # with the sigs.k8s.io/cluster-api version in go.mod (v1beta2 API).
+        CLUSTERCTL_VERSION=v1.13.4
+        curl -L -o /tmp/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64"
+        chmod +x /tmp/clusterctl
+        sudo mv /tmp/clusterctl /usr/local/bin/clusterctl
+        clusterctl version
+        clusterctl init
+        for ns in capi-system capi-kubeadm-bootstrap-system capi-kubeadm-control-plane-system; do
+          kubectl wait --for=condition=Available --timeout=300s deployment --all -n "$ns"
+        done
+
+    - name: Publish this tree as a clusterctl local repository
+      run: |
+        # The newest release series in metadata.yaml, patch 0, names the
+        # repository version; the image tag inside the components is rewritten
+        # to the kind-loaded one through clusterctl's image overrides.
+        OVERRIDE_VERSION=$(awk '/major:/{M=$2} /minor:/{m=$2; print "v" M "." m ".0"; exit}' metadata.yaml)
+        echo "OVERRIDE_VERSION=$OVERRIDE_VERSION" >> "$GITHUB_ENV"
+        make clusterctl-override VERSION="$OVERRIDE_VERSION"
+        cat > /tmp/clusterctl.yaml <<EOF
+        providers:
+          - name: beskar7
+            type: InfrastructureProvider
+            url: https://github.com/projectbeskar/beskar7/releases/latest/infrastructure-components.yaml
+        images:
+          infrastructure-beskar7:
+            repository: ${{ env.REGISTRY }}/${{ github.repository }}
+            tag: smoke-ci
+        EOF
+        cat /tmp/clusterctl.yaml
+
+    - name: Install Beskar7 via clusterctl init
+      env:
+        GOPROXY: "off"
+      run: |
+        clusterctl init --infrastructure "beskar7:${OVERRIDE_VERSION}" --config /tmp/clusterctl.yaml -v 3
+        kubectl -n beskar7-system get pods,deploy,svc
+        kubectl -n beskar7-system rollout status deploy/beskar7-controller-manager --timeout=300s
+        echo "=== provider inventory ==="
+        kubectl get providers -A
+        echo "=== the args clusterctl rendered (variable default must be resolved) ==="
+        kubectl -n beskar7-system get deploy beskar7-controller-manager -o jsonpath='{.spec.template.spec.containers[0].args}'; echo
+        if kubectl -n beskar7-system get deploy beskar7-controller-manager -o jsonpath='{.spec.template.spec.containers[0].args}' | grep -q '\${'; then
+          echo "unresolved clusterctl variable in the rendered Deployment"; exit 1
+        fi
+
+    - name: Run make smoke
+      run: make smoke
+
+    - name: Diagnostics on failure
+      if: failure()
+      run: |
+        echo "=== Providers ==="
+        kubectl get providers -A || true
+        echo "=== Pods (all namespaces) ==="
+        kubectl get pods -A -o wide
+        echo "=== Beskar7 objects in beskar7-system ==="
+        kubectl -n beskar7-system get all,certificate,networkpolicy || true
+        echo "=== Beskar7 controller log (last 2000) ==="
+        kubectl -n beskar7-system logs deploy/beskar7-controller-manager --tail=2000 || true
+        echo "=== Mock-redfish log ==="
+        kubectl -n beskar7-smoke logs deploy/mock-redfish --tail=100 || true
+        echo "=== Mock-inspector Job + log ==="
+        kubectl -n beskar7-smoke get job mock-inspector -o yaml || true
+        kubectl -n beskar7-smoke logs -l app.kubernetes.io/name=mock-inspector --tail=100 || true
+        echo "=== PhysicalHost ==="
+        kubectl -n beskar7-smoke get physicalhost -o yaml || true
+        echo "=== Beskar7Machine ==="
+        kubectl -n beskar7-smoke get beskar7machine -o yaml || true
+
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, security, test, integration-test, container, manifests, e2e-setup]
+    needs: [lint, security, test, integration-test, container, manifests, e2e-setup, e2e-clusterctl]
     if: always()
     steps:
     - name: Check all jobs status
@@ -461,7 +612,8 @@ jobs:
               "${{ needs.integration-test.result }}" != "success" || \
               "${{ needs.container.result }}" != "success" || \
               "${{ needs.manifests.result }}" != "success" || \
-              "${{ needs.e2e-setup.result }}" != "success" ]]; then
+              "${{ needs.e2e-setup.result }}" != "success" || \
+              "${{ needs.e2e-clusterctl.result }}" != "success" ]]; then
           echo "One or more critical jobs failed"
           exit 1
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,7 @@ jobs:
         # created in a live namespace (creating content in a Terminating
         # namespace is forbidden), so wait for the deletion to finish before
         # recreating it.
-        kubectl wait --for=delete namespace/beskar7-smoke --timeout=120s 2>/dev/null || true
+        kubectl wait --for=delete namespace/beskar7-smoke --timeout=300s 2>/dev/null || true
         kubectl apply -f hack/smoke/manifests/00-namespace.yaml
         helm upgrade beskar7 ./charts/beskar7 \
           --namespace beskar7-system \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,7 +544,10 @@ jobs:
         # The newest release series in metadata.yaml, patch 0, names the
         # repository version; the image tag inside the components is rewritten
         # to the kind-loaded one through clusterctl's image overrides.
-        OVERRIDE_VERSION=$(awk '/major:/{M=$2} /minor:/{m=$2; print "v" M "." m ".0"; exit}' metadata.yaml)
+        OVERRIDE_VERSION=$(awk '/major:/{M=$NF} /minor:/{m=$NF; print "v" M "." m ".0"; exit}' metadata.yaml)
+        if ! [[ "$OVERRIDE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "could not derive a semantic version from metadata.yaml: '$OVERRIDE_VERSION'"; exit 1
+        fi
         echo "OVERRIDE_VERSION=$OVERRIDE_VERSION" >> "$GITHUB_ENV"
         make clusterctl-override VERSION="$OVERRIDE_VERSION"
         cat > /tmp/clusterctl.yaml <<EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,8 +300,17 @@ jobs:
     - name: Verify manifest generation
       run: |
         VERSION=${{ github.ref_name }}
-        if [ ! -f "beskar7-manifests-$VERSION.yaml" ]; then
-          echo "❌ Manifest file not generated: beskar7-manifests-$VERSION.yaml"
+        for f in "beskar7-manifests-$VERSION.yaml" infrastructure-components.yaml metadata.yaml; do
+          if [ ! -f "$f" ]; then
+            echo "❌ Release asset missing: $f"
+            exit 1
+          fi
+        done
+        # The kubectl manifest must have every clusterctl variable resolved; the
+        # clusterctl components keep them (clusterctl init resolves them).
+        if grep -q '\${' "beskar7-manifests-$VERSION.yaml"; then
+          echo "❌ Unresolved clusterctl variables in the kubectl manifest:"
+          grep '\${' "beskar7-manifests-$VERSION.yaml"
           exit 1
         fi
         echo "✅ Manifest file generated successfully: beskar7-manifests-$VERSION.yaml"
@@ -316,7 +325,7 @@ jobs:
         
     - name: Generate checksums
       run: |
-        sha256sum beskar7-manifests-${{ github.ref_name }}.yaml > checksums.txt
+        sha256sum beskar7-manifests-${{ github.ref_name }}.yaml infrastructure-components.yaml metadata.yaml > checksums.txt
         
     - name: Upload release artifacts
       uses: actions/upload-artifact@v4
@@ -324,6 +333,8 @@ jobs:
         name: release-artifacts
         path: |
           beskar7-manifests-${{ github.ref_name }}.yaml
+          infrastructure-components.yaml
+          metadata.yaml
           checksums.txt
 
   # Job 4: Create Helm Chart (TODO: Implement Helm chart)
@@ -408,6 +419,18 @@ jobs:
         echo "" >> release-notes.md
         echo "## 📦 Installation" >> release-notes.md
         echo "" >> release-notes.md
+        echo "### Using clusterctl" >> release-notes.md
+        echo "Add the provider to \`~/.cluster-api/clusterctl.yaml\` (until beskar7 is in clusterctl's built-in list):" >> release-notes.md
+        echo "\`\`\`yaml" >> release-notes.md
+        echo "providers:" >> release-notes.md
+        echo "  - name: beskar7" >> release-notes.md
+        echo "    type: InfrastructureProvider" >> release-notes.md
+        echo "    url: https://github.com/projectbeskar/beskar7/releases/latest/infrastructure-components.yaml" >> release-notes.md
+        echo "\`\`\`" >> release-notes.md
+        echo "\`\`\`bash" >> release-notes.md
+        echo "clusterctl init --infrastructure beskar7:$VERSION" >> release-notes.md
+        echo "\`\`\`" >> release-notes.md
+        echo "" >> release-notes.md
         echo "### Using Kubectl" >> release-notes.md
         echo "\`\`\`bash" >> release-notes.md
         echo "kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/$VERSION/beskar7-manifests-$VERSION.yaml" >> release-notes.md
@@ -450,6 +473,8 @@ jobs:
         prerelease: ${{ contains(github.ref_name, '-') }}
         files: |
           release-artifacts/beskar7-manifests-${{ github.ref_name }}.yaml
+          release-artifacts/infrastructure-components.yaml
+          release-artifacts/metadata.yaml
           release-artifacts/checksums.txt
           sbom/sbom.spdx.json
           vulnerability-report/trivy-report.txt
@@ -470,14 +495,15 @@ jobs:
     - name: Update README with latest version
       run: |
         VERSION=${{ github.ref_name }}
-        # Update installation examples in README
-        sed -i "s|beskar7-manifests-v[0-9]\+\.[0-9]\+\.[0-9]\+\.yaml|beskar7-manifests-$VERSION.yaml|g" README.md
+        # Update installation examples: the release path and the manifest name
+        # carry the version (the old pattern left `releases/download/<old>/` behind).
+        sed -i -E "s|releases/download/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?/beskar7-manifests-v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?\.yaml|releases/download/$VERSION/beskar7-manifests-$VERSION.yaml|g" README.md docs/installation.md
         
     - name: Commit changes
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git add README.md
+        git add README.md docs/installation.md
         if git diff --staged --quiet; then
           echo "No changes to commit"
         else

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ fix-go-env.sh
 # release workflow attaches them as GitHub Release assets but they should
 # not be tracked in git).
 beskar7-manifests-*.yaml
+infrastructure-components.yaml
 field-testing/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,31 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- **Installable with `clusterctl init`.** Every release now publishes the two assets
+  the [clusterctl provider contract](https://cluster-api.sigs.k8s.io/developer/providers/contracts/clusterctl)
+  asks for: `infrastructure-components.yaml` (the kustomize overlay, with the
+  clusterctl variable `${BESKAR7_BOOTSTRAP_URL_BASE:=…}` for `--bootstrap-url-base`)
+  and `metadata.yaml` (release series → contract, pinned to the CRD contract label by
+  `test/contract`). `beskar7-manifests-<version>.yaml` stays as the plain-kubectl
+  manifest with the variables resolved. Until beskar7 is in clusterctl's built-in
+  list, declare it under `providers:` in the clusterctl config; `docs/installation.md`
+  has the snippet. `make clusterctl-override` publishes the current tree into a
+  clusterctl local repository, and a new CI job installs beskar7 that way on every
+  pull request and runs the smoke suite against it.
+
 ### Fixed
 
+- **The kustomize / release-manifest install could not provision a host.** It had
+  no Service for the callback server (`--bootstrap-url-base` pointed at
+  `beskar7-controller-manager.beskar7-system.svc:8082`, a name only the Helm chart
+  created), the serving certificate did not cover that name, and the NetworkPolicy
+  allowed neither `:8082` nor the metrics port the manager actually binds (`:8443`,
+  not `:8080`). All four are fixed; the Deployment is now named
+  `beskar7-controller-manager` like the chart's (delete the old `controller-manager`
+  Deployment after re-applying a manifest install, see `docs/upgrading.md`), and its
+  image pull policy is `IfNotPresent` (the tag is pinned per release).
 - **A bootstrap token or boot nonce is no longer re-minted while the host controller
   is promoting it.** `applyBootstrapTokenAnnotation` / `applyBootNonceAnnotation`
   copied the freshly minted hash into `Status.Bootstrap` and cleared the annotation

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,14 @@ IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)
 
+# clusterctl variable syntax (${VAR:=default}, drone/envsubst) resolved to the
+# default for consumers that never run envsubst: `make deploy` and the
+# plain-kubectl release manifest. `clusterctl init` gets the raw file.
+RESOLVE_CLUSTERCTL_DEFAULTS = sed -E 's/\$$\{[A-Za-z_][A-Za-z0-9_]*:=([^}]*)\}/\1/g'
+
+# Where `make clusterctl-override` writes a local clusterctl repository.
+CLUSTERCTL_OVERRIDES ?= $(HOME)/.cluster-api/overrides
+
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "generateEmbeddedObjectMeta=true,maxDescLen=0"
 
@@ -166,31 +174,40 @@ uninstall:
 deploy:
 	$(MAKE) manifests
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | $(RESOLVE_CLUSTERCTL_DEFAULTS) | kubectl apply -f -
 
 # Undeploy controller from the cluster specified in ~/.kube/config
 undeploy:
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
+	$(KUSTOMIZE) build config/default | $(RESOLVE_CLUSTERCTL_DEFAULTS) | kubectl delete -f -
 
-# Generate a single manifest file for a release
+# Generate the release manifests: infrastructure-components.yaml (clusterctl,
+# keeps ${VAR:=default}) and beskar7-manifests-$(VERSION).yaml (plain kubectl,
+# defaults resolved). VERSION is stamped into the image tag and the version
+# label of temporary copies of the kustomizations; the originals are restored
+# afterwards from a scratch directory — never with `git checkout`, which would
+# also throw away uncommitted edits to those files.
 release-manifests:
-	$(MAKE) manifests # Ensure CRDs and RBAC are up-to-date
-	# Update kustomization.yaml files with current VERSION before building
-	# Pattern matches versions with optional suffixes like -alpha, -beta, -rc1, etc.
-	sed -i.bak 's/app\.kubernetes\.io\/version: v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9]\+\)*/app.kubernetes.io\/version: $(VERSION)/g' config/default/kustomization.yaml
-	sed -i.bak 's/newTag: v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9]\+\)*/newTag: $(VERSION)/g' config/default/kustomization.yaml
-	# Update manager kustomization (critical for image tag)
-	sed -i.bak 's/newTag: v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9]\+\)*/newTag: $(VERSION)/g' config/manager/kustomization.yaml
-	# Update overlay files too
-	find config/overlays -name "kustomization.yaml" -exec sed -i.bak 's/app\.kubernetes\.io\/version: v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9]\+\)*/app.kubernetes.io\/version: $(VERSION)/g' {} \;
-	find config/overlays -name "kustomization.yaml" -exec sed -i.bak 's/newTag: v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9]\+\)*/newTag: $(VERSION)/g' {} \;
-	# CRITICAL: Delete backup files BEFORE kustomize runs (it tries to parse them)
-	find config/ -name "*.yaml.bak" -delete 2>/dev/null || true
-	# Build manifests (now that .bak files are gone)
-	$(KUSTOMIZE) build config/default > beskar7-manifests-$(VERSION).yaml
-	# Restore original kustomization.yaml files using git
-	git checkout config/default/kustomization.yaml config/manager/kustomization.yaml 2>/dev/null || true
-	git checkout config/overlays/ 2>/dev/null || true
-	@echo "Release manifests generated: beskar7-manifests-$(VERSION).yaml"
+	$(MAKE) manifests
+	@set -e; \
+	files="config/default/kustomization.yaml config/manager/kustomization.yaml $$(find config/overlays -name kustomization.yaml)"; \
+	tmp=$$(mktemp -d); \
+	for f in $$files; do \
+	  mkdir -p "$$tmp/$$(dirname $$f)"; cp "$$f" "$$tmp/$$f"; \
+	  sed -i -E 's/app\.kubernetes\.io\/version: v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?/app.kubernetes.io\/version: $(VERSION)/g; s/newTag: v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?/newTag: $(VERSION)/g' "$$f"; \
+	done; \
+	rc=0; $(KUSTOMIZE) build config/default > infrastructure-components.yaml || rc=$$?; \
+	for f in $$files; do cp "$$tmp/$$f" "$$f"; done; rm -rf "$$tmp"; \
+	if [ $$rc -ne 0 ]; then echo "kustomize build failed ($$rc)"; rm -f infrastructure-components.yaml; exit $$rc; fi; \
+	$(RESOLVE_CLUSTERCTL_DEFAULTS) infrastructure-components.yaml > beskar7-manifests-$(VERSION).yaml; \
+	echo "Release manifests generated: infrastructure-components.yaml (clusterctl) and beskar7-manifests-$(VERSION).yaml (kubectl)"
 
-.PHONY: build build-mock-redfish build-mock-inspector generate manifests test lint docker-build docker-build-mock-redfish docker-build-mock-inspector docker-push deploy install-controller-gen install-golangci-lint install uninstall undeploy rbac crd webhook release-manifests sync-chart-crds manifests-and-sync smoke smoke-teardown
+# Publish the release assets into a clusterctl local repository so that
+# `clusterctl init --infrastructure beskar7:$(VERSION)` installs this tree.
+# VERSION must be a semantic version (the directory name is one).
+clusterctl-override: release-manifests
+	mkdir -p $(CLUSTERCTL_OVERRIDES)/infrastructure-beskar7/$(VERSION)
+	cp infrastructure-components.yaml metadata.yaml $(CLUSTERCTL_OVERRIDES)/infrastructure-beskar7/$(VERSION)/
+	@echo "clusterctl local repository: $(CLUSTERCTL_OVERRIDES)/infrastructure-beskar7/$(VERSION)"
+	@echo "install with: clusterctl init --infrastructure beskar7:$(VERSION)  (provider 'beskar7' must be in your clusterctl config, see docs/installation.md)"
+
+.PHONY: build build-mock-redfish build-mock-inspector generate manifests test lint docker-build docker-build-mock-redfish docker-build-mock-inspector docker-push deploy install-controller-gen install-golangci-lint install uninstall undeploy rbac crd webhook release-manifests clusterctl-override sync-chart-crds manifests-and-sync smoke smoke-teardown

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ helm install beskar7 beskar7/beskar7 \
 ```
 
 
+**Using clusterctl** (add the provider to `~/.cluster-api/clusterctl.yaml` first, see [Installation](docs/installation.md#install-via-clusterctl)):
+
+```bash
+clusterctl init --infrastructure beskar7   # v0.5.0 and later publish the clusterctl assets
+```
+
 **Using Release Manifests:**
 
 ```bash

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -13,6 +13,9 @@ spec:
   commonName: beskar7-webhook-service.beskar7-system.svc
   dnsNames:
   - beskar7-webhook-service.beskar7-system.svc
+  # The callback server (:8082) serves from the same certificate directory;
+  # in-cluster callers verify against the callback Service name.
+  - beskar7-controller-manager.beskar7-system.svc
   issuerRef:
     name: beskar7-selfsigned-issuer
     kind: ClusterIssuer 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- service-callback.yaml
 - namespace.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,7 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  # Same name as the Helm chart's Deployment so docs, diagnostics and the
+  # smoke runner (OPERATOR_DEPLOY) work for both install paths.
+  name: beskar7-controller-manager
   namespace: beskar7-system
   labels:
     control-plane: controller-manager
@@ -41,9 +43,15 @@ spec:
         - --enable-webhook=true
         - --metrics-bind-address=:8443
         - --health-probe-bind-address=:8081
-        - --bootstrap-url-base=https://beskar7-controller-manager.beskar7-system.svc:8082
+        # clusterctl variable (drone/envsubst syntax): `clusterctl init` resolves
+        # BESKAR7_BOOTSTRAP_URL_BASE from the environment or its config file and
+        # falls back to the in-cluster callback Service. `make release-manifests`
+        # and `make deploy` resolve the default for plain kubectl consumers.
+        - --bootstrap-url-base=${BESKAR7_BOOTSTRAP_URL_BASE:=https://beskar7-controller-manager.beskar7-system.svc:8082}
         image: controller
-        imagePullPolicy: Always
+        # The tag is pinned per release; IfNotPresent also lets a locally loaded
+        # image (kind, clusterctl local repository) run without a registry.
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
@@ -79,6 +87,9 @@ spec:
           protocol: TCP
         - containerPort: 9443
           name: webhook
+          protocol: TCP
+        - containerPort: 8082
+          name: callback
           protocol: TCP
         livenessProbe:
           httpGet:

--- a/config/manager/service-callback.yaml
+++ b/config/manager/service-callback.yaml
@@ -1,0 +1,24 @@
+# The host-callback server: inspection POST, bootstrap GET, the provisioned /
+# provision-failed callbacks and the per-host /boot endpoint, all on :8082 over
+# TLS. The manager's default --bootstrap-url-base points at this Service, and
+# PhysicalHost.Status.Bootstrap.URL is derived from it, so without it a
+# kustomize / clusterctl install could never hear back from a host. Bare-metal
+# hosts reach it while PXE-booting: expose it (LoadBalancer/NodePort/Ingress)
+# or run a callback-only manager on the provisioning network, and set
+# BESKAR7_BOOTSTRAP_URL_BASE to the address they will use.
+apiVersion: v1
+kind: Service
+metadata:
+  name: beskar7-controller-manager
+  namespace: beskar7-system
+  labels:
+    app.kubernetes.io/component: callback-server
+spec:
+  type: ClusterIP
+  ports:
+  - name: callback
+    port: 8082
+    targetPort: 8082
+    protocol: TCP
+  selector:
+    control-plane: controller-manager

--- a/config/security/network-policy.yaml
+++ b/config/security/network-policy.yaml
@@ -24,20 +24,30 @@ spec:
     - protocol: TCP
       port: 9443
   
-  # Allow metrics scraping from monitoring systems
+  # Allow metrics scraping from monitoring systems (the manager binds
+  # --metrics-bind-address=:8443)
   - from:
     - namespaceSelector:
         matchLabels:
           name: monitoring
     ports:
     - protocol: TCP
-      port: 8080
+      port: 8443
   
   # Allow health checks from ingress controllers/load balancers
   - from: []
     ports:
     - protocol: TCP
       port: 8081
+  
+  # Callback traffic (inspection POST, bootstrap GET, provisioned / provision-failed
+  # callbacks, the per-host /boot endpoint). Authorization is the per-host bearer
+  # token and boot nonce; bare-metal hosts boot from addresses that cannot be
+  # allow-listed here. TLS is mandatory.
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 8082
   
   # Egress rules - what the manager can connect TO
   egress:
@@ -130,7 +140,7 @@ spec:
           app: prometheus
     ports:
     - protocol: TCP
-      port: 8080
+      port: 8443
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -67,6 +67,15 @@ make deploy IMG=my-registry/my-repo:dev
 
 This applies the full kustomize overlay including RBAC, the deployment, and the webhook configuration. Ensure cert-manager is installed first (see [Installation](installation.md#prerequisites)).
 
+To exercise the clusterctl install path against the current tree, publish it as a clusterctl local repository and let `clusterctl init` install it:
+
+```bash
+make clusterctl-override VERSION=v0.5.0        # writes ~/.cluster-api/overrides/infrastructure-beskar7/v0.5.0/
+clusterctl init --infrastructure beskar7:v0.5.0 # needs the provider in ~/.cluster-api/clusterctl.yaml, see Installation
+```
+
+`VERSION` must be a semantic version; it names the repository directory and the image tag in the components, so point clusterctl at the image you built (`images:` overrides in its config) or push it under that tag.
+
 ## Verify
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,15 +66,49 @@ helm install beskar7 beskar7/beskar7 \
 
 The external SAN is added to both certificate paths: the cert-manager `Certificate` (`certManager.enabled=true`) and the chart's self-signed cert (`certManager.enabled=false`). In self-signed mode the cert is generated once and reused across upgrades — changing `callback.externalNames` / `callback.externalIPs` after the first install does not rotate it; delete the Secret named in `certManager.certificate.secretName` to force regeneration with the new SANs.
 
+## Install via clusterctl
+
+beskar7 implements the [clusterctl provider contract](https://cluster-api.sigs.k8s.io/developer/providers/contracts/clusterctl): every release publishes `infrastructure-components.yaml` and `metadata.yaml`, so `clusterctl init` can install it like any other infrastructure provider, and `clusterctl move` / `clusterctl upgrade` know about it through the provider inventory.
+
+Until beskar7 is in clusterctl's built-in provider list, declare it in `~/.cluster-api/clusterctl.yaml`:
+
+```yaml
+providers:
+  - name: beskar7
+    type: InfrastructureProvider
+    url: https://github.com/projectbeskar/beskar7/releases/latest/infrastructure-components.yaml
+```
+
+Then initialise the management cluster (clusterctl installs cert-manager and the core providers itself):
+
+```bash
+export BESKAR7_BOOTSTRAP_URL_BASE=https://beskar7.example.com:8082   # optional, see below
+clusterctl init --infrastructure beskar7
+```
+
+The assets exist from `v0.5.0` on; `clusterctl init --infrastructure beskar7:<version>` pins a release.
+
+Variables the components accept (set them in the environment or in the clusterctl config file):
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `BESKAR7_BOOTSTRAP_URL_BASE` | `https://beskar7-controller-manager.beskar7-system.svc:8082` | Scheme, host and port bare-metal hosts use to reach the callback server (`--bootstrap-url-base`). Rendered into `PhysicalHost.Status.Bootstrap.URL`. |
+
+A clusterctl install is the kustomize-based install: the `beskar7-system` namespace, a `ClusterIP` Service `beskar7-controller-manager` for the callback server on `:8082`, and a cert-manager `Certificate` whose SANs cover the webhook and callback Service names. Bare-metal hosts reach the callback server while PXE-booting, so for real hardware either expose that Service (patch it to `LoadBalancer` / `NodePort`, or front it with an Ingress) and set `BESKAR7_BOOTSTRAP_URL_BASE` to the external address before `clusterctl init`, or run a [callback-only manager](ipxe-setup.md#management-cluster-off-the-provisioning-network-a-callback-only-instance) on the provisioning network. The external name must also appear in the serving certificate: edit the `Certificate` `beskar7-serving-cert` in `beskar7-system` (`spec.dnsNames` / `spec.ipAddresses`) after the install, the way the chart's `callback.externalNames` does it.
+
+To install a build of the current tree instead of a release, publish it into a clusterctl local repository first: `make clusterctl-override VERSION=v0.5.0` writes `~/.cluster-api/overrides/infrastructure-beskar7/v0.5.0/`, and `clusterctl init --infrastructure beskar7:v0.5.0` uses it without touching the network. CI does exactly that on every pull request and runs the smoke suite against the result.
+
 ## Install via release manifests
 
 ```bash
 kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.4/beskar7-manifests-v0.4.4.yaml
 ```
 
-This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`.
+This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `beskar7-system` namespace and the default `bootstrap.urlBase`. It is the clusterctl components file with the variables above resolved to their defaults; do not `kubectl apply` `infrastructure-components.yaml` itself — it keeps the `${…}` placeholders for `clusterctl init` to fill in.
 
 ## `clusterctl move`
+
+With a [clusterctl install](#install-via-clusterctl) the provider inventory and the labels are in place and `clusterctl move` works as for any other provider; the notes below are for Helm and release-manifest installs.
 
 `clusterctl move` builds its object graph only from CRDs that carry the `clusterctl.cluster.x-k8s.io` label. `clusterctl init` adds that label to everything it installs, but neither the Helm chart nor the release manifest goes through `clusterctl init`, so the four beskar7 CRDs carry it themselves, together with `cluster.x-k8s.io/provider: infrastructure-beskar7` (the component label the CAPI provider contract asks for; every other beskar7 component carries the same two). `Beskar7Cluster`, `Beskar7Machine` and `Beskar7MachineTemplate` objects are then moved through their owner references to the `Cluster`, as with any provider. `PhysicalHost` also carries `clusterctl.cluster.x-k8s.io/move-hierarchy`: nothing owns a host, so without it a move would discover the hosts and leave every one of them behind. With it, every `PhysicalHost` in the namespace being moved goes along, together with the bootstrap-token Secret and inspection-result ConfigMap it owns, and is deleted from the source afterwards like any other namespaced object.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -112,6 +112,14 @@ What changes on your side:
   `clusterctl.cluster.x-k8s.io/move-hierarchy` (nothing owns a host, so without it a move would leave
   every host behind). Replacing the CRDs installs them; there is no relabel step. Read
   [Installation](installation.md#clusterctl-move) before moving a namespace.
+- **Release-manifest installs:** the Deployment is now named `beskar7-controller-manager` (it was
+  `controller-manager`; the chart's name), a `beskar7-controller-manager` Service exposes the callback
+  server on `:8082`, and the serving certificate and NetworkPolicy cover it — a manifest install can
+  provision hosts for the first time. After re-applying the manifest, delete the old Deployment or
+  two managers will run: `kubectl -n beskar7-system delete deploy controller-manager`.
+- **clusterctl:** the release ships `infrastructure-components.yaml` and `metadata.yaml`, so
+  `clusterctl init --infrastructure beskar7` is a supported install path from `v0.5.0` on (see
+  [Installation](installation.md#install-via-clusterctl)).
 
 ### Procedure
 

--- a/hack/smoke/run.sh
+++ b/hack/smoke/run.sh
@@ -130,8 +130,14 @@ teardown() {
   # namespace is already gone (idempotent re-runs).
   kubectl get ns "${SMOKE_NS}" >/dev/null 2>&1 || return 0
 
+  # The layer-7 MachineDeployment/MachineSet go first: a MachineSet that
+  # outlives its Machines recreates them (new finalizers, new claims against
+  # hosts that are being deleted), and the namespace then takes minutes to
+  # finalize instead of seconds.
   kubectl delete --ignore-not-found=true -n "${SMOKE_NS}" \
-    machine,kubeadmconfig,beskar7machine,beskar7cluster,cluster,physicalhost --all \
+    machinedeployment,machineset --all --wait=false >/dev/null 2>&1 || true
+  kubectl delete --ignore-not-found=true -n "${SMOKE_NS}" \
+    machine,kubeadmconfig,beskar7machine,beskar7machinetemplate,beskar7cluster,cluster,physicalhost --all \
     --wait=false >/dev/null 2>&1 || true
 
   # Give controllers a few seconds to honour finalizers, then force-remove
@@ -142,7 +148,7 @@ teardown() {
   # Force-removing is safe for ephemeral smoke fixtures.
   sleep 5
   local obj name
-  for obj in machine kubeadmconfig beskar7machine beskar7cluster cluster physicalhost; do
+  for obj in machinedeployment machineset machine kubeadmconfig beskar7machine beskar7cluster cluster physicalhost; do
     while read -r name; do
       [[ -z "${name}" ]] && continue
       kubectl -n "${SMOKE_NS}" patch "${name}" --type=merge \

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,11 @@
+# clusterctl provider metadata (clusterctl provider contract). Each release
+# series maps to the Cluster API contract its CRDs declare. Keep the newest
+# series first: test/contract pins it to the CRD contract label, and CI's
+# clusterctl smoke installs the first series listed. Releases before v0.5.0
+# predate the clusterctl assets and are not listed.
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 0
+  minor: 5
+  contract: v1beta2

--- a/test/contract/clusterctl_metadata_test.go
+++ b/test/contract/clusterctl_metadata_test.go
@@ -1,0 +1,111 @@
+package contract
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/yaml"
+)
+
+// TestClusterctlMetadataMatchesTheCRDContract pins metadata.yaml, the file
+// `clusterctl init` reads to learn which Cluster API contract a beskar7
+// release series speaks, to the contract the CRDs actually declare.
+//
+// clusterctl uses the metadata contract during init/upgrade (a mismatch with
+// the core provider's contract aborts the install); at runtime CAPI uses the
+// CRD label. The two must agree, and metadata.yaml must be valid under
+// clusterctl's strict validation (apiVersion, kind, at least one series).
+// The newest series is listed first: CI's clusterctl smoke installs it.
+func TestClusterctlMetadataMatchesTheCRDContract(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "metadata.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta clusterctlv1.Metadata
+	if err := yaml.UnmarshalStrict(raw, &meta); err != nil {
+		t.Fatalf("metadata.yaml: %v", err)
+	}
+	if meta.APIVersion != clusterctlv1.GroupVersion.String() {
+		t.Errorf("metadata.yaml apiVersion = %q, want %q", meta.APIVersion, clusterctlv1.GroupVersion.String())
+	}
+	if meta.Kind != "Metadata" {
+		t.Errorf("metadata.yaml kind = %q, want Metadata", meta.Kind)
+	}
+	if len(meta.ReleaseSeries) == 0 {
+		t.Fatal("metadata.yaml: releaseSeries must list at least one series")
+	}
+
+	newest := meta.ReleaseSeries[0]
+	for _, rs := range meta.ReleaseSeries[1:] {
+		if rs.Major > newest.Major || (rs.Major == newest.Major && rs.Minor > newest.Minor) {
+			t.Errorf("metadata.yaml: release series %d.%d is listed after the older %d.%d — keep the newest first (CI installs the first one)",
+				rs.Major, rs.Minor, newest.Major, newest.Minor)
+		}
+	}
+
+	// The contract the CRDs declare is the version suffix of the
+	// cluster.x-k8s.io/<contract> label; the label's value is the served
+	// apiVersion (pinned by TestCRDsClaimTheV1Beta2Contract).
+	crdContract := ""
+	for key := range crdLabels(t, filepath.Join(generatedCRDDir, "infrastructure.cluster.x-k8s.io_beskar7clusters.yaml")) {
+		if strings.HasPrefix(key, "cluster.x-k8s.io/v1") {
+			crdContract = strings.TrimPrefix(key, "cluster.x-k8s.io/")
+		}
+	}
+	if crdContract == "" {
+		t.Fatal("beskar7clusters CRD carries no cluster.x-k8s.io/<contract> label")
+	}
+	if newest.Contract != crdContract {
+		t.Errorf("metadata.yaml newest series %d.%d declares contract %q but the CRDs declare %q",
+			newest.Major, newest.Minor, newest.Contract, crdContract)
+	}
+}
+
+// TestComponentsVariablesResolveForKubectl pins the two consumers of the
+// kustomize overlay. `clusterctl init` gets the raw components with
+// ${VAR:=default} placeholders; `make deploy` and the plain-kubectl release
+// manifest run them through RESOLVE_CLUSTERCTL_DEFAULTS (a sed in the
+// Makefile). Every variable must therefore carry a default in exactly the
+// form that sed understands, or the kubectl manifest ships a literal `${…}`
+// as a manager argument.
+func TestComponentsVariablesResolveForKubectl(t *testing.T) {
+	// The Makefile's sed, transcribed: `\$\{[A-Za-z_][A-Za-z0-9_]*:=([^}]*)\}` → `\1`.
+	resolver := regexp.MustCompile(`\$\{[A-Za-z_][A-Za-z0-9_]*:=([^}]*)\}`)
+	anyVariable := regexp.MustCompile(`\$\{`)
+
+	var files []string
+	for _, dir := range []string{"manager", "rbac", "webhook", "certmanager", "security", "default"} {
+		matches, err := filepath.Glob(filepath.Join("..", "..", "config", dir, "*.yaml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, matches...)
+	}
+	sawVariable := false
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !anyVariable.Match(raw) {
+			continue
+		}
+		sawVariable = true
+		resolved := resolver.ReplaceAll(raw, []byte("$1"))
+		if anyVariable.Match(resolved) {
+			t.Errorf("%s: a clusterctl variable has no ${VAR:=default} form; the kubectl manifest would ship it unresolved", f)
+		}
+		for _, m := range resolver.FindAllSubmatch(raw, -1) {
+			if !strings.HasPrefix(string(m[0]), "${BESKAR7_") {
+				t.Errorf("%s: clusterctl variables must be prefixed with the provider name, got %s", f, m[0])
+			}
+		}
+	}
+	if !sawVariable {
+		t.Error("expected at least one clusterctl variable in the kustomize overlay (BESKAR7_BOOTSTRAP_URL_BASE); the Makefile resolver and the docs table would be dead")
+	}
+}


### PR DESCRIPTION
## What

beskar7 becomes installable with `clusterctl init --infrastructure beskar7`, per the [clusterctl provider contract](https://cluster-api.sigs.k8s.io/developer/providers/contracts/clusterctl), and the kustomize-based install it relies on is made to actually work. Stacked on #170 (the docs it edits are the renamed ones); rebases onto `main` once that merges.

## Why

The path towards listing beskar7 among the CAPI infrastructure providers. Upstream inclusion is a visibility entry in clusterctl's built-in provider list and the book; the prerequisite is a provider repository that follows the contract: `infrastructure-components.yaml` and `metadata.yaml` as release assets, the components labelled and single-namespaced, variables in `${VAR:=default}` form, a Deployment whose container is `manager`. Until the upstream PR merges, users add the provider through the clusterctl config file (documented).

## How

**Contract assets**
- `metadata.yaml` (release series 0.5 → `v1beta2`; newest first). `test/contract` pins its contract to the CRD contract label so the two can never drift.
- `make release-manifests` now produces `infrastructure-components.yaml` (raw overlay, with `${BESKAR7_BOOTSTRAP_URL_BASE:=https://beskar7-controller-manager.beskar7-system.svc:8082}` for `--bootstrap-url-base`) **and** `beskar7-manifests-<version>.yaml` (the same objects with the variables resolved, for plain `kubectl apply`; `make deploy` resolves them too). A contract test checks every variable in the overlay has a default in the form the resolver understands and a `BESKAR7_` prefix.
- `make clusterctl-override VERSION=vX.Y.Z` publishes the tree into `~/.cluster-api/overrides/infrastructure-beskar7/vX.Y.Z/` — the clusterctl local-repository mechanism.
- Release workflow: attaches both manifests plus `metadata.yaml`, verifies the kubectl manifest has no unresolved variable, release notes gain a clusterctl section, and the docs-update step rewrites the whole `releases/download/<version>/…` path (the old sed left the previous version in the path, so README links broke on every release).

**The kustomize install could not provision a host** (nobody noticed because the Helm chart is the only path CI exercised): no Service for the callback server although the manager's default `--bootstrap-url-base` names one; the serving certificate did not cover that name; the NetworkPolicy allowed neither `:8082` nor the metrics port the manager binds (`:8443`, not `:8080`). Fixed, plus: the Deployment is named `beskar7-controller-manager` like the chart's (docs, CI diagnostics and the smoke runner already assumed it; upgrading.md tells manifest installs to delete the old `controller-manager`), `containerPort: 8082` declared, `imagePullPolicy: IfNotPresent` (pinned tag; also what lets a kind-loaded image run).

**`make release-manifests` no longer runs `git checkout` on the kustomizations** to undo its VERSION stamping — that also discarded uncommitted edits to those files (it ate this branch's own change once). It stamps scratch copies and restores the originals.

**CI: new job `E2E clusterctl install`.** Same kind cluster and images as the Helm job, then: `make clusterctl-override` with the newest series from `metadata.yaml`, a clusterctl config that declares the provider and rewrites the image tag to the kind-loaded one via clusterctl's image overrides, `clusterctl init --infrastructure beskar7:v0.5.0 --config …` with `GOPROXY=off`, an assertion that the rendered Deployment has no unresolved `${…}`, then `make smoke`. Wired into `CI Success`. The Helm job is unchanged.

**Docs:** `docs/installation.md` "Install via clusterctl" (providers snippet, variable table, exposing the callback Service or running a callback-only manager, local repositories; the `clusterctl move` section now says a clusterctl install needs none of its caveats), README quick install, `docs/upgrading.md`, `docs/development-setup.md`, CHANGELOG.

## Naming for upstream

The contract requires providers outside `kubernetes-sigs` to register under `<github-org>-<name>` in the built-in list, i.e. `projectbeskar-beskar7`; clusterctl derives its component label from that name at install time (`infrastructure-projectbeskar-beskar7`), overriding the `infrastructure-beskar7` the CRDs carry, which is fine — the label only has to be consistent per install. Users of the config-file route keep `beskar7`. Worth deciding before the upstream issue; nothing in this PR depends on it.

## Verification

- `kustomize build config/default`: 21 objects, all carrying the clusterctl labels; callback Service `beskar7-controller-manager:8082`; certificate SANs for both Services; NetworkPolicy ingress 9443/8443/8081/8082.
- `make clusterctl-override VERSION=v0.5.0-check` into a scratch directory: components keep the variable, the kubectl manifest has none, kustomization files untouched afterwards.
- `go test ./test/contract/`, `golangci-lint`: clean. The new CI job is the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
