### PR TITLE
chore(release): v0.5.0 — API v1beta2, capb7-system, clusterctl-installable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [v0.5.0] - 2026-09-10
+
+A clean break from the `v0.4.x` line, with no in-place upgrade path — read
+`docs/upgrading.md` before touching an existing install. The API is
+`infrastructure.cluster.x-k8s.io/v1beta2`, the only served version (the
+`v1beta1` schema renamed, no conversion webhook); the controller is built
+against Cluster API v1.13 and needs a management cluster on Cluster API
+v1.11 or newer; the install namespace is `capb7-system` and every component
+is named `capb7-…`; every release now ships the clusterctl provider assets,
+so `clusterctl init --infrastructure beskar7` works, and `clusterctl move`
+discovers beskar7 objects. Behind the scenes: the callback-only manager mode
+for management clusters off the provisioning network, a bootstrap-credential
+reuse check backed by the per-host Secret, hosts turning `Available` waking
+the machines waiting for one, and the credential promotion window that
+re-minted tokens under an inspector's feet closed.
+
 ### Added
 
 - **Installable with `clusterctl init`.** Every release now publishes the two assets
@@ -1237,7 +1253,8 @@ For detailed implementation information, see the examples directory and document
 - CI: lint, tests, container build, CRD generation, Kind sanity checks.
 - Core controllers and CRDs for `PhysicalHost`, `Beskar7Machine`, `Beskar7Cluster`.
 
-[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.4.4...HEAD
+[Unreleased]: https://github.com/projectbeskar/beskar7/compare/v0.5.0...HEAD
+[v0.5.0]: https://github.com/projectbeskar/beskar7/compare/v0.4.4...v0.5.0
 [v0.4.4]: https://github.com/projectbeskar/beskar7/compare/v0.4.3...v0.4.4
 [v0.4.3]: https://github.com/projectbeskar/beskar7/compare/v0.4.2...v0.4.3
 [v0.4.2]: https://github.com/projectbeskar/beskar7/compare/v0.4.1...v0.4.2

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 KUSTOMIZE ?= kustomize
 
 # Image URL to use all building/pushing image targets
-VERSION ?= v0.4.4
+VERSION ?= v0.5.0
 IMAGE_REGISTRY ?= ghcr.io/projectbeskar/beskar7
 IMAGE_REPO ?= beskar7
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Kubernetes operator that implements the Cluster API infrastructure provider fo
 
 ## Current Status
 
-**Version:** v0.4.4 — patch release on the GA line (`v0.4.0` was the first GA)  
+**Version:** v0.5.0 — a clean break from the `v0.4.x` line: API `v1beta2`, install namespace `capb7-system`, installable with `clusterctl init` (`v0.4.0` was the first GA)  
 **API:** `infrastructure.cluster.x-k8s.io/v1beta2` is the only served version — the `v1beta1` schema renamed in place, with no conversion webhook: `v1beta1` CRDs and objects must be recreated (see [Upgrading](docs/upgrading.md)). From here the schema evolves **additive-only**.  
 **Contract:** controller↔inspector wire contract **v4.2, frozen** ([contract](docs/inspector-contract.md)). Pair with a `contract-v4.2` [inspector release](https://github.com/projectbeskar/beskar7-inspector/releases).  
 **Upgrading:** v0.4.0 is **not** compatible with v0.3.x, and the alpha series contains breaking API changes — see [Upgrading](docs/upgrading.md) and the [CHANGELOG](CHANGELOG.md).
@@ -62,7 +62,7 @@ clusterctl init --infrastructure beskar7   # v0.5.0 and later publish the cluste
 **Using Release Manifests:**
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.4/beskar7-manifests-v0.4.4.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.5.0/beskar7-manifests-v0.5.0.yaml
 ```
 
 See [Installation](docs/installation.md) for detailed install steps, or the [Quick Start](docs/quick-start.md) for the first provisioning flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,7 +38,8 @@ without conversion (see `docs/upgrading.md`).
 
 | Version | Supported |
 |---|---|
-| `v0.4.4` (latest) | ✅ |
+| `v0.5.0` (latest) | ✅ |
+| `v0.4.4` | ✅ |
 | `v0.4.3` | ✅ |
 | `v0.4.2` | ⚠️ upgrade — a released host cannot be provisioned again ([CHANGELOG](CHANGELOG.md)) |
 | `v0.4.1` | ⚠️ upgrade — also makes `kubectl apply` upgrades impossible |

--- a/charts/beskar7/Chart.yaml
+++ b/charts/beskar7/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: beskar7
 description: A Helm chart for Beskar7 - Cluster API Infrastructure Provider for Immutable Bare Metal
 type: application
-version: 0.4.4
-appVersion: "v0.4.4"
+version: 0.5.0
+appVersion: "v0.5.0"
 keywords:
   - cluster-api
   - infrastructure

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -281,8 +281,8 @@ trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
 
 1. **Create Release Tag** — the current release line is `v0.4.x` (GA); bump the patch for each release. Use a `vX.Y.Z` (or `vX.Y.Z-pre`) format the `release.yml` workflow recognises.
    ```bash
-   git tag v0.4.4
-   git push origin v0.4.4
+   git tag v0.5.0
+   git push origin v0.5.0
    ```
 
 2. **Automated Release** - GitHub Actions automatically:

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,7 +31,7 @@ kustomize is pulled by the Makefile when needed.
 make docker-build docker-push IMG=my-registry/my-repo:dev
 ```
 
-The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.4.4`. Override it to push to your own registry.
+The default `IMG` value in the Makefile is `ghcr.io/projectbeskar/beskar7/beskar7:v0.5.0`. Override it to push to your own registry.
 
 ## Regenerate CRDs and RBAC
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,7 +95,7 @@ To install a build of the current tree instead of a release, publish it into a c
 ## Install via release manifests
 
 ```bash
-kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.4.4/beskar7-manifests-v0.4.4.yaml
+kubectl apply -f https://github.com/projectbeskar/beskar7/releases/download/v0.5.0/beskar7-manifests-v0.5.0.yaml
 ```
 
 This applies CRDs, RBAC, and the controller deployment in a single manifest. The release manifest always uses the `capb7-system` namespace and the default `bootstrap.urlBase`. It is the clusterctl components file with the variables above resolved to their defaults; do not `kubectl apply` `infrastructure-components.yaml` itself — it keeps the `${…}` placeholders for `clusterctl init` to fill in.


### PR DESCRIPTION
## What

Version pointers for **v0.5.0**: Makefile `VERSION`, chart `version`/`appVersion`, README and installation download URL, development-setup image, the ci-cd tag example, the SECURITY table, and the CHANGELOG section (dated today) with its link table. Nothing else — `docs/upgrading.md` already carries the v0.4.4 → v0.5.0 procedure and `metadata.yaml` the 0.5 release series.

## Why

First release of the clean break: API `infrastructure.cluster.x-k8s.io/v1beta2` as the only served version (#170), Cluster API v1.13 / `api/core/v1beta2` (#162), install namespace `capb7-system` and `capb7-…` component names (#172), the clusterctl provider contract with `infrastructure-components.yaml` + `metadata.yaml` as release assets (#171), clusterctl labels on the CRDs (#167), plus the fixes since v0.4.4 (#163 wake-up, #164 credential reuse, #165 callback-only manager, #166 phantom webhooks, #168 promotion window).

## After merge

Tag the merge commit `v0.5.0` and push it: the release workflow builds and signs the images, attaches `infrastructure-components.yaml`, `metadata.yaml`, `beskar7-manifests-v0.5.0.yaml` and checksums to the GitHub release, and the chart workflow publishes chart 0.5.0. The lab rebuild on the released artifacts follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
