### PR TITLE
ci: replace Trivy with OSV-Scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,25 +55,36 @@ jobs:
           exit 1
         fi
 
-  # Job 2: Security Scanning
+  # Job 2: Dependency vulnerability scan (OSV-Scanner, https://google.github.io/osv-scanner/).
+  # A pull request is diffed against its base branch, so only a vulnerability the
+  # PR introduces fails the job. Pushes run a full scan that feeds the Security
+  # tab without blocking; osv-scanner-scheduled.yml repeats it weekly.
   security:
     name: Security Scanning
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: 'trivy-results.sarif'
+    if: github.event_name == 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+    with:
+      scan-args: |-
+        -r
+        ./
+
+  security-push:
+    name: Security Scanning (full)
+    if: github.event_name == 'push'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+    with:
+      scan-args: |-
+        -r
+        ./
+      fail-on-vuln: false
 
   # Job 3: Unit Tests
   test:
@@ -186,17 +197,37 @@ jobs:
         cache-to: type=gha,mode=max
         load: true  # Load the image to local Docker daemon for scanning
         
-    - name: Run container security scan
-      uses: aquasecurity/trivy-action@master
+    # OSV-Scanner runs as a container action without access to the Docker
+    # daemon, so the freshly built image is handed over as a docker-save archive.
+    - name: Export the image for scanning
+      run: docker save -o osv-image.tar "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test"
+
+    - name: Scan the container image with OSV-Scanner
+      uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+      continue-on-error: true # exits 1 on findings; the report below decides
       with:
-        image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test
-        format: 'sarif'
-        output: 'container-scan.sarif'
-        
+        scan-args: |-
+          scan
+          image
+          --archive
+          osv-image.tar
+          --format=json
+          --output=osv-image-results.json
+
+    - name: Convert the image scan to SARIF
+      uses: google/osv-scanner-action/osv-reporter-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+      with:
+        scan-args: |-
+          --new=osv-image-results.json
+          --output=osv-image-results.sarif
+          --gh-annotations=false
+          --fail-on-vuln=false
+
     - name: Upload container scan results
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: 'container-scan.sarif'
+        sarif_file: osv-image-results.sarif
+        category: osv-scanner-image
 
   # Job 6: Generate and Validate Manifests
   manifests:
@@ -615,13 +646,14 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, security, test, integration-test, container, manifests, e2e-setup, e2e-clusterctl]
+    needs: [lint, security, security-push, test, integration-test, container, manifests, e2e-setup, e2e-clusterctl]
     if: always()
     steps:
     - name: Check all jobs status
       run: |
         if [[ "${{ needs.lint.result }}" != "success" || \
-              "${{ needs.security.result }}" != "success" || \
+              ( "${{ needs.security.result }}" != "success" && "${{ needs.security.result }}" != "skipped" ) || \
+              ( "${{ needs.security-push.result }}" != "success" && "${{ needs.security-push.result }}" != "skipped" ) || \
               "${{ needs.test.result }}" != "success" || \
               "${{ needs.integration-test.result }}" != "success" || \
               "${{ needs.container.result }}" != "success" || \

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -1,0 +1,24 @@
+name: OSV-Scanner (scheduled)
+
+# A weekly full dependency scan of the default branch, so an advisory published
+# against code that has not changed still surfaces: the run turns red and the
+# findings land in the Security tab. Pull requests and pushes are scanned by
+# ci.yml; released images by release.yml.
+on:
+  schedule:
+    - cron: "12 12 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scan:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+    with:
+      scan-args: |-
+        -r
+        ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,31 +236,63 @@ jobs:
     name: Security Scan Released Image
     runs-on: ubuntu-latest
     needs: build-and-push
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+    # OSV-Scanner runs as a container action without access to the Docker
+    # daemon, so the released image is pulled and handed over as an archive.
+    - name: Pull and export the released image
+      run: |
+        image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}"
+        docker pull "${image}"
+        docker save -o osv-image.tar "${image}"
+
+    - name: Scan the released image with OSV-Scanner
+      uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+      continue-on-error: true # exits 1 on findings; the report is the deliverable
       with:
-        image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        
-    - name: Upload Trivy scan results
+        scan-args: |-
+          scan
+          image
+          --archive
+          osv-image.tar
+          --format=json
+          --output=osv-image-results.json
+
+    - name: Convert the scan to SARIF
+      uses: google/osv-scanner-action/osv-reporter-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+      with:
+        scan-args: |-
+          --new=osv-image-results.json
+          --output=osv-image-results.sarif
+          --gh-annotations=false
+          --fail-on-vuln=false
+
+    - name: Upload scan results to the Security tab
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: 'trivy-results.sarif'
-        
-    - name: Run Trivy vulnerability scanner (table format)
-      uses: aquasecurity/trivy-action@master
+        sarif_file: osv-image-results.sarif
+        category: osv-scanner-release-image
+
+    - name: Write the human-readable vulnerability report
+      uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+      continue-on-error: true
       with:
-        image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-        format: 'table'
-        output: 'trivy-report.txt'
-        
+        scan-args: |-
+          scan
+          image
+          --archive
+          osv-image.tar
+          --format=table
+          --output=osv-scanner-report.txt
+
     - name: Upload vulnerability report
       uses: actions/upload-artifact@v4
       with:
         name: vulnerability-report
-        path: trivy-report.txt
+        path: osv-scanner-report.txt
 
   # Job 5: Generate Release Artifacts
   generate-artifacts:
@@ -477,7 +509,7 @@ jobs:
           release-artifacts/metadata.yaml
           release-artifacts/checksums.txt
           sbom/sbom.spdx.json
-          vulnerability-report/trivy-report.txt
+          vulnerability-report/osv-scanner-report.txt
         token: ${{ secrets.GITHUB_TOKEN }}
 
   # Job 7: Update Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   was already `omitempty` and the `b7://<namespace>/<name>` format is unchanged. Affects Go
   importers of `api/v1beta2` only.
 
+- **CI: vulnerability scanning moved from Trivy to OSV-Scanner.** Pull requests are diffed against
+  their base branch and fail only on vulnerabilities they introduce; pushes to `main`, a weekly
+  scheduled run and the release image scan feed the Security tab. The release asset is now
+  `osv-scanner-report.txt` (was `trivy-report.txt`).
+
 ### Removed
 
 - **BREAKING: `Beskar7Machine.status.failureReason` and `status.failureMessage` are gone.** A

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -15,7 +15,7 @@ Runs on every push and pull request to `main` and `develop` branches.
 
 **Jobs:**
 - **Lint and Code Quality**: Go linting, formatting checks, and code quality analysis
-- **Security Scanning**: Vulnerability scanning with Gosec and Trivy
+- **Security Scanning**: dependency vulnerability scanning with OSV-Scanner (a pull request fails only on vulnerabilities it introduces)
 - **Unit Tests**: Multi-version Go testing with coverage reporting
 - **Integration Tests**: Full integration test suite
 - **Container Build**: Multi-arch Docker image building and security scanning
@@ -200,18 +200,17 @@ golangci-lint run --fix
 
 ### Security Scanning
 
-Multiple security tools are integrated:
+Vulnerability scanning uses [OSV-Scanner](https://google.github.io/osv-scanner/) against the [OSV](https://osv.dev) database:
 
-- **Gosec**: Go security checker
-- **Trivy**: Vulnerability scanner for code and containers
-- **CodeQL**: GitHub's semantic code analysis
+- **Pull requests**: the dependency scan is diffed against the base branch, so a PR fails only when it introduces a vulnerability (`Security Scanning` job). The container image built for the PR is scanned as well and reported to the Security tab without blocking.
+- **Pushes to `main`** and a **weekly schedule** (`.github/workflows/osv-scanner-scheduled.yml`): full dependency scans feed the Security tab; the weekly run fails when an advisory affects the tree.
+- **Releases**: the published image is scanned and `osv-scanner-report.txt` is attached to the GitHub release.
 
 ```bash
-# Run security scan locally
-gosec ./...
-
-# Scan container images
-trivy image ghcr.io/projectbeskar/beskar7/beskar7:latest
+# Run the same scans locally
+go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
+osv-scanner scan source -r .
+osv-scanner scan image ghcr.io/projectbeskar/beskar7/beskar7:latest
 ```
 
 ## Development Workflow

--- a/docs/security/configuration.md
+++ b/docs/security/configuration.md
@@ -196,7 +196,7 @@ The `Deployment` template (kustomize and Helm) sets `runAsNonRoot: true`, `runAs
 There is no built-in security-scanning or compliance-reporting CronJob. Use your platform's normal tooling:
 
 - Kubernetes audit logs from the kube-apiserver.
-- A workload-CVE scanner (e.g. Trivy, Grype) against the manager image.
+- A workload-CVE scanner (e.g. OSV-Scanner, Trivy, Grype) against the manager image.
 - A Pod Security Admission profile (`baseline` or `restricted`) on the `capb7-system` namespace.
 
 ## See also


### PR DESCRIPTION
## Replace Trivy with OSV-Scanner

Vulnerability scanning moves to [OSV-Scanner](https://google.github.io/osv-scanner/) v2.5.1 (`google/osv-scanner-action`, pinned to the `v2.5.1` tag commit) with an explicit policy; the Trivy jobs never failed on anything.

| Where | What runs | Fails when |
|---|---|---|
| Pull request (`Security Scanning`) | official diff workflow: base branch vs PR head on `go.mod` | the PR **introduces** a vulnerability |
| Push to `main`/`develop` (`Security Scanning (full)`) | full dependency scan → Security tab | never |
| Weekly + manual (`osv-scanner-scheduled.yml`, Mon 12:12 UTC) | full dependency scan → Security tab | any vulnerability affects the tree |
| `container` job | the PR's built image, scanned as a `docker save` archive → Security tab (`osv-scanner-image`) | never |
| Release `security-scan` | the published image → Security tab (`osv-scanner-release-image`) + `osv-scanner-report.txt` attached to the release (was `trivy-report.txt`) | never |

`ci-success` accepts whichever of the two source-scan jobs was skipped for the event.

### Notes
- The container action has no Docker daemon access, so images are handed over with `--archive`; its entrypoint passes arguments to `osv-scanner` without a subcommand, so the image scans spell out `scan image …` (verified with the pinned action image locally: JSON, SARIF via the reporter, and the table report all produced against the v0.5.0 image).
- Baseline as of today, visible in the Security tab once this lands: `google.golang.org/grpc v1.80.0` (indirect, 2 High) and `golang.org/x/text v0.38.0` in `go.mod`; the image additionally carries Go stdlib 1.25.9 advisories because the Dockerfile pins an older `golang:1.25` digest. None of these blocks a PR under the diff policy; the weekly run will be red until the toolchain/deps are bumped (separate PR).
- `actionlint` is clean for `ci.yml` and the scheduled workflow; its one complaint in `release.yml` (`steps.build.outputs.image-url`, line 23) predates this change.
- Docs: `docs/ci-cd-and-testing.md` (the section also dropped the Gosec/CodeQL claims, which no workflow implements), `docs/security/configuration.md`, CHANGELOG.
