### PR TITLE
fix(physicalhost): HostAvailable must read False while the host is claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   requires an explicit `spec.checks.unhealthyMachineConditions` entry keyed on `InfrastructureReady`;
   see the rewritten `examples/machinehealthcheck.yaml` and `docs/upgrading.md`.
 
+### Fixed
+
+- **`PhysicalHost`'s `HostAvailable` condition now reads `False` while the host is claimed.** It
+  was set `True` on the transition into `Available` and never flipped back, so a host that was
+  `InUse`, `Inspecting`, `Deploying` or `Ready` still advertised `HostAvailable=True`. The
+  controller now asserts it on every reconcile: `False` with the new reason `HostClaimed` while
+  `spec.consumerRef` is set, `True` with reason `HostAvailable` otherwise. Host selection never
+  read the condition (it filters on `status.state`), so this changes what `kubectl describe`
+  and `kubectl wait --for=condition=HostAvailable` report, nothing else.
+
 ## [v0.5.0] - 2026-09-10
 
 A clean break from the `v0.4.x` line, with no in-place upgrade path — read

--- a/api/v1beta2/physicalhost_types.go
+++ b/api/v1beta2/physicalhost_types.go
@@ -411,6 +411,10 @@ const (
 	// Available. The inspection described the run that just ended, not the
 	// hardware, so it must not carry into the next consumer's claim.
 	HostReleasedReason string = "HostReleased"
+	// HostClaimedReason marks HostAvailable=False for as long as a consumer
+	// holds the host (Spec.ConsumerRef is set). The condition returns to True
+	// with HostAvailableReason once the claim is released.
+	HostClaimedReason string = "HostClaimed"
 	// InsecureCABundleConflictReason is set when InsecureSkipVerify=true is
 	// combined with CABundleSecretRef != "" — the two are mutually exclusive
 	// (a CA bundle and "skip verification" together is incoherent). The

--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -352,12 +352,21 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 			logger.Info("Host claimed, transitioning to InUse", "consumer", physicalHost.Spec.ConsumerRef.Name)
 			r.updateStatus(physicalHost, infrav1.StateInUse, true, "")
 		}
+		// HostAvailable follows the claim, not the sub-state, so it is asserted
+		// on every claimed reconcile rather than on the InUse edge above: a
+		// claim that lands together with the inspect annotation goes straight
+		// to Inspecting and never crosses that edge. Re-asserting an unchanged
+		// status leaves lastTransitionTime alone.
+		setFalse(physicalHost, infrav1.HostAvailableCondition, infrav1.HostClaimedReason,
+			"Claimed by %s %s", physicalHost.Spec.ConsumerRef.Kind, physicalHost.Spec.ConsumerRef.Name)
 	} else {
 		if physicalHost.Status.State != infrav1.StateAvailable {
 			logger.Info("Host available, transitioning to Available")
 			r.updateStatus(physicalHost, infrav1.StateAvailable, true, "")
-			setTrue(physicalHost, infrav1.HostAvailableCondition, infrav1.HostAvailableReason)
 		}
+		// Same level-triggered shape as the claimed branch: True for as long
+		// as nobody holds the host.
+		setTrue(physicalHost, infrav1.HostAvailableCondition, infrav1.HostAvailableReason)
 	}
 
 	logger.Info("Reconciliation complete", "state", physicalHost.Status.State, "ready", physicalHost.Status.Ready)

--- a/controllers/physicalhost_controller_test.go
+++ b/controllers/physicalhost_controller_test.go
@@ -251,6 +251,11 @@ var _ = Describe("PhysicalHost Controller", func() {
 				g.Expect(got.Status.State).To(Equal(infrav1.StateInspecting))
 				g.Expect(got.Status.InspectionPhase).To(Equal(infrav1.InspectionPhaseBooting))
 				g.Expect(got.Status.InspectionTimestamp).NotTo(BeNil())
+				// The claim and the inspect request arrived in one patch, so the host
+				// went Available -> Inspecting without ever being InUse. HostAvailable
+				// must still read False: it follows the claim, not the InUse edge.
+				g.Expect(conditions.IsFalse(got, infrav1.HostAvailableCondition)).To(BeTrue(),
+					"a claimed host must not advertise HostAvailable=True, even one that skipped InUse")
 				// Annotation must be cleared so it is not acted on again.
 				g.Expect(got.Annotations).NotTo(HaveKey(InspectionRequestAnnotation))
 			}, Timeout, Interval).Should(Succeed())
@@ -365,6 +370,8 @@ var _ = Describe("PhysicalHost Controller", func() {
 					"InspectionPhase describes the finished run")
 				g.Expect(conditions.IsTrue(got, infrav1.HostInspectedCondition)).To(BeFalse(),
 					"HostInspected describes the finished run, not the hardware")
+				g.Expect(conditions.IsTrue(got, infrav1.HostAvailableCondition)).To(BeTrue(),
+					"a released host is available again")
 			}, Timeout, Interval).Should(Succeed())
 
 			By("A second consumer can claim it and start a fresh inspection")
@@ -394,6 +401,90 @@ var _ = Describe("PhysicalHost Controller", func() {
 				// the first consumer's run began.
 				g.Expect(got.Status.InspectionTimestamp.Time).To(BeTemporally("~", time.Now(), 2*time.Minute),
 					"the reclaimed host's inspection clock must start at the new claim")
+			}, Timeout, Interval).Should(Succeed())
+		})
+
+		// HostAvailable is a condition, not an event: it has to read False for
+		// as long as a consumer holds the host and True again once released.
+		// The controller used to set it True on the transition into Available
+		// and never flip it back, so a host that was InUse, Inspecting,
+		// Deploying or Ready kept advertising HostAvailable=True.
+		It("Should hold HostAvailable=False while the host is claimed and restore True on release", func() {
+			By("Creating the PhysicalHost resource and making it Available")
+			Expect(k8sClient.Create(ctx, physicalHost)).To(Succeed())
+
+			phLookupKey := types.NamespacedName{Name: physicalHost.Name, Namespace: physicalHost.Namespace}
+
+			_, err := reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				got := &infrav1.PhysicalHost{}
+				g.Expect(k8sClient.Get(ctx, phLookupKey, got)).To(Succeed())
+				g.Expect(got.Status.State).To(Equal(infrav1.StateAvailable))
+				g.Expect(conditions.IsTrue(got, infrav1.HostAvailableCondition)).To(BeTrue())
+			}, Timeout, Interval).Should(Succeed())
+
+			By("Claiming the host with a bare ConsumerRef, so it lands in InUse")
+			ph := &infrav1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, phLookupKey, ph)).To(Succeed())
+			claim := ph.DeepCopy()
+			claim.Spec.ConsumerRef = &corev1.ObjectReference{
+				Kind:       "Beskar7Machine",
+				APIVersion: InfrastructureAPIVersion,
+				Name:       "claimant",
+				Namespace:  ph.Namespace,
+			}
+			Expect(k8sClient.Patch(ctx, claim, client.MergeFrom(ph))).To(Succeed())
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			var claimedAt time.Time
+			Eventually(func(g Gomega) {
+				got := &infrav1.PhysicalHost{}
+				g.Expect(k8sClient.Get(ctx, phLookupKey, got)).To(Succeed())
+				g.Expect(got.Status.State).To(Equal(infrav1.StateInUse))
+				cond := conditions.Get(got, infrav1.HostAvailableCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse),
+					"a claimed host must not advertise HostAvailable=True")
+				g.Expect(cond.Reason).To(Equal(infrav1.HostClaimedReason))
+				g.Expect(cond.Message).To(ContainSubstring("claimant"))
+				claimedAt = cond.LastTransitionTime.Time
+			}, Timeout, Interval).Should(Succeed())
+
+			By("Reconciling again while still claimed: the condition is re-asserted, not re-transitioned")
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			stillClaimed := &infrav1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, phLookupKey, stillClaimed)).To(Succeed())
+			cond := conditions.Get(stillClaimed, infrav1.HostAvailableCondition)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.LastTransitionTime.Time).To(BeTemporally("==", claimedAt),
+				"re-asserting an unchanged status must not move lastTransitionTime")
+
+			By("Releasing the host: ConsumerRef = nil")
+			released := &infrav1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, phLookupKey, released)).To(Succeed())
+			relPatch := released.DeepCopy()
+			relPatch.Spec.ConsumerRef = nil
+			Expect(k8sClient.Patch(ctx, relPatch, client.MergeFrom(released))).To(Succeed())
+			_, err = reconcileWithTimeout(reconciler, phLookupKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				got := &infrav1.PhysicalHost{}
+				g.Expect(k8sClient.Get(ctx, phLookupKey, got)).To(Succeed())
+				g.Expect(got.Status.State).To(Equal(infrav1.StateAvailable))
+				cond := conditions.Get(got, infrav1.HostAvailableCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue),
+					"a released host is available again")
+				g.Expect(cond.Reason).To(Equal(infrav1.HostAvailableReason))
 			}, Timeout, Interval).Should(Succeed())
 		})
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -143,7 +143,7 @@ Per-host bootstrap fetch coordinates and the hashed bearer token used to authent
 | Type | Set by | True reason | False reasons |
 |---|---|---|---|
 | `RedfishConnectionReady` | `PhysicalHost` | `RedfishConnected` | `MissingCredentials` (covers a missing secret ref, a secret that doesn't exist, a `Get` error, or a missing `username`/`password` key — the controller collapses all credential-fetch failures to this one reason), `RedfishConnectionFailed`, `RedfishQueryFailed`, `InsecureCABundleConflict`, `CABundleFetchFailed`. |
-| `HostAvailable` | `PhysicalHost` | `HostAvailable` | — (set only on the transition into `Available`; the controller does not currently flip it back to `False` when the host is claimed). |
+| `HostAvailable` | `PhysicalHost` | `HostAvailable` | `HostClaimed` (a consumer holds the host — `spec.consumerRef` is set; the condition returns to `True` once the claim is released. It follows the claim only: BMC health is `RedfishConnectionReady`). |
 | `HostInspected` | `PhysicalHost` | `HostInspected` | `HostReleased` (the host went back to `Available`; the prior inspection describes a run that ended, not the hardware). |
 
 ### Example

--- a/docs/physicalhost.md
+++ b/docs/physicalhost.md
@@ -71,7 +71,7 @@ Native `metav1.Condition` (`status.conditions[]`) — no `severity` field, and a
 | Type | Meaning | True reason | Other reasons |
 |---|---|---|---|
 | `RedfishConnectionReady` | BMC reachable and authenticating successfully. | `RedfishConnected` | `MissingCredentials`, `SecretGetFailed`, `SecretNotFound`, `MissingSecretData`, `RedfishConnectionFailed`, `RedfishQueryFailed`, `InsecureCABundleConflict`, `CABundleFetchFailed`. |
-| `HostAvailable` | Host has no consumer claim. | `HostAvailable` | — (set only on the transition into `Available`; not currently flipped back to `False` on claim). |
+| `HostAvailable` | No consumer holds the host (`spec.consumerRef` is unset). Follows the claim only — BMC health is `RedfishConnectionReady`. | `HostAvailable` | `HostClaimed` (a consumer holds the host; back to `True` once the claim is released). |
 | `HostInspected` | An inspection report has been persisted. | `HostInspected` | `HostReleased` (host went back to `Available`; the prior run's inspection no longer describes it). |
 
 ## Deletion

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -167,7 +167,7 @@ kubectl patch physicalhost <name> --type=merge -p '{"metadata":{"finalizers":[]}
 `kubectl describe physicalhost <name>` shows the conditions list — native `metav1.Condition`, no `severity` field, every condition (including `True`) carries a `reason`. Key types:
 
 - `RedfishConnectionReady` — BMC connectivity. True reason `RedfishConnected`.
-- `HostAvailable` — host has no consumer. True reason `HostAvailable`.
+- `HostAvailable` — no consumer holds the host. True reason `HostAvailable`; `False (HostClaimed)` while `spec.consumerRef` is set.
 - `HostInspected` — inspection report has been persisted. True reason `HostInspected`; `False (HostReleased)` when a host returns to `Available` after a run.
 
 Full reason lists: [PhysicalHost → Conditions](physicalhost.md#conditions).

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -115,8 +115,12 @@ The practical differences:
   `InfrastructureReady` condition. See `docs/api-reference.md` § Conditions and the CAPI mirror.
 - **`PhysicalHost` gains no `Ready` or `Paused` condition** — it is not a CAPI contract resource
   and has no owning `Cluster`. Its three conditions (`RedfishConnectionReady`, `HostAvailable`,
-  `HostInspected`) are otherwise unchanged, now with a `reason` on their `True` state too
+  `HostInspected`) keep their types, now with a `reason` on their `True` state too
   (`RedfishConnected`, `HostAvailable`, `HostInspected`).
+- **`HostAvailable` now goes `False` (reason `HostClaimed`) while a consumer holds the host.**
+  Previously it was set `True` once, on the transition into `Available`, and never flipped back,
+  so a claimed host kept reporting `HostAvailable=True`. Anything that waits on the condition
+  (`kubectl wait --for=condition=HostAvailable`) now sees it drop on claim and return on release.
 
 ### `Beskar7Machine.status.failureReason` / `status.failureMessage` are gone
 


### PR DESCRIPTION
## The gap

`HostAvailable` had exactly one call site — `setTrue(...)` on the transition into `StateAvailable` — and no `setFalse` anywhere in the package. Once a host had been `Available` once, the condition stayed `True` forever: `kubectl describe physicalhost` and `kubectl wait --for=condition=HostAvailable` reported a host as free while a consumer held it, through `InUse`, `Inspecting`, `Deploying` and `Ready`.

## Not deliberate

The condition originally had a full lifecycle — `MarkTrue` when free, `conditions.Delete` when consumed, `MarkFalse` on deletion and on Redfish query failures. Commit 944d1c5 ("remove redfish virtualmedia", 2025-11-26) removed every `MarkFalse`/`Delete` call and kept the single `MarkTrue`. The commit is about virtual media; this looks like collateral damage rather than a narrowing anyone chose.

Not related to the native-conditions work in #174 — that changed the type shape (`clusterv1.Conditions` → `[]metav1.Condition`) and added the True-state reason constant, not this behavior.

## The fix

Assert the condition level-triggered on every reconcile: `False` with the new reason `HostClaimed` while `spec.consumerRef` is set, `True` with reason `HostAvailable` otherwise.

**Deliberately not on the `InUse` edge.** A claim that arrives in the same patch as the inspect annotation goes `Available` → `Inspecting` and never crosses that edge, so an edge-triggered `setFalse` would miss exactly the hosts a real `Beskar7Machine` claim produces. The existing "drive state transitions" spec takes that path. Re-asserting an unchanged status leaves `lastTransitionTime` alone, via apimachinery's `meta.SetStatusCondition`.

**Scope of the condition.** It tracks the claim only. A host with an unreachable BMC keeps `HostAvailable=True` and reports the outage through `RedfishConnectionReady`, so the three conditions stay orthogonal. The pre-944d1c5 code overlapped them on Redfish failures; that is not restored.

## Blast radius

Nothing reads the condition. Host selection filters on `status.state` plus the consumer ref, and the metrics count state too. No CRD schema change — a new reason constant, not a new field. This changes what operators see and nothing else.

## Tests

- New spec: bare claim → `InUse` with `False`/`HostClaimed` and the consumer name in the message, a second reconcile that does not move `lastTransitionTime`, then release restoring `True`/`HostAvailable`.
- Two assertions added to existing specs: `False` while `Inspecting` after a combined claim-and-inspect patch (the edge-skipping path), and `True` again after release.
- With the controller change reverted, both claimed-host specs fail on the new assertions.

## Verification

| Gate | Result |
|---|---|
| `go test ./...` | pass |
| `go test -race ./...` | pass |
| `golangci-lint run` (CI-pinned v2.12.2) | 0 issues |
| `make manifests` | no drift |
| `go vet -tags=integration ./test/integration/...` | pass |
| `kustomize build config/default`, `helm template` | pass |

## Docs

Condition tables in `docs/physicalhost.md`, `docs/api-reference.md` and `docs/state-management.md` now describe the real behavior instead of documenting the gap; `docs/upgrading.md` gains a v0.6.0 note for anyone waiting on the condition; `CHANGELOG.md` gains a `Fixed` entry under `Unreleased`.

## Follow-up, not in this PR

A claimed host that the provision-failed callback or the inspection timeout moves to `StateError` is not in the claimed-branch guard list, so the same reconcile appears to rewrite it to `InUse` and clear `ErrorMessage` before the deferred patch persists anything. The D-016 specs call the handler directly and never run the state block, so no test covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)