### PR TITLE
fix(images): pin the mock images to the same Go builder as the manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   `cel-go` ahead of the 0.26.0 `k8s.io/apiserver` v0.35.4 pins.
   `sigs.k8s.io/cluster-api` v1.13.4 and `sigs.k8s.io/controller-runtime` v0.23.3 are unchanged.
 
+- **The two published mock images no longer build on a stale Go.** `Dockerfile.mock-redfish` and
+  `Dockerfile.mock-inspector` still pinned the May `golang:1.25` digest after the manager's was
+  refreshed, so the release workflow would have published `mock-redfish` and `mock-inspector`
+  carrying the go1.25.9 standard-library advisories while the manager image was clean. All three
+  Dockerfiles now pin the same go1.25.14 builder, which is what their "same pins as the main
+  Dockerfile" comment already claimed. Neither image is scanned by CI, which is why this did not
+  show up in the baseline.
+
 ### Fixed
 
 - **A BMC that is briefly unreachable no longer strands its `PhysicalHost` in `Error` for minutes.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,14 +57,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   `cel-go` ahead of the 0.26.0 `k8s.io/apiserver` v0.35.4 pins.
   `sigs.k8s.io/cluster-api` v1.13.4 and `sigs.k8s.io/controller-runtime` v0.23.3 are unchanged.
 
-- **The two published mock images no longer build on a stale Go.** `Dockerfile.mock-redfish` and
-  `Dockerfile.mock-inspector` still pinned the May `golang:1.25` digest after the manager's was
-  refreshed, so the release workflow would have published `mock-redfish` and `mock-inspector`
-  carrying the go1.25.9 standard-library advisories while the manager image was clean. All three
-  Dockerfiles now pin the same go1.25.14 builder, which is what their "same pins as the main
-  Dockerfile" comment already claimed. Neither image is scanned by CI, which is why this did not
-  show up in the baseline.
-
 ### Fixed
 
 - **A BMC that is briefly unreachable no longer strands its `PhysicalHost` in `Error` for minutes.**
@@ -103,6 +95,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   `spec.consumerRef` is set, `True` with reason `HostAvailable` otherwise. Host selection never
   read the condition (it filters on `status.state`), so this changes what `kubectl describe`
   and `kubectl wait --for=condition=HostAvailable` report, nothing else.
+- **The two published mock images no longer build on a stale Go.** `Dockerfile.mock-redfish` and
+  `Dockerfile.mock-inspector` still pinned the May `golang:1.25` digest after the manager's was
+  refreshed, so the release workflow would have published `mock-redfish` and `mock-inspector`
+  carrying the go1.25.9 standard-library advisories while the manager image was clean. All three
+  Dockerfiles now pin the same go1.25.14 builder, which is what their "same pins as the main
+  Dockerfile" comment already claimed. Neither image is scanned by CI, which is why this did not
+  show up in the baseline.
 
 ### Removed
 

--- a/Dockerfile.mock-inspector
+++ b/Dockerfile.mock-inspector
@@ -1,8 +1,8 @@
 # Build the mock-inspector binary.
 # Base images are pinned by digest — same pins as the main Dockerfile.
 # To refresh: see the digest-update instructions in Dockerfile.
-# golang:1.25 (refreshed 2026-05-03)
-FROM golang:1.25@sha256:8a7adc288b77e9b787cd2695029eb54d10ae80571b21d44fed68d067ad0a9c96 as builder
+# golang:1.25 (refreshed 2026-09-10) — go1.25.14
+FROM golang:1.25@sha256:699337d620559a59b4a2bb298ad59611e535d2ee755a34cf2d2a98f37578dc80 as builder
 WORKDIR /workspace
 
 COPY go.mod go.mod

--- a/Dockerfile.mock-redfish
+++ b/Dockerfile.mock-redfish
@@ -1,8 +1,8 @@
 # Build the mock-redfish binary.
 # Base images are pinned by digest — same pins as the main Dockerfile.
 # To refresh: see the digest-update instructions in Dockerfile.
-# golang:1.25 (refreshed 2026-05-03)
-FROM golang:1.25@sha256:8a7adc288b77e9b787cd2695029eb54d10ae80571b21d44fed68d067ad0a9c96 as builder
+# golang:1.25 (refreshed 2026-09-10) — go1.25.14
+FROM golang:1.25@sha256:699337d620559a59b4a2bb298ad59611e535d2ee755a34cf2d2a98f37578dc80 as builder
 WORKDIR /workspace
 
 COPY go.mod go.mod


### PR DESCRIPTION
## Pin the mock images to the same Go builder as the manager

Follow-up to the gap I raised on #178. That PR refreshed the manager's builder digest to go1.25.14 but left the other two:

```
Dockerfile                   golang:1.25@sha256:699337d62055   (go1.25.14)
Dockerfile.mock-redfish      golang:1.25@sha256:8a7adc288b77   (go1.25.9, May)
Dockerfile.mock-inspector    golang:1.25@sha256:8a7adc288b77   (go1.25.9, May)
```

The release workflow builds both with `push: true`, so cutting `v0.6.0` as things stood would publish `mock-redfish` and `mock-inspector` carrying the full set of go1.25.9 standard-library advisories while the manager image was clean. Their own header comment already says "same pins as the main Dockerfile", so this restores an invariant rather than inventing one.

Why it escaped the baseline: CI and the release workflow only scan the manager image. Neither mock image is scanned anywhere, so both read as clean by omission.

### Verification
Built each image from this branch and scanned the archive with OSV-Scanner v2.5.1: both report `No issues found`. The previous digest reported the go1.25.9 advisory set.

Worth noting that with `toolchain go1.25.14` now in `go.mod`, the stale images were also downloading a toolchain at build time instead of using the one in the image.

#179 adds the Dependabot `docker` entry that would have kept all three in step.
