### PR TITLE
ci: scope Dependabot to the updates that are safe to take routinely

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,22 @@ updates:
         patterns:
           - "*"
     ignore:
+      # Majors are a project, not a bot merge.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # The Kubernetes and Cluster API packages are pre-1.0, so for them a minor
+      # bump IS the breaking bump — and it only works when cluster-api moves
+      # with them. Dependabot proposed k8s.io/* 0.35.4 → 0.37.0 with
+      # controller-runtime 0.23.3 → 0.25.0 while cluster-api stayed on v1.13.4,
+      # which is precisely the combination that does not hold together. Patch
+      # updates still come through, so security fixes within a minor are not
+      # blocked; moving the set is a deliberate piece of work (it was #162).
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io/cluster-api"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types: ["version-update:semver-minor"]
 
   # Base images. Covers all three Dockerfiles in the repository root: the
   # manager, and the mock-redfish and mock-inspector images that the release
@@ -52,6 +66,17 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore(images)"
+    ignore:
+      # Digest refreshes only, which is the drift this entry exists to catch.
+      # Moving the Go minor version is something else entirely: it changes what
+      # the release binary is built with, and it has to move `go` / `toolchain`
+      # in go.mod and CI's `go-version` in the same breath or the image builds
+      # on a toolchain nothing tested. Dependabot's first run proposed
+      # golang:1.25 → 1.27 on its own, which is the case for this rule.
+      - dependency-name: "golang"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   # Workflow actions, including the ones pinned by commit (OSV-Scanner and
   # cosign-installer); Dependabot rewrites the pin and its version comment
@@ -69,3 +94,13 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      # A major action bump is a behaviour change, and several of these actions
+      # carry the release: the artifact upload/download pair moves the release
+      # assets between jobs, and docker/build-push-action pushes the images.
+      # Dependabot's first run bundled twelve majors into one pull request
+      # (setup-go v5 → v7, upload-artifact v4 → v7, build-push-action v5 → v7,
+      # codecov v4 → v7 …), which is not reviewable as a unit. Minors and
+      # patches within a major still flow; majors are a deliberate pass.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   excluded, the digest-pinned images in all three Dockerfiles, and the workflow actions. Added
   after a four-month-stale builder digest carried Go standard-library advisories into a release.
 
+- **Dependabot is scoped to the updates that are safe to take routinely.** Its first run showed
+  why: it proposed `golang:1.25` → `1.27` in the Dockerfiles with nothing moving `go.mod` or CI's
+  `go-version`, `k8s.io/*` 0.35.4 → 0.37.0 with `controller-runtime` 0.25.0 while `cluster-api`
+  stayed on v1.13.4, and twelve major action bumps in one pull request. Base images are now limited
+  to digest refreshes, the pre-1.0 Kubernetes and Cluster API minors are excluded alongside all
+  majors, and action majors are excluded; patch and minor updates still flow.
+
 ### Fixed
 
 - **A BMC that is briefly unreachable no longer strands its `PhysicalHost` in `Error` for minutes.**

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -207,9 +207,14 @@ Vulnerability scanning uses [OSV-Scanner](https://google.github.io/osv-scanner/)
 - **Releases**: the published image is scanned and `osv-scanner-report.txt` is attached to the GitHub release.
 
 Dependency and base-image updates are proposed weekly by Dependabot
-(`.github/dependabot.yml`): Go modules (Kubernetes and Cluster API packages grouped, since they
-must move together; major bumps excluded), the digest-pinned base images in all three Dockerfiles,
-and the workflow actions including the commit-pinned ones.
+(`.github/dependabot.yml`). It is deliberately scoped to the updates that are safe to take
+routinely, so anything that changes a contract stays a human decision:
+
+| Entry | Proposes | Left to a person |
+|---|---|---|
+| `gomod` | patch and minor updates, Kubernetes and Cluster API grouped because they must move together | all majors; and minors of `k8s.io/*`, `cluster-api` and `controller-runtime`, which are pre-1.0 so a minor is the breaking bump |
+| `docker` | digest refreshes for the pinned `golang` and `distroless` images in all three Dockerfiles | the Go minor version, which has to move with `go`/`toolchain` in `go.mod` and CI's `go-version` |
+| `github-actions` | minor and patch updates, including the commit-pinned actions | majors, since several of these actions carry the release assets and images |
 
 ```bash
 # Run the same scans locally


### PR DESCRIPTION
## Scope Dependabot to the updates that are safe to take routinely

#179 turned Dependabot on. Its first run, minutes later, opened four pull requests, and three of them are changes no bot should decide on its own. This narrows the config; it does not turn anything off.

| Pull request | What it proposed | Why that is not routine |
|---|---|---|
| #182 | `golang:1.25` → `1.27` in all three Dockerfiles | Nothing moves `go 1.25.0` / `toolchain go1.25.14` in `go.mod` or CI's `go-version: '1.25'`, so the release binary would be built on a toolchain nothing tested. #178 also held `x/text` and `x/mod` back precisely because newer versions need Go ≥ 1.26 — so the Go move is worth doing, deliberately, together. |
| #183 | `k8s.io/*` 0.35.4 → 0.37.0 and `controller-runtime` 0.23.3 → 0.25.0, with `cluster-api` staying on v1.13.4 | These are pre-1.0, so a minor **is** the breaking bump, and the set only holds together when `cluster-api` moves with it. That was #162, a multi-PR project. |
| #185 | twelve major action bumps in one pull request (`setup-go` v5→v7, `upload-artifact` v4→v7, `build-push-action` v5→v7, `codecov` v4→v7, …) | The artifact upload/download pair moves the release assets between jobs and `build-push-action` pushes the images. Twelve majors is not reviewable as a unit. |
| #184 | ginkgo, gomega, prometheus, logr, x/time, protobuf | This one is exactly what the config is for. Nothing to change. |

### What changes

- **`docker`** — digest refreshes only, which is the drift the entry exists to catch. The Go minor version is excluded.
- **`gomod`** — all majors excluded as before, plus minors of `k8s.io/*`, `cluster-api` and `controller-runtime`. Patch updates still flow, so a security fix inside a minor is not blocked.
- **`github-actions`** — majors excluded. Minors and patches within a major still flow.

### Suggested disposition of the open four

Close #182, #183 and #185; they will not be reopened once this lands. Let #184 run CI and merge it on its own merits.

Two follow-ups worth doing deliberately rather than by bot, and I am happy to take either: moving the project to a newer Go (go.mod, CI and the images together, which also unblocks `x/text` and `x/mod`), and a reviewed pass over the action majors.
