### PR TITLE
chore: move to Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.27'
         
     - name: Install dependencies
       run: |
         go mod download
         # Pin to a CI-known-good v2 version. The v2 module path includes /v2/.
-        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+        go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2
 
     - name: Run golangci-lint
       run: golangci-lint run --timeout=5m
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25']
+        go-version: ['1.27']
     steps:
     - uses: actions/checkout@v4
     
@@ -159,7 +159,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.27'
         
     - name: Install dependencies
       run: go mod download
@@ -239,7 +239,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.27'
         
     - name: Install dependencies
       run: |
@@ -474,7 +474,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.27'
         
     - name: Run benchmarks
       run: |
@@ -511,7 +511,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.27'
 
     - name: Install kustomize and controller-gen
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,7 +305,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25'
+        go-version: '1.27'
         
     - name: Install dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   excluded, the digest-pinned images in all three Dockerfiles, and the workflow actions. Added
   after a four-month-stale builder digest carried Go standard-library advisories into a release.
 
+- **Go 1.27.** `go.mod` moves to `go 1.27.0` / `toolchain go1.27.1`, the `golang` builder in all
+  three Dockerfiles to the `1.27` tag (go1.27.1) by digest, and every `go-version` in CI and the
+  release workflow to `1.27`. This also lifts the constraint that held `golang.org/x/text` at 0.41.0
+  and `golang.org/x/mod` at 0.40.0, whose newer releases require Go ≥ 1.26.
+  `golangci-lint` moves with it, to **v2.13.2**: v2.12.2 cannot analyse a Go 1.27 tree at all — its
+  bundled staticcheck (honnef.co/go/tools v0.7.0) panics in the IR builder on `*ast.KeyValueExpr`,
+  so the lint job would crash rather than report. v2.13.2 carries v0.8.1 and reports cleanly.
+  `go mod tidy` under 1.27 regroups the `require` blocks; no dependency version changed.
+
 ### Fixed
 
 - **A BMC that is briefly unreachable no longer strands its `PhysicalHost` in `Error` for minutes.**

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # supply-chain provenance explicit. To bump: pull the new tag and run
 #   docker inspect <tag> --format '{{index .RepoDigests 0}}'
 # then update both the digest and the human-readable tag comment below.
-# golang:1.25 (refreshed 2026-09-10) — go1.25.14
-FROM golang:1.25@sha256:699337d620559a59b4a2bb298ad59611e535d2ee755a34cf2d2a98f37578dc80 as builder
+# golang:1.27 (refreshed 2026-09-10) — go1.27.1
+FROM golang:1.27@sha256:f44f6e88636cfb311f9ebace870ded69d943f227bb3cb27d32ffd84ea18c43ea as builder
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/Dockerfile.mock-inspector
+++ b/Dockerfile.mock-inspector
@@ -1,8 +1,8 @@
 # Build the mock-inspector binary.
 # Base images are pinned by digest — same pins as the main Dockerfile.
 # To refresh: see the digest-update instructions in Dockerfile.
-# golang:1.25 (refreshed 2026-09-10) — go1.25.14
-FROM golang:1.25@sha256:699337d620559a59b4a2bb298ad59611e535d2ee755a34cf2d2a98f37578dc80 as builder
+# golang:1.27 (refreshed 2026-09-10) — go1.27.1
+FROM golang:1.27@sha256:f44f6e88636cfb311f9ebace870ded69d943f227bb3cb27d32ffd84ea18c43ea as builder
 WORKDIR /workspace
 
 COPY go.mod go.mod

--- a/Dockerfile.mock-redfish
+++ b/Dockerfile.mock-redfish
@@ -1,8 +1,8 @@
 # Build the mock-redfish binary.
 # Base images are pinned by digest — same pins as the main Dockerfile.
 # To refresh: see the digest-update instructions in Dockerfile.
-# golang:1.25 (refreshed 2026-09-10) — go1.25.14
-FROM golang:1.25@sha256:699337d620559a59b4a2bb298ad59611e535d2ee755a34cf2d2a98f37578dc80 as builder
+# golang:1.27 (refreshed 2026-09-10) — go1.27.1
+FROM golang:1.27@sha256:f44f6e88636cfb311f9ebace870ded69d943f227bb3cb27d32ffd84ea18c43ea as builder
 WORKDIR /workspace
 
 COPY go.mod go.mod

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install-controller-gen:
 # schema; this target installs the matching v2 binary so local lint matches
 # CI. The v2 module path includes /v2/.
 GOLANGCI_LINT = $(GOBIN)/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT_VERSION ?= v2.13.2
 install-golangci-lint:
 	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 

--- a/docs/ci-cd-and-testing.md
+++ b/docs/ci-cd-and-testing.md
@@ -226,7 +226,7 @@ osv-scanner scan image ghcr.io/projectbeskar/beskar7/beskar7:latest
    ```bash
    # Install development dependencies
    make install-controller-gen
-   go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2  # the version CI pins
    ```
 
 2. **Run Tests**

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -6,7 +6,7 @@ This page covers building Beskar7 from source and deploying it into a developmen
 
 ## Prerequisites
 
-- Go 1.25 (matches `go.mod` and the CI toolchain in `.github/workflows/ci.yml`)
+- Go 1.27 (matches `go.mod` and the CI toolchain in `.github/workflows/ci.yml`)
 - Docker with `buildx` configured for multi-arch builds:
   ```bash
   docker buildx create --use

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -150,7 +150,7 @@ Source: `charts/beskar7/templates/networkpolicy.yaml`.
 The Dockerfile uses a multi-stage build with `CGO_ENABLED=0` and a distroless `nonroot` runtime base, both pinned by digest:
 
 ```Dockerfile
-FROM golang:1.25@sha256:8a7adc288b77e9b787cd2695029eb54d10ae80571b21d44fed68d067ad0a9c96 as builder
+FROM golang:1.27@sha256:f44f6e88636cfb311f9ebace870ded69d943f227bb3cb27d32ffd84ea18c43ea as builder
 ...
 FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,36 +1,68 @@
 module github.com/projectbeskar/beskar7
 
-go 1.25.0
+go 1.27.0
 
-toolchain go1.25.14
+toolchain go1.27.1
 
 require (
+	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
+	github.com/stmcginnis/gofish v0.20.0
+	golang.org/x/time v0.11.0
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
+	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/cluster-api v1.13.4
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
 	cel.dev/expr v0.25.2 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
+	github.com/go-openapi/jsonpointer v0.21.1 // indirect
+	github.com/go-openapi/jsonreference v0.21.0 // indirect
+	github.com/go-openapi/swag v0.23.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gobuffalo/flect v1.0.3 // indirect
+	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.30.0 // indirect
+	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/common v0.66.1 // indirect
+	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
@@ -40,71 +72,36 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect
 	golang.org/x/mod v0.40.0 // indirect
-	golang.org/x/tools v0.49.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.83.2 // indirect
-	k8s.io/apiserver v0.35.4 // indirect
-	k8s.io/component-base v0.35.4 // indirect
-	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-)
-
-replace github.com/projectbeskar/beskar7 => ./
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
-	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3
-	github.com/go-logr/zapr v1.3.0 // indirect
-	github.com/go-openapi/jsonpointer v0.21.1 // indirect
-	github.com/go-openapi/jsonreference v0.21.0 // indirect
-	github.com/go-openapi/swag v0.23.1 // indirect
-	github.com/google/btree v1.1.3 // indirect
-	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/mailru/easyjson v0.9.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_golang v1.23.2
-	github.com/prometheus/client_model v0.6.2
-	github.com/prometheus/common v0.66.1 // indirect
-	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/stmcginnis/gofish v0.20.0
-	github.com/x448/float16 v0.8.4 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.1 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
-	golang.org/x/time v0.11.0
+	golang.org/x/tools v0.49.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/grpc v1.83.2 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.4 // indirect
+	k8s.io/apiserver v0.35.4 // indirect
+	k8s.io/component-base v0.35.4 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/yaml v1.6.0
+	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )
+
+replace github.com/projectbeskar/beskar7 => ./


### PR DESCRIPTION
## Move to Go 1.27

Go 1.27.1 is current, 1.26.8 is the previous release, and this project was on 1.25. Everything that names a Go version moves together, which is the whole point: #182 showed what happens when only the image moves, and the release would have been built on a toolchain nothing tested.

| Where | From | To |
|---|---|---|
| `go.mod` | `go 1.25.0`, `toolchain go1.25.14` | `go 1.27.0`, `toolchain go1.27.1` |
| `Dockerfile`, `Dockerfile.mock-redfish`, `Dockerfile.mock-inspector` | `golang:1.25` (go1.25.14) | `golang:1.27` by digest (go1.27.1, pulled and verified) |
| `ci.yml` (6 jobs) and `release.yml` | `go-version: '1.25'` | `'1.27'` |
| `docs/development-setup.md`, `docs/security/README.md` | Go 1.25, and a base-image example still showing the May digest | Go 1.27, current digest |

### golangci-lint has to move with it

Not a tidy-up bundled in — a hard blocker. The pinned **v2.12.2 cannot analyse a Go 1.27 tree at all**: its bundled staticcheck (`honnef.co/go/tools v0.7.0`) panics in the IR builder on `*ast.KeyValueExpr` and the run aborts, so the lint job would crash rather than report:

```
level=error msg="Running error: can't run linter goanalysis_metalinter
goanalysis_metalinter: fact_purity: package \"poll\": interface conversion: interface {} is nil, not *buildir.IR"
```

**v2.13.2** carries `honnef.co/go/tools v0.8.1` and reports `0 issues` here. The pin moves in the Makefile and `ci.yml`. While there: `docs/ci-cd-and-testing.md` told contributors to install `@latest`, which is exactly how a local linter ends up disagreeing with CI, so it now names the pinned version.

### What this unblocks

#178 had to hold `golang.org/x/text` at 0.41.0 and `golang.org/x/mod` at 0.40.0 because their newer releases need Go ≥ 1.26. That constraint is gone. I have deliberately **not** bundled those bumps here — Dependabot will now propose them on its own, and #186 keeps that in the safe lane.

### Verification, all under go1.27.1

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./test/...`
- `go test ./... -race -count=1` — all packages pass; **282 of 282** envtest specs
- `make manifests` idempotent, chart CRDs in sync
- the manager image builds on 1.27 and an archive scan reports **no findings**
- lint clean with v2.13.2 installed the way CI installs it, cold cache

`go mod tidy` under 1.27 regroups the `require` blocks, which is most of the `go.mod` diff. **No dependency version changed** — I checked that explicitly rather than eyeballing it.

### One note for anyone building locally

A `~/go/bin/golangci-lint` built with Go 1.26 will panic on this tree even at v2.13.2's version number; it is the Go it was compiled with that matters as much as the version. Reinstall it with the 1.27 toolchain.
