### PR TITLE
fix(boot): stop fresh boot nonces inheriting an earlier nonce's consume record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,29 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   `Error` no longer yields to an inspection request either: an `inspect-complete` the machine sent
   again, having read the host before its first one was applied, used to put a host whose deployment
   had just been reported failed back in `Deploying`. The inspector sees `202` exactly as before.
+- **A re-claimed host's boot nonce is consumed like its first one.** `/boot` records a nonce's
+  consume in `status.bootstrap.bootNonceConsumedAt`, which nothing clears, and a released host keeps
+  `status.bootstrap` for its next claim. From a host's second provisioning cycle on — a re-claim
+  after release, a `MachineHealthCheck` replacement — every fresh nonce inherited the record its
+  first boot left. `/boot` took the fresh nonce for one it had already consumed and served it
+  without recording anything, so the optimistic-locked single-use write never happened for it and
+  the record kept the first boot's time. The `Beskar7Machine` counted the fresh nonce spent as soon
+  as the host had taken it up, so triggering inspection again in that cycle minted over a nonce the
+  operator's boot service may already have handed out. The record now names the nonce it describes,
+  in the new `status.bootstrap.bootNonceConsumedHash`, and counts only while that matches
+  `bootNonceHash`. `/boot` is still its only writer (D-010), in the same patch. Clearing the record
+  when a new nonce is promoted was the alternative, and was rejected: the `PhysicalHost`
+  reconciler's status patch carries no `resourceVersion`, so a pass working from a stale cache could
+  erase a consume `/boot` had just recorded and leave a used nonce reusable. A retry with the same
+  nonce inside its 10-minute lifetime still gets the same script, on the first cycle and every later
+  one (contract §4.1). Two related fixes: after a conflict on its consume patch, `/boot` verifies
+  the nonce again before it takes the record it reads back as a lost race, so it never serves a
+  nonce a newer mint has replaced; and the `Beskar7Machine` no longer takes a consumed nonce for
+  reusable while the host has yet to clear its `boot-nonce` annotation, which it does one pass after
+  promoting the hash. A record written by an earlier release has no hash. `/boot` records the
+  advertised nonce's consume afresh, and the `Beskar7Machine` does not reuse a nonce such a record
+  might describe, so hosts provisioned before the upgrade need nothing, and a callback-only instance
+  still on the previous release keeps the old behaviour until it is upgraded.
 - **`hack/smoke/run.sh` no longer creates a `PhysicalHost` against a mock BMC that cannot yet
   answer.** Layer 3 applied the mock manifest, then patched the image with `kubectl set image`,
   which starts a second rollout; `kubectl rollout status` returns as soon as the new pod is Ready,

--- a/api/v1beta2/physicalhost_types.go
+++ b/api/v1beta2/physicalhost_types.go
@@ -368,20 +368,31 @@ type BootstrapStatus struct {
 	// BootNonceExpiresAt is the time the current boot nonce stops being
 	// accepted. Defaults to mint time + 10 min (BootNonceLifetime, D-009).
 	// A shorter window than the bearer-token lifetime is intentional: the
-	// nonce is single-use and consumed at first boot, so a long window only
-	// widens the race window for a co-located attacker.
+	// nonce is consumed at first boot and never reused for another boot, but
+	// /boot serves a retry of it until it expires (contract §4.1), so a long
+	// window only widens the race window for a co-located attacker.
 	// +optional
 	BootNonceExpiresAt *metav1.Time `json:"bootNonceExpiresAt,omitempty"`
 
-	// BootNonceConsumedAt is the timestamp at which the boot nonce was
-	// single-use consumed by the GET /api/v1/boot handler (D-010). Nil
-	// until that handler fires. Once set, the nonce is permanently spent:
-	// no controller in this PR clears or re-uses it. A new nonce is minted
-	// on every re-provision cycle (triggerInspection detects ConsumedAt != nil
-	// and forces a fresh mint). Written exclusively by the /boot handler
-	// (D-010) — nothing in this PR writes this field.
+	// BootNonceConsumedAt is the timestamp at which the GET /api/v1/boot
+	// handler consumed the boot nonce named by BootNonceConsumedHash (D-010).
+	// Nil until that handler first fires. Neither field is ever cleared: a
+	// nonce minted afterwards has a different hash, so the record does not
+	// apply to it, and the handler records that nonce's consume over it on
+	// its first fetch. A consumed nonce is never reused: triggerInspection
+	// mints a fresh one. Written exclusively by the /boot handler (D-010).
 	// +optional
 	BootNonceConsumedAt *metav1.Time `json:"bootNonceConsumedAt,omitempty"`
+
+	// BootNonceConsumedHash is the BootNonceHash of the nonce that
+	// BootNonceConsumedAt records the consume of. The advertised nonce has
+	// been consumed only while the two hashes match. Written by the /boot
+	// handler in the same patch as BootNonceConsumedAt (D-010). Empty
+	// alongside a set BootNonceConsumedAt when a handler from before this
+	// field existed wrote the record; which nonce it describes is then
+	// unknown.
+	// +optional
+	BootNonceConsumedHash string `json:"bootNonceConsumedHash,omitempty"`
 }
 
 // Redfish conditions and reasons - simplified for power management only

--- a/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
+++ b/charts/beskar7/crds/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
@@ -112,6 +112,8 @@ spec:
                   bootNonceConsumedAt:
                     format: date-time
                     type: string
+                  bootNonceConsumedHash:
+                    type: string
                   bootNonceExpiresAt:
                     format: date-time
                     type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_physicalhosts.yaml
@@ -112,6 +112,8 @@ spec:
                   bootNonceConsumedAt:
                     format: date-time
                     type: string
+                  bootNonceConsumedHash:
+                    type: string
                   bootNonceExpiresAt:
                     format: date-time
                     type: string

--- a/controllers/annotations.go
+++ b/controllers/annotations.go
@@ -112,8 +112,9 @@ const ProvisionFailedRequestAnnotation = "infrastructure.cluster.x-k8s.io/provis
 // The nonce plaintext never appears here — only the hash (safe to log per the
 // same reasoning as BootstrapTokenAnnotationValue.Hash) and the expiry instant.
 // No IssuedAt field: the nonce lifecycle check only needs to know whether it
-// is expired and whether it has been consumed (BootNonceConsumedAt, written by
-// the /boot handler in D-010 — not present here).
+// is expired and whether it has been consumed (the BootNonceConsumedAt /
+// BootNonceConsumedHash record, written by the /boot handler in D-010 — not
+// present here).
 type BootNonceAnnotationValue struct {
 	// Hash is the hex-encoded SHA-256 of the plaintext boot nonce (64 chars).
 	Hash string `json:"hash"`

--- a/controllers/beskar7machine_controller.go
+++ b/controllers/beskar7machine_controller.go
@@ -549,9 +549,9 @@ func (r *Beskar7MachineReconciler) triggerInspection(ctx context.Context, logger
 
 	// Mint a fresh boot nonce (D-009) unless the existing one is still valid,
 	// unconsumed and backed by the Secret. The nonce has a shorter lifetime
-	// (10 min) than the bearer token (60 min) and is single-use: once
-	// BootNonceConsumedAt is set by the /boot handler (D-010) it is never
-	// reused — we always mint fresh on the next triggerInspection. The Secret
+	// (10 min) than the bearer token (60 min) and is single-use: once the /boot
+	// handler has recorded its consume (D-010) it is never reused — we always
+	// mint fresh on the next triggerInspection. The Secret
 	// cross-check matters here as much as for the token: the operator's boot
 	// service reads the nonce out of the Secret (docs/ipxe-setup.md), and a
 	// nonce that does not hash to Status.BootNonceHash fails every /boot
@@ -729,8 +729,13 @@ func (r *Beskar7MachineReconciler) bootstrapTokenReusable(
 //   - BootNonceHash is non-empty (a nonce was minted and the PhysicalHost
 //     reconciler has promoted the BootNonceAnnotation into Status), AND
 //   - BootNonceExpiresAt is set and strictly after now, AND
-//   - BootNonceConsumedAt is nil — a consumed nonce is never valid; force a
-//     fresh mint on the next triggerInspection call (re-provision path).
+//   - it has not been consumed — a consumed nonce is never valid; force a
+//     fresh mint on the next triggerInspection call (re-provision path). The
+//     consume record counts only when it names this nonce's hash
+//     (bootNonceConsumed): Status.Bootstrap outlives a claim, and the record of
+//     an earlier cycle's nonce must not spend the fresh one next to it. A record
+//     that names no hash might describe this nonce, so it counts as well
+//     (bootNonceConsumeUnattributed).
 //
 // Like unexpiredBootstrapTokenHash, a pending BootNonceAnnotation that has not
 // yet been promoted to Status also counts, and wins over Status: mint-race
@@ -742,27 +747,32 @@ func unexpiredBootNonceHash(physicalHost *infrav1.PhysicalHost, now time.Time) s
 	if physicalHost == nil {
 		return ""
 	}
+	bs := physicalHost.Status.Bootstrap
 	// (1) Pending-annotation check: a previous reconcile already minted and
 	// signalled via BootNonceAnnotation; the PhysicalHost controller has not
-	// yet promoted it to Status. The annotation does not carry ConsumedAt —
-	// once a nonce is consumed the handler writes Status directly (D-010) —
-	// but the /boot handler verifies against Status, so a nonce can only be
-	// consumed after promotion, by which time the annotation is gone and (2)
-	// below sees ConsumedAt.
+	// yet promoted it to Status. The annotation carries no consume record —
+	// the /boot handler writes that to Status directly (D-010), and it
+	// verifies against Status, so a nonce can only be consumed after
+	// promotion. Promotion does not remove the annotation, though: the
+	// PhysicalHost controller clears it one pass later, and a nonce fetched in
+	// between is consumed while its annotation is still pending. Once Status
+	// carries the annotation's hash, (2) below decides.
 	if raw, ok := physicalHost.Annotations[BootNonceAnnotation]; ok && raw != "" {
 		var v BootNonceAnnotationValue
 		if err := json.Unmarshal([]byte(raw), &v); err == nil &&
 			v.Hash != "" &&
-			now.Before(v.ExpiresAt.Time) {
+			now.Before(v.ExpiresAt.Time) &&
+			(bs == nil || bs.BootNonceHash != v.Hash) {
 			return v.Hash
 		}
 	}
 	// (2) Steady-state check from Status.Bootstrap.
-	if bs := physicalHost.Status.Bootstrap; bs != nil &&
+	if bs != nil &&
 		bs.BootNonceHash != "" &&
 		bs.BootNonceExpiresAt != nil &&
 		now.Before(bs.BootNonceExpiresAt.Time) &&
-		bs.BootNonceConsumedAt == nil {
+		!bootNonceConsumed(bs) &&
+		!bootNonceConsumeUnattributed(bs) {
 		return bs.BootNonceHash
 	}
 	return ""

--- a/controllers/beskar7machine_controller_test.go
+++ b/controllers/beskar7machine_controller_test.go
@@ -1913,7 +1913,9 @@ var _ = Describe("unexpiredBootNonceHash", func() {
 			"now.Before(expiresAt) is false at equality — boundary must re-mint")
 	})
 
-	It("returns no hash when BootNonceConsumedAt is set (consumed nonce is never valid)", func() {
+	// A record from a /boot handler that did not yet name the nonce's hash may
+	// describe this nonce, so it is never reused.
+	It("returns no hash when BootNonceConsumedAt is set without a hash (consumed nonce is never valid)", func() {
 		exp := metav1.NewTime(now.Add(5 * time.Minute))
 		consumed := metav1.NewTime(now.Add(-30 * time.Second))
 		ph := &infrav1.PhysicalHost{
@@ -1927,6 +1929,41 @@ var _ = Describe("unexpiredBootNonceHash", func() {
 		}
 		Expect(unexpiredBootNonceHash(ph, now)).To(BeEmpty(),
 			"consumed nonce (BootNonceConsumedAt != nil) must never be considered valid")
+	})
+
+	It("returns no hash when the consume record names this nonce", func() {
+		exp := metav1.NewTime(now.Add(5 * time.Minute))
+		consumed := metav1.NewTime(now.Add(-30 * time.Second))
+		ph := &infrav1.PhysicalHost{
+			Status: infrav1.PhysicalHostStatus{
+				Bootstrap: &infrav1.BootstrapStatus{
+					BootNonceHash:         "abcdef01",
+					BootNonceExpiresAt:    &exp,
+					BootNonceConsumedAt:   &consumed,
+					BootNonceConsumedHash: "abcdef01",
+				},
+			},
+		}
+		Expect(unexpiredBootNonceHash(ph, now)).To(BeEmpty())
+	})
+
+	// Status.Bootstrap outlives a claim: a re-claimed host's fresh nonce sits
+	// next to the record of the nonce the previous claim booted with.
+	It("returns the hash when the consume record names an earlier nonce", func() {
+		exp := metav1.NewTime(now.Add(5 * time.Minute))
+		consumed := metav1.NewTime(now.Add(-time.Hour))
+		ph := &infrav1.PhysicalHost{
+			Status: infrav1.PhysicalHostStatus{
+				Bootstrap: &infrav1.BootstrapStatus{
+					BootNonceHash:         "abcdef01",
+					BootNonceExpiresAt:    &exp,
+					BootNonceConsumedAt:   &consumed,
+					BootNonceConsumedHash: "0badf00d",
+				},
+			},
+		}
+		Expect(unexpiredBootNonceHash(ph, now)).To(Equal("abcdef01"),
+			"an earlier nonce's consume record must not spend the fresh nonce")
 	})
 
 	It("returns the hash when nonce is fresh, unexpired, and unconsumed", func() {
@@ -2016,6 +2053,60 @@ var _ = Describe("unexpiredBootNonceHash", func() {
 			},
 		}
 		Expect(unexpiredBootNonceHash(ph, now)).To(Equal("abcdef01"))
+	})
+
+	// The mint-race guard still holds next to a consumed earlier nonce: the
+	// pending mint is newer than anything Status says.
+	It("prefers a pending annotation over a consumed Status hash", func() {
+		exp := metav1.NewTime(now.Add(5 * time.Minute))
+		consumed := metav1.NewTime(now.Add(-2 * time.Minute))
+		annoBytes, _ := json.Marshal(BootNonceAnnotationValue{
+			Hash:      "cafef00d",
+			ExpiresAt: metav1.NewTime(now.Add(9 * time.Minute)),
+		})
+		ph := &infrav1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{BootNonceAnnotation: string(annoBytes)},
+			},
+			Status: infrav1.PhysicalHostStatus{
+				Bootstrap: &infrav1.BootstrapStatus{
+					BootNonceHash:         "abcdef01",
+					BootNonceExpiresAt:    &exp,
+					BootNonceConsumedAt:   &consumed,
+					BootNonceConsumedHash: "abcdef01",
+				},
+			},
+		}
+		Expect(unexpiredBootNonceHash(ph, now)).To(Equal("cafef00d"))
+	})
+
+	// The PhysicalHost controller clears the annotation one pass after it
+	// promotes the hash, and the /boot handler can consume the nonce in
+	// between. From promotion on, Status is what knows whether it was.
+	It("returns no hash for a pending annotation whose nonce Status has promoted and the handler consumed", func() {
+		exp := metav1.NewTime(now.Add(9 * time.Minute))
+		consumed := metav1.NewTime(now.Add(-10 * time.Second))
+		annoBytes, _ := json.Marshal(BootNonceAnnotationValue{Hash: "cafef00d", ExpiresAt: exp})
+		ph := &infrav1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{BootNonceAnnotation: string(annoBytes)},
+			},
+			Status: infrav1.PhysicalHostStatus{
+				Bootstrap: &infrav1.BootstrapStatus{
+					BootNonceHash:         "cafef00d",
+					BootNonceExpiresAt:    &exp,
+					BootNonceConsumedAt:   &consumed,
+					BootNonceConsumedHash: "cafef00d",
+				},
+			},
+		}
+		Expect(unexpiredBootNonceHash(ph, now)).To(BeEmpty(),
+			"a consumed nonce must not be reused because its annotation has not been cleared yet")
+
+		By("and returns it while the promoted nonce is still unconsumed")
+		ph.Status.Bootstrap.BootNonceConsumedAt = nil
+		ph.Status.Bootstrap.BootNonceConsumedHash = ""
+		Expect(unexpiredBootNonceHash(ph, now)).To(Equal("cafef00d"))
 	})
 })
 

--- a/controllers/boot_handler.go
+++ b/controllers/boot_handler.go
@@ -117,21 +117,22 @@ type ipEntry struct {
 // BootHandler serves the per-host iPXE boot script.
 //
 // Auth: the {nonce} path segment is verified constant-time against
-// Status.Bootstrap.BootNonceHash, within TTL, and not yet consumed. NOT
-// bearer-gated — the booting host has no bearer token yet; that token is
-// delivered by this endpoint in the rendered cmdline.
+// Status.Bootstrap.BootNonceHash, within TTL. NOT bearer-gated — the booting
+// host has no bearer token yet; that token is delivered by this endpoint in the
+// rendered cmdline.
 //
-// On success: marks the nonce consumed (D-010, single-use) and returns the
-// rendered iPXE script. A second fetch for the same host (race loser or NIC
-// retry) returns identical content (§4.1).
+// On success: records the nonce consumed if it is not yet (D-010) and returns
+// the rendered iPXE script. A second fetch with the same nonce (race loser or
+// NIC retry) returns identical content and records nothing (§4.1).
 //
 // Every failure returns the same opaque response so callers cannot distinguish
-// "host not found" from "wrong nonce" from "expired" from "consumed" (§4.1).
+// "host not found" from "wrong nonce" from "expired" (§4.1).
 //
-// Status ownership exception: this handler writes exactly one field,
-// PhysicalHost.Status.Bootstrap.BootNonceConsumedAt, via an optimistic-locked
-// Status().Patch. This is the sole audited exception to the D-005 invariant.
-// See D-010 in PROJECT_CONTEXT.md for the rationale.
+// Status ownership exception: this handler writes exactly one thing, the
+// consume record PhysicalHost.Status.Bootstrap.{BootNonceConsumedAt,
+// BootNonceConsumedHash}, via a single optimistic-locked Status().Patch. This
+// is the sole audited exception to the D-005 invariant. See D-010 in
+// PROJECT_CONTEXT.md for the rationale.
 //
 // INVARIANT (D-005 amendment): grep "client.Status().Update" controllers/*_handler.go
 // must remain empty. Only the single audited Status().Patch below is permitted.
@@ -202,21 +203,25 @@ func (h *BootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// 3. Consume the nonce (D-010 — atomic single-use under optimistic lock).
 	//
-	// If already consumed (BootNonceConsumedAt != nil), this is a race loser or
-	// a legitimate NIC retry. Skip the patch and fall through to render identical
-	// content (§4.1 guarantees same response for same host regardless of order).
+	// If this nonce is already consumed, this is a race loser or a legitimate
+	// NIC retry. Skip the patch and fall through to render identical content
+	// (§4.1 guarantees same response for same host regardless of order). The
+	// record must name this nonce: Status.Bootstrap outlives a claim, and the
+	// record an earlier nonce left says nothing about one minted after it.
 	//
 	// D-010: this Status().Patch is the sole audited exception to D-005.
-	// The field written (BootNonceConsumedAt) is owned exclusively by this
-	// handler; no reconciler writes it, so the BUG-1 last-write-wins hazard
+	// The fields written (the consume record) are owned exclusively by this
+	// handler; no reconciler writes them, so the BUG-1 last-write-wins hazard
 	// does not apply. A Conflict is the desired outcome (the winner consumed;
 	// the loser confirms it and renders identically).
-	if ph.Status.Bootstrap.BootNonceConsumedAt == nil {
+	if !bootNonceConsumed(ph.Status.Bootstrap) {
 		var consumeOK bool
 		for attempt := 0; attempt < bootNonceConsumeMaxRetries; attempt++ {
 			base := ph.DeepCopy()
 			now := metav1.NewTime(time.Now())
 			ph.Status.Bootstrap.BootNonceConsumedAt = &now
+			// verifyBootNonce has matched the nonce to this hash.
+			ph.Status.Bootstrap.BootNonceConsumedHash = ph.Status.Bootstrap.BootNonceHash
 
 			// Status().Update is FORBIDDEN in handler files (D-005).
 			// This single Status().Patch is the audited D-010 exception.
@@ -241,18 +246,20 @@ func (h *BootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			ph = fresh
 
-			// If the fresh object is already consumed, we lost the race; render
-			// identical content below.
-			if ph.Status.Bootstrap != nil && ph.Status.Bootstrap.BootNonceConsumedAt != nil {
-				consumeOK = true
-				break
-			}
-			// If the nonce is no longer valid in the fresh copy (e.g. the
-			// PhysicalHost reconciler cleared the hash), treat as opaque failure.
+			// The nonce must still be the one the host advertises before
+			// anything else is judged: the conflict may be a newer mint being
+			// promoted over it (or the hash cleared), and the fresh consume
+			// record would then describe that nonce, not this one.
 			if !verifyBootNonce(nonce, ph) {
 				log.V(1).Info("boot GET: nonce no longer valid after conflict re-get")
 				h.opaqueFailure(w)
 				return
+			}
+			// Still this nonce, and a concurrent fetch consumed it first: we
+			// lost the race; render identical content below.
+			if bootNonceConsumed(ph.Status.Bootstrap) {
+				consumeOK = true
+				break
 			}
 		}
 		if !consumeOK {
@@ -294,7 +301,7 @@ func (h *BootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // in the future, and auth.Verify constant-time match. Pulled out so it can be
 // re-evaluated after an optimistic-lock conflict without duplicating logic.
 //
-// Deliberately does NOT check BootNonceConsumedAt — that check belongs in the
+// Deliberately does NOT check the consume record — that check belongs in the
 // consume path so the already-consumed branch can render identical content.
 func verifyBootNonce(nonce string, ph *infrav1.PhysicalHost) bool {
 	bs := ph.Status.Bootstrap
@@ -305,6 +312,35 @@ func verifyBootNonce(nonce string, ph *infrav1.PhysicalHost) bool {
 		return false
 	}
 	return auth.Verify(nonce, bs.BootNonceHash)
+}
+
+// bootNonceConsumed reports whether the consume record in bs names the boot
+// nonce bs currently advertises (D-010).
+//
+// The record is never cleared: Status.Bootstrap outlives a claim, and the
+// nonce the next claim mints is promoted next to the record of the one before.
+// Telling the two apart by hash is what keeps that new nonce unconsumed until
+// its own first fetch. Clearing the record when a new hash is promoted is not
+// an option: the PhysicalHost reconciler's status patch carries no
+// resourceVersion, so a pass computed from a stale cache would clear a consume
+// the handler had already recorded for the new nonce.
+//
+// A record without a hash, written by a handler from before the record named
+// one, is not attributed to the current nonce here, so the next fetch records
+// its consume afresh. The Beskar7Machine reads such a record the other way
+// (bootNonceConsumeUnattributed): it never reuses a nonce the record might
+// describe.
+func bootNonceConsumed(bs *infrav1.BootstrapStatus) bool {
+	return bs != nil && bs.BootNonceConsumedAt != nil &&
+		bs.BootNonceHash != "" && bs.BootNonceConsumedHash == bs.BootNonceHash
+}
+
+// bootNonceConsumeUnattributed reports whether bs carries a consume record that
+// does not say which nonce it consumed: one written by a /boot handler from
+// before BootNonceConsumedHash existed, which may describe the current nonce or
+// an earlier one.
+func bootNonceConsumeUnattributed(bs *infrav1.BootstrapStatus) bool {
+	return bs != nil && bs.BootNonceConsumedAt != nil && bs.BootNonceConsumedHash == ""
 }
 
 // validateBootURL rejects values that could break out of a single

--- a/controllers/boot_handler_test.go
+++ b/controllers/boot_handler_test.go
@@ -18,6 +18,8 @@ package controllers
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -31,11 +33,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	infrav1 "github.com/projectbeskar/beskar7/api/v1beta2"
 	"github.com/projectbeskar/beskar7/internal/auth"
@@ -263,13 +267,15 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 		Expect(providerIDIdx).To(BeNumerically("<", caIdx),
 			"beskar7.provider-id must precede beskar7.ca")
 
-		By("asserting BootNonceConsumedAt is set")
+		By("asserting BootNonceConsumedAt is set, for this nonce")
 		Eventually(func(g Gomega) {
 			got := &infrav1.PhysicalHost{}
 			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, got)).To(Succeed())
 			g.Expect(got.Status.Bootstrap).NotTo(BeNil())
 			g.Expect(got.Status.Bootstrap.BootNonceConsumedAt).NotTo(BeNil(),
 				"BootNonceConsumedAt must be set after first /boot fetch")
+			g.Expect(got.Status.Bootstrap.BootNonceConsumedHash).To(Equal(ph.Status.Bootstrap.BootNonceHash),
+				"the consume record must name the nonce it consumed")
 		}, Timeout, Interval).Should(Succeed())
 	})
 
@@ -369,11 +375,12 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 	It("already-consumed: identical render, no second patch, ConsumedAt value unchanged", func() {
 		ph, b7m, _, nonce := bootTestFixture(testNs.Name)
 
-		By("pre-consuming the nonce")
+		By("pre-consuming the nonce: a record naming this nonce's hash")
 		consumedAt := metav1.NewTime(time.Now().Add(-1 * time.Second))
 		freshPH := &infrav1.PhysicalHost{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}, freshPH)).To(Succeed())
 		freshPH.Status.Bootstrap.BootNonceConsumedAt = &consumedAt
+		freshPH.Status.Bootstrap.BootNonceConsumedHash = freshPH.Status.Bootstrap.BootNonceHash
 		Expect(k8sClient.Status().Update(ctx, freshPH)).To(Succeed())
 
 		By("issuing a /boot fetch against an already-consumed nonce")
@@ -393,6 +400,147 @@ var _ = Describe("Boot GET handler (D-009 / D-010)", func() {
 		Expect(got.Status.Bootstrap.BootNonceConsumedAt.Truncate(time.Second)).To(
 			BeTemporally("==", consumedAt.Truncate(time.Second)),
 			"ConsumedAt must not be advanced by a second /boot fetch")
+		Expect(got.Status.Bootstrap.BootNonceConsumedHash).To(Equal(got.Status.Bootstrap.BootNonceHash))
+	})
+
+	// ── 3b. A consume record that does not name this nonce ─────────────────
+	//
+	// Status.Bootstrap outlives a claim, so a re-claimed host's fresh nonce is
+	// promoted next to the consume record an earlier nonce left. That record must
+	// not make the fresh nonce look consumed, or its first fetch would record
+	// nothing (boot_nonce_cycles_test.go runs the whole re-claim). A record from
+	// a handler that did not yet name the hash is not attributed to this nonce
+	// either; the Beskar7Machine reads that one the safe way for reuse.
+
+	for _, tc := range []struct {
+		name      string
+		namesHash bool
+	}{
+		{name: "an earlier nonce's consume record", namesHash: true},
+		{name: "a consume record that names no nonce", namesHash: false},
+	} {
+		It("fresh nonce next to "+tc.name+" → 200, and the fetch records this nonce's consume", func() {
+			ph, _, _, nonce := bootTestFixture(testNs.Name)
+			key := types.NamespacedName{Name: ph.Name, Namespace: testNs.Name}
+
+			By("leaving the record in Status, as a re-claimed host carries it")
+			earlier := metav1.NewTime(time.Now().Add(-time.Hour))
+			freshPH := &infrav1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, key, freshPH)).To(Succeed())
+			freshPH.Status.Bootstrap.BootNonceConsumedAt = &earlier
+			if tc.namesHash {
+				_, earlierHash, err := auth.MintToken()
+				Expect(err).NotTo(HaveOccurred())
+				freshPH.Status.Bootstrap.BootNonceConsumedHash = earlierHash
+			}
+			Expect(k8sClient.Status().Update(ctx, freshPH)).To(Succeed())
+
+			resp := doBoot(server.URL, testNs.Name, ph.Name, nonce)
+			body := readBody(resp)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), body)
+
+			got := &infrav1.PhysicalHost{}
+			Expect(k8sClient.Get(ctx, key, got)).To(Succeed())
+			Expect(got.Status.Bootstrap.BootNonceConsumedHash).To(Equal(got.Status.Bootstrap.BootNonceHash),
+				"the record must name the nonce this fetch consumed")
+			Expect(got.Status.Bootstrap.BootNonceConsumedAt.Time).To(BeTemporally(">", earlier.Time),
+				"the record must be this fetch's, not the earlier one")
+		})
+	}
+
+	// ── 3c. The nonce is superseded while the consume is in flight ─────────
+	//
+	// The consume patch conflicts whenever the host changed after the handler
+	// read it, and a newer nonce being promoted is one such change. The host
+	// read back then carries that nonce's hash, and maybe its consume record,
+	// so the handler must verify its own nonce again before it takes a record
+	// as a lost race: the script is only ever served for the advertised nonce.
+	It("conflict re-get: nonce superseded by a newer, consumed one before the consume lands → opaque 404", func() {
+		noncePlaintext, nonceHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		_, newerHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		_, tokenHash, err := auth.MintToken()
+		Expect(err).NotTo(HaveOccurred())
+		nonceExpiresAt := metav1.NewTime(time.Now().Add(10 * time.Minute))
+		tokenExpiresAt := metav1.NewTime(time.Now().Add(30 * time.Minute))
+
+		ph := &infrav1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "h-superseded", Namespace: "n"},
+			Spec: infrav1.PhysicalHostSpec{
+				RedfishConnection: infrav1.RedfishConnection{Address: "https://192.168.1.1", CredentialsSecretRef: "x"},
+				ConsumerRef: &corev1.ObjectReference{
+					Kind: "Beskar7Machine", APIVersion: InfrastructureAPIVersion, Name: "b7m-superseded", Namespace: "n",
+				},
+			},
+			Status: infrav1.PhysicalHostStatus{
+				Bootstrap: &infrav1.BootstrapStatus{
+					TokenHash:          tokenHash,
+					ExpiresAt:          &tokenExpiresAt,
+					BootNonceHash:      nonceHash,
+					BootNonceExpiresAt: &nonceExpiresAt,
+				},
+			},
+		}
+		b7m := &infrav1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: "b7m-superseded", Namespace: "n"},
+			Spec: infrav1.Beskar7MachineSpec{
+				InspectionImageURL: "https://boot.example.com/inspect",
+				TargetImageURL:     "https://boot.example.com/kairos.raw",
+				TargetImageDigest:  bootTestDigest,
+			},
+		}
+		tokenSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenSecretName(ph.Name), Namespace: "n"},
+			Data:       map[string][]byte{bootstrapTokenSecretKey: []byte("superseded-token")},
+		}
+
+		// The first consume patch finds the newer nonce promoted and consumed.
+		// Setup errors are kept rather than returned: the handler would turn
+		// them into the very 404 this spec expects.
+		var superseded bool
+		var supersedeErr error
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(k8sClient.Scheme()).
+			WithObjects(b7m, tokenSecret).
+			WithStatusSubresource(ph).
+			WithObjects(ph).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, c client.Client, subResource string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					if superseded {
+						return c.SubResource(subResource).Patch(ctx, obj, patch, opts...)
+					}
+					superseded = true
+					current := &infrav1.PhysicalHost{}
+					if supersedeErr = c.Get(ctx, client.ObjectKeyFromObject(obj), current); supersedeErr != nil {
+						return supersedeErr
+					}
+					consumedAt := metav1.Now()
+					current.Status.Bootstrap.BootNonceHash = newerHash
+					current.Status.Bootstrap.BootNonceConsumedAt = &consumedAt
+					current.Status.Bootstrap.BootNonceConsumedHash = newerHash
+					if supersedeErr = c.Status().Update(ctx, current); supersedeErr != nil {
+						return supersedeErr
+					}
+					return apierrors.NewConflict(infrav1.GroupVersion.WithResource("physicalhosts").GroupResource(),
+						obj.GetName(), errors.New("the object has been modified"))
+				},
+			}).
+			Build()
+
+		handler := &BootHandler{Client: fakeClient, Log: ctrl.Log.WithName("boot-superseded-test"), Config: bootTestConfig()}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/boot/n/h-superseded/"+noncePlaintext, nil)
+		req.SetPathValue("namespace", "n")
+		req.SetPathValue("hostName", ph.Name)
+		req.SetPathValue("nonce", noncePlaintext)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		Expect(superseded).To(BeTrue(), "the handler must have tried to record the consume")
+		Expect(supersedeErr).NotTo(HaveOccurred())
+		Expect(w.Code).To(Equal(http.StatusNotFound),
+			"a nonce the host no longer advertises must not be served the script: %s", w.Body.String())
+		Expect(w.Body.String()).NotTo(ContainSubstring("superseded-token"))
 	})
 
 	// ── 4. Opaque failures ─────────────────────────────────────────────────

--- a/controllers/boot_nonce_cycles_test.go
+++ b/controllers/boot_nonce_cycles_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2024 The Beskar7 Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "github.com/projectbeskar/beskar7/api/v1beta2"
+	"github.com/projectbeskar/beskar7/internal/auth"
+)
+
+// Status.Bootstrap outlives a claim: a released host keeps it, and the next
+// Beskar7Machine to claim the host mints its credentials into it. The boot
+// nonce's consume record in it is written by the /boot handler and cleared by
+// nothing, so the record a host's first boot left used to be inherited by every
+// nonce minted after it. /boot took each new nonce for one it had already
+// consumed and never recorded its consume, and the Beskar7Machine counted the
+// nonce spent from the moment the host promoted it, so a repeated trigger
+// replaced a nonce the operator's boot service may already have handed out.
+// These specs run two provisioning cycles on one host through the real
+// Beskar7Machine mint, PhysicalHostReconciler.Reconcile and BootHandler.
+var _ = Describe("Boot nonce across two provisioning cycles of one host", func() {
+	var (
+		ns       *corev1.Namespace
+		server   *httptest.Server
+		hostR    *PhysicalHostReconciler
+		machineR *Beskar7MachineReconciler
+		hostKey  client.ObjectKey
+	)
+
+	BeforeEach(func() {
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "boot-nonce-cycles-"}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		credentials := bmcCredentialsSecret(ns.Name)
+		Expect(k8sClient.Create(ctx, credentials)).To(Succeed())
+		server = httptest.NewServer(buildBootMux(bootTestConfig()))
+
+		hostR = &PhysicalHostReconciler{
+			Client: k8sClient, Scheme: k8sClient.Scheme(),
+			Log:                  ctrl.Log.WithName("boot-nonce-cycles-host"),
+			Recorder:             record.NewFakeRecorder(10),
+			RedfishClientFactory: reachableBMC(),
+		}
+		machineR = &Beskar7MachineReconciler{
+			Client: k8sClient, Scheme: k8sClient.Scheme(),
+			Log:                  ctrl.Log.WithName("boot-nonce-cycles-machine"),
+			RedfishClientFactory: reachableBMC(),
+		}
+
+		host := &infrav1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{Name: "recycled-host", Namespace: ns.Name},
+			Spec: infrav1.PhysicalHostSpec{RedfishConnection: infrav1.RedfishConnection{
+				Address:              "https://mock-redfish.example.invalid:8443",
+				CredentialsSecretRef: credentials.Name,
+			}},
+		}
+		Expect(k8sClient.Create(ctx, host)).To(Succeed())
+		hostKey = client.ObjectKeyFromObject(host)
+		Expect(settlePhysicalHost(hostR, hostKey).Status.State).To(Equal(infrav1.StateAvailable))
+	})
+
+	AfterEach(func() {
+		server.Close()
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+	})
+
+	// claim hands the host to a new Beskar7Machine, as a re-claim after release
+	// or a MachineHealthCheck's replacement does, by setting its ConsumerRef.
+	claim := func(machineName string) *infrav1.Beskar7Machine {
+		machine := &infrav1.Beskar7Machine{
+			ObjectMeta: metav1.ObjectMeta{Name: machineName, Namespace: ns.Name},
+			Spec: infrav1.Beskar7MachineSpec{
+				InspectionImageURL: "https://boot.example.com/inspect",
+				TargetImageURL:     "https://boot.example.com/kairos.raw",
+				TargetImageDigest:  bootTestDigest,
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		host := getPhysicalHost(hostKey)
+		claimed := host.DeepCopy()
+		claimed.Spec.ConsumerRef = &corev1.ObjectReference{
+			Kind: "Beskar7Machine", APIVersion: InfrastructureAPIVersion,
+			Name: machine.Name, Namespace: machine.Namespace, UID: machine.UID,
+		}
+		Expect(k8sClient.Patch(ctx, claimed, client.MergeFrom(host))).To(Succeed())
+		Expect(settlePhysicalHost(hostR, hostKey).Status.State).To(Equal(infrav1.StateInUse))
+		return machine
+	}
+
+	// secretNonce returns the boot nonce the per-host Secret holds: the one the
+	// operator's boot service puts in the host's /boot URL.
+	secretNonce := func() string {
+		secret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: bootstrapTokenSecretName(hostKey.Name)}, secret)).To(Succeed())
+		return string(secret.Data[bootNonceSecretKey])
+	}
+
+	// startInspection runs the machine's triggerInspection on the host as
+	// persisted, has the host reconciler take up what it signalled, and returns
+	// the nonce the host now advertises.
+	startInspection := func(machine *infrav1.Beskar7Machine) string {
+		_, err := machineR.triggerInspection(ctx, machineR.Log, machine, getPhysicalHost(hostKey))
+		Expect(err).NotTo(HaveOccurred())
+		host := settlePhysicalHost(hostR, hostKey)
+		Expect(host.Status.State).To(Equal(infrav1.StateInspecting))
+		Expect(host.Annotations).NotTo(HaveKey(BootNonceAnnotation), "the host has taken up the mint")
+		nonce := secretNonce()
+		Expect(auth.Verify(nonce, host.Status.Bootstrap.BootNonceHash)).To(BeTrue(),
+			"the host advertises the nonce the Secret holds")
+		return nonce
+	}
+
+	// fetchBoot asks /boot for the host's script with nonce, and returns the
+	// response with the host as persisted afterwards.
+	fetchBoot := func(nonce string) (int, string, *infrav1.PhysicalHost) {
+		resp := doBoot(server.URL, ns.Name, hostKey.Name, nonce)
+		body := readBody(resp)
+		return resp.StatusCode, body, getPhysicalHost(hostKey)
+	}
+
+	// bootTwice fetches the script with nonce, then again as a NIC retry would.
+	// The first fetch must write the consume record — later than previous, the
+	// record an earlier cycle left, when one is given — and the retry must get
+	// the same script without writing anything. Returns the record's time.
+	bootTwice := func(nonce string, previous *metav1.Time) *metav1.Time {
+		unfetched := getPhysicalHost(hostKey)
+
+		code, script, fetched := fetchBoot(nonce)
+		Expect(code).To(Equal(http.StatusOK))
+		Expect(script).To(ContainSubstring("beskar7.token="))
+		Expect(fetched.ResourceVersion).NotTo(Equal(unfetched.ResourceVersion),
+			"the first fetch of a nonce records that the nonce was consumed")
+		consumedAt := fetched.Status.Bootstrap.BootNonceConsumedAt
+		Expect(consumedAt).NotTo(BeNil())
+		if previous != nil {
+			Expect(consumedAt.After(previous.Time)).To(BeTrue(),
+				"the record must describe this nonce's fetch, not the previous cycle's (recorded %s, previous %s)",
+				consumedAt, previous)
+		}
+
+		code, retried, afterRetry := fetchBoot(nonce)
+		Expect(code).To(Equal(http.StatusOK),
+			"a retry with the same nonce within its lifetime is served the same script (contract §4.1)")
+		Expect(retried).To(Equal(script))
+		Expect(afterRetry.ResourceVersion).To(Equal(fetched.ResourceVersion),
+			"a retry does not consume the nonce a second time")
+		return consumedAt
+	}
+
+	It("records the first /boot fetch of each cycle's nonce as that nonce's consume", func() {
+		By("cycle 1: the first claim mints a nonce, and the host boots with it")
+		firstNonce := startInspection(claim("first-machine"))
+		firstConsumedAt := bootTwice(firstNonce, nil)
+
+		By("releasing the host, which keeps Status.Bootstrap and the consume record in it")
+		releasePhysicalHost(hostKey)
+		released := settlePhysicalHost(hostR, hostKey)
+		Expect(released.Status.State).To(Equal(infrav1.StateAvailable))
+		Expect(released.Status.Bootstrap.BootNonceConsumedAt).NotTo(BeNil())
+
+		By("cycle 2: the next claim mints a fresh nonce")
+		secondNonce := startInspection(claim("second-machine"))
+		Expect(secondNonce).NotTo(Equal(firstNonce))
+		code, _, _ := fetchBoot(firstNonce)
+		Expect(code).To(Equal(http.StatusNotFound), "the first cycle's nonce no longer boots the host")
+
+		// metav1.Time keeps whole seconds; a boot in the same second as the
+		// first cycle's would leave a record indistinguishable from it.
+		By("booting with the fresh nonce a second later than the first cycle's record")
+		time.Sleep(time.Until(firstConsumedAt.Add(time.Second)))
+		bootTwice(secondNonce, firstConsumedAt)
+	})
+
+	It("counts a re-claimed host's fresh nonce as unspent until it is fetched", func() {
+		By("cycle 1: claim, mint, and boot")
+		firstNonce := startInspection(claim("first-machine"))
+		code, _, _ := fetchBoot(firstNonce)
+		Expect(code).To(Equal(http.StatusOK))
+		releasePhysicalHost(hostKey)
+		Expect(settlePhysicalHost(hostR, hostKey).Status.State).To(Equal(infrav1.StateAvailable))
+
+		By("cycle 2: the re-claim's nonce, promoted but not fetched yet")
+		machine := claim("second-machine")
+		secondNonce := startInspection(machine)
+		promoted := getPhysicalHost(hostKey)
+		Expect(unexpiredBootNonceHash(promoted, time.Now())).To(Equal(promoted.Status.Bootstrap.BootNonceHash),
+			"a nonce nothing has fetched is not spent, whatever an earlier nonce's consume record says")
+
+		By("triggering inspection again, which must keep the nonce the boot service may already have handed out")
+		_, err := machineR.triggerInspection(ctx, machineR.Log, machine, promoted)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secretNonce()).To(Equal(secondNonce))
+		Expect(getPhysicalHost(hostKey).Annotations).NotTo(HaveKey(BootNonceAnnotation), "no fresh nonce is advertised")
+
+		By("fetching it, after which it counts as spent")
+		code, _, fetched := fetchBoot(secondNonce)
+		Expect(code).To(Equal(http.StatusOK))
+		Expect(unexpiredBootNonceHash(fetched, time.Now())).To(BeEmpty(),
+			"a consumed nonce is never reused: the next trigger mints a fresh one")
+	})
+})

--- a/controllers/physicalhost_controller.go
+++ b/controllers/physicalhost_controller.go
@@ -359,8 +359,9 @@ func (r *PhysicalHostReconciler) reconcileNormal(ctx context.Context, logger log
 	// Consume the boot-nonce annotation (D-009): the Beskar7Machine controller
 	// signals the hash + expiry of the freshly minted per-host boot nonce; we
 	// persist them to Status.Bootstrap.{BootNonceHash,BootNonceExpiresAt}.
-	// BootNonceConsumedAt is NOT touched here — it is the /boot handler's field
-	// (D-010). Same idempotent annotation-in/status-out pattern as the token.
+	// The consume record (BootNonceConsumedAt/BootNonceConsumedHash) is NOT
+	// touched here — it is the /boot handler's (D-010). Same idempotent
+	// annotation-in/status-out pattern as the token.
 	r.applyBootNonceAnnotation(logger, physicalHost)
 
 	// Consume the inspection-result annotation (PR-5.2 / D-005): the inspection
@@ -716,10 +717,14 @@ func (r *PhysicalHostReconciler) applyBootstrapTokenAnnotation(logger logr.Logge
 
 // applyBootNonceAnnotation reads the BootNonceAnnotation, JSON-decodes the
 // {hash, expiresAt} payload, and persists those values to Status.Bootstrap.
-// BootNonceConsumedAt is NOT written here — it is exclusively written by the
-// /boot handler (D-010). Any code path that reads ConsumedAt after this call
-// will see only whatever value was already in Status before the annotation was
-// applied (nil until the handler fires).
+// The consume record (BootNonceConsumedAt/BootNonceConsumedHash) is NOT
+// written here — it is exclusively written by the /boot handler (D-010). A
+// record left by an earlier nonce therefore stays in Status next to the newly
+// promoted hash; it names that earlier nonce's hash, so the new nonce counts as
+// unconsumed until its own first fetch (bootNonceConsumed). Clearing the record
+// here instead would race the handler: this reconciler's status patch carries
+// no resourceVersion, and a pass computed from a stale cache would erase a
+// consume already recorded for the new nonce.
 //
 // Same two-phase handoff as applyBootstrapTokenAnnotation: status first, the
 // annotation is cleared on the following pass once status shows the same
@@ -760,8 +765,8 @@ func (r *PhysicalHostReconciler) applyBootNonceAnnotation(logger logr.Logger, ph
 	physicalHost.Status.Bootstrap.BootNonceHash = value.Hash
 	expiresAt := value.ExpiresAt
 	physicalHost.Status.Bootstrap.BootNonceExpiresAt = &expiresAt
-	// Intentionally do NOT touch BootNonceConsumedAt — that field belongs to
-	// the /boot handler (D-010). This controller must not clear or overwrite it.
+	// Intentionally do NOT touch the consume record — it belongs to the /boot
+	// handler (D-010). This controller must not clear or overwrite it.
 	logger.Info("Applied boot-nonce annotation to Status.Bootstrap", "host", physicalHost.Name)
 }
 

--- a/controllers/physicalhost_controller_test.go
+++ b/controllers/physicalhost_controller_test.go
@@ -1164,6 +1164,47 @@ var _ = Describe("applyBootNonceAnnotation", func() {
 		Expect(ph.Status.Bootstrap.BootNonceConsumedAt.Time.Equal(consumed.Time)).To(BeTrue())
 	})
 
+	// Status.Bootstrap outlives a claim, so a re-claimed host's fresh nonce is
+	// promoted next to the record of the nonce before it. The record stays the
+	// handler's to write; it is its hash that keeps the fresh nonce unconsumed.
+	It("leaves an earlier nonce's consume record in place, and the nonce it promotes counts as unconsumed", func() {
+		earlierHash := "9988776655443322110099887766554433221100998877665544332211009988"
+		freshHash := "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+		consumed := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+		earlierExpiry := metav1.NewTime(time.Now().Add(-50 * time.Minute).Truncate(time.Second))
+		freshExpiry := metav1.NewTime(time.Now().Add(10 * time.Minute).Truncate(time.Second))
+		encoded, err := json.Marshal(BootNonceAnnotationValue{Hash: freshHash, ExpiresAt: freshExpiry})
+		Expect(err).NotTo(HaveOccurred())
+
+		ph := &infrav1.PhysicalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{BootNonceAnnotation: string(encoded)},
+			},
+			Status: infrav1.PhysicalHostStatus{
+				Bootstrap: &infrav1.BootstrapStatus{
+					BootNonceHash:         earlierHash,
+					BootNonceExpiresAt:    &earlierExpiry,
+					BootNonceConsumedAt:   &consumed,
+					BootNonceConsumedHash: earlierHash,
+				},
+			},
+		}
+
+		for pass := 1; pass <= 2; pass++ {
+			By(fmt.Sprintf("pass %d", pass))
+			r.applyBootNonceAnnotation(r.Log, ph)
+			Expect(ph.Status.Bootstrap.BootNonceHash).To(Equal(freshHash))
+			Expect(ph.Status.Bootstrap.BootNonceConsumedAt.Time.Equal(consumed.Time)).To(BeTrue(),
+				"the consume record is the /boot handler's to write")
+			Expect(ph.Status.Bootstrap.BootNonceConsumedHash).To(Equal(earlierHash))
+			Expect(bootNonceConsumed(ph.Status.Bootstrap)).To(BeFalse(),
+				"the record names the earlier nonce, not the one just promoted")
+			Expect(unexpiredBootNonceHash(ph, time.Now())).To(Equal(freshHash),
+				"the Beskar7Machine may reuse the promoted nonce until it is fetched")
+		}
+		Expect(ph.Annotations).NotTo(HaveKey(BootNonceAnnotation))
+	})
+
 	It("leaves annotation in place when JSON is malformed", func() {
 		ph := &infrav1.PhysicalHost{
 			ObjectMeta: metav1.ObjectMeta{

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -134,7 +134,8 @@ Per-host bootstrap fetch coordinates and the hashed bearer token used to authent
 | `expiresAt` | `*metav1.Time` | When the current token stops being accepted. Defaults to `issuedAt + 60m` (`auth.TokenLifetime`, SEC-D015-1). |
 | `bootNonceHash` | string | Hex-encoded SHA-256 of the per-host boot nonce minted at inspection time (D-009). Gates `GET /api/v1/boot/{ns}/{host}/{nonce}`. The plaintext nonce is never stored here — it lives in a per-host Secret under key `plaintext-boot-nonce`. |
 | `bootNonceExpiresAt` | `*metav1.Time` | When the current boot nonce stops being accepted. Defaults to mint time `+ 10m` (`auth.BootNonceLifetime`, D-009) — intentionally shorter than the bearer-token lifetime because the nonce is single-use. |
-| `bootNonceConsumedAt` | `*metav1.Time` | Timestamp at which the boot nonce was single-use consumed by the `/boot` handler (D-010). Nil until first boot; once set it is never cleared — a new nonce is minted on the next re-provision cycle. |
+| `bootNonceConsumedAt` | `*metav1.Time` | Timestamp at which the `/boot` handler consumed the boot nonce named by `bootNonceConsumedHash` (D-010). Nil until first boot, and never cleared: a nonce minted later has a different hash, so the record does not apply to it, and that nonce's first fetch records its own consume over it. A consumed nonce is never reused — a new nonce is minted on the next re-provision cycle. |
+| `bootNonceConsumedHash` | string | The `bootNonceHash` of the nonce `bootNonceConsumedAt` records. The advertised nonce has been consumed only while the two hashes match. Written with `bootNonceConsumedAt` by the `/boot` handler. Empty next to a `bootNonceConsumedAt` recorded by a release before this field existed: `/boot` then records the advertised nonce's consume afresh, and the controller does not reuse that nonce. |
 
 #### Conditions
 

--- a/docs/inspector-contract.md
+++ b/docs/inspector-contract.md
@@ -156,15 +156,15 @@ HTTPS listener (default `:8082`, `controllers/inspection_handler.go`
 ### 4.1 `GET /api/v1/boot/{namespace}/{hostName}/{nonce}` — boot-param rendering
 
 - **Auth**: the `{nonce}` path segment, verified constant-time against
-  `Status.Bootstrap.BootNonceHash`, within TTL, and **not yet consumed**
-  (`Status.Bootstrap.BootNonceConsumedAt == nil`). NOT bearer-gated.
-- **On success**: marks the nonce consumed (single-use, see §7) and returns the
-  rendered iPXE script / kernel cmdline carrying the parameters in §5. A second
-  successful fetch within the window (e.g. a NIC retry) MUST return **identical**
-  content for the same host.
-- **Failure**: opaque response identical for "no such host", "wrong nonce",
-  "expired", and "already consumed" — no oracle. The nonce, the URL, and the
-  `{nonce}` path value MUST NOT be logged (the nonce hash MAY be).
+  `Status.Bootstrap.BootNonceHash`, and within TTL. NOT bearer-gated.
+- **On success**: marks the nonce consumed unless it already is (single-use, see
+  §7) and returns the rendered iPXE script / kernel cmdline carrying the
+  parameters in §5. A second successful fetch within the window (e.g. a NIC
+  retry) MUST return **identical** content for the same host.
+- **Failure**: opaque response identical for "no such host", "wrong nonce"
+  (including a nonce a newer mint has replaced), and "expired" — no oracle. The
+  nonce, the URL, and the `{nonce}` path value MUST NOT be logged (the nonce hash
+  MAY be).
 - **Rate limiting**: this route is ungated; it MUST be rate-limited per source IP
   (and SHOULD be per `{namespace}/{hostName}`).
 
@@ -411,14 +411,28 @@ evaluate correctly:
 ## 7. Single-use semantics (boot nonce)
 
 - The nonce is consumed on first successful `/boot` fetch by setting
-  `Status.Bootstrap.BootNonceConsumedAt`. The consume MUST be atomic
-  (optimistic-locked) so two concurrent fetches cannot both treat the nonce as
-  fresh. Note: the existing inspection/bootstrap annotation writes deliberately
-  drop optimistic locking (single unique writer); the consume is the opposite
-  situation — a Conflict is the desired outcome and MUST be enforced.
+  `Status.Bootstrap.BootNonceConsumedAt` together with
+  `Status.Bootstrap.BootNonceConsumedHash`, the hash of the nonce consumed. The
+  consume MUST be atomic (optimistic-locked) so two concurrent fetches cannot both
+  treat the nonce as fresh. Note: the existing inspection/bootstrap annotation
+  writes deliberately drop optimistic locking (single unique writer); the consume
+  is the opposite situation — a Conflict is the desired outcome and MUST be
+  enforced.
+- The consume record describes one nonce: the advertised nonce is consumed only
+  while `BootNonceConsumedHash` equals `BootNonceHash`. `Status.Bootstrap`
+  outlives a claim, so a re-claimed host's fresh nonce is promoted next to the
+  record of the nonce before it, and that record MUST NOT count for the fresh
+  nonce — otherwise `/boot` records nothing for it and the controller treats it
+  as spent before anything has fetched it. Nothing clears the record (a
+  reconciler clearing it without an optimistic lock could erase a consume
+  `/boot` had already recorded); the fresh nonce's first fetch replaces it. A
+  record with no `BootNonceConsumedHash`, written before the field existed, is
+  read the safe way by each side: `/boot` records the advertised nonce's consume
+  afresh, and the controller never reuses a nonce such a record might describe.
 - A double-fetch to the **same host** (race loser, or a legitimate retry) is
-  benign and MUST return identical content (§4.1). A second fetch for a
-  **different** host's nonce is impossible by construction (per-host nonce).
+  benign and MUST return identical content (§4.1), until the nonce expires or a
+  newer mint replaces it. A second fetch for a **different** host's nonce is
+  impossible by construction (per-host nonce).
 - Re-provision (reboot, inspection-timeout retry, delete-and-recreate) MUST mint
   a **fresh** nonce (and fresh bearer token) — there is no "un-consume" path.
 - If the consume is routed through the D-005 annotation→reconciler handoff rather


### PR DESCRIPTION
## Summary

A host keeps `status.bootstrap` across release, and `/boot`'s consume record (`bootNonceConsumedAt`) is never cleared. From a host's second provisioning cycle on — a re-claim after release, a `MachineHealthCheck` replacement — every fresh boot nonce was promoted next to the record the host's first boot left:

- **`/boot` never recorded the fresh nonce's consume.** It took the nonce for one it had already consumed and served it without the optimistic-locked single-use write; the record kept the first boot's timestamp.
- **The `Beskar7Machine` counted the fresh nonce spent before anything had fetched it**, so triggering inspection again in that cycle minted over a nonce the operator's boot service may already have handed out.

What it did **not** do is widen the bearer token's exposure. `/boot` serves a retry with the same nonce until the nonce expires on every boot, the first included — the §4.1 NIC-retry rule, pinned by the existing "already-consumed" spec. That behaviour is unchanged here (see *Not in this PR*).

## Fix

- New `status.bootstrap.bootNonceConsumedHash`. `/boot` writes it together with `bootNonceConsumedAt` in its single audited, optimistic-locked status patch — D-010's one handler→status write now covers two fields in the same patch. A nonce counts as consumed only while that hash matches `bootNonceHash` (`bootNonceConsumed`). The `PhysicalHost` reconciler still never touches the record.
- **Rejected: resetting `bootNonceConsumedAt` when the reconciler promotes a new hash.** CAPI's `patch.Helper` sends status as a raw merge patch with no `resourceVersion` (checked in v1.13.5 `util/patch`), so a pass computed from a stale cache could erase a consume `/boot` had just recorded for the new nonce and leave a used nonce reusable — the last-write-wins hazard D-010 exists to rule out.
- `/boot`'s conflict retry re-verifies the nonce **before** it takes the re-read record as a lost race, so it cannot serve a nonce a newer mint has replaced.
- `unexpiredBootNonceHash`: a pending `boot-nonce` annotation wins (the mint-race guard) only until Status carries its hash. The host clears the annotation one pass after promoting it, and a nonce `/boot` consumed in that gap must not read as reusable.

**Upgrade and mixed versions.** A record written by an earlier release has no hash, and each side reads it the safe way: `/boot` records the advertised nonce's consume afresh, and the `Beskar7Machine` never reuses a nonce such a record might describe (`bootNonceConsumeUnattributed`). A callback-only instance (`--controllers=none`) still on the previous release keeps the old behaviour until it is upgraded; neither upgrade order makes anything worse.

## Tests

- **`controllers/boot_nonce_cycles_test.go` (new)** runs two provisioning cycles on one host through the real `triggerInspection`, `PhysicalHostReconciler.Reconcile` and `BootHandler`. It uses only pre-existing API fields, so it compiles against `main`, where both specs fail:
  - cycle 2's first `/boot` fetch returns 200 and writes nothing (resourceVersion unchanged), while cycle 1's identical assertions pass;
  - `unexpiredBootNonceHash` returns `""` for the promoted, never-fetched nonce.
- Handler specs for a record naming an earlier nonce, a record with no hash, and the conflict path (a fake client whose first consume patch finds a newer, consumed nonce promoted → opaque 404).
- A reconciler spec (promotion leaves an earlier nonce's record alone and the promoted nonce unconsumed) and `unexpiredBootNonceHash` unit specs for the hash-bound record and the pending-annotation window.
- **Existing specs changed:** "already-consumed: identical render…" now seeds a record naming this nonce, since a record without a hash now means "unattributed" and `/boot` re-records it; one `unexpiredBootNonceHash` spec is retitled. Their assertions are otherwise unchanged, and no other boot/nonce spec was touched.

Local verification:
- `make manifests` + `make sync-chart-crds`: the CRD gains `bootNonceConsumedHash`; a second run produces no diff.
- `KUBEBUILDER_ASSETS=…/k8s/1.31.0-linux-amd64 go test ./... -race -count=1`: all packages pass.
- `golangci-lint` v2.13.2 built with go1.27.1, after `cache clean`: 0 issues.
- Mutation checks: undoing each of the six changes one at a time makes at least one spec fail.
- The focused nonce specs: 5/5 green with `-race -ginkgo.randomize-all`.

## Docs

CHANGELOG `[Unreleased]` → Fixed. `docs/inspector-contract.md` §4.1 (its Auth bullet required "not yet consumed", contradicting the retry rule two lines below) and §7 (the consume record is per nonce). `docs/api-reference.md` field table. No wire change, so no contract version bump.

## Not in this PR

- **Should `/boot` refuse a re-fetch once the nonce is consumed?** That would make a nonce good for one fetch per boot on every cycle, but it changes the endpoint's semantics inside the frozen v4.x line (§14), and a lost response would strand the host until the inspection timeout. A short retry window after the consume is a middle option.
- `docs/ipxe-setup.md` ("authorizes one fetch", "already consumed → 404") and `SECURITY.md` contradict §4.1 today. Which way to correct them depends on the decision above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
